### PR TITLE
CircleCI build improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,9 +263,9 @@ jobs:
     steps:
       - prepare-for-build
       - run:
-        name: Cargo build
-        command: |
-          cargo build
+          name: Cargo build
+          command: |
+            cargo build
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,7 @@ jobs:
           name: Run all unit tests
           command: |
             cargo test
+      - check-dirty-git
       - run:
           name: Lint/fmt
           command: |
@@ -266,6 +267,7 @@ jobs:
           name: Cargo build
           command: |
             cargo build
+      - check-dirty-git
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,11 +103,26 @@ commands:
           paths:
             - "~/.cargo"
 
-  build_setup:
+  generate-pem-file:
+    steps:
+      - run:
+          name: Generating Enclave_private.pem
+          command: |
+            openssl genrsa -out $(pwd)/Enclave_private.pem -3 3072
+            export CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
+            export INGEST_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
+            export LEDGER_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
+            export VIEW_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
+
+  prepare-for-build:
     steps:
       - checkout
       - print_versions
       - env_setup
+      - enable_sccache
+      - restore-cargo-cache
+      - restore-sccache-cache
+      - generate-pem-file
 
   check-dirty-git:
     steps:
@@ -129,11 +144,7 @@ jobs:
   build-parallel-tests:
     executor: build-executor
     steps:
-      - build_setup
-      - enable_sccache
-      - restore-cargo-cache
-      - restore-sccache-cache
-
+      - prepare-for-build
       - run:
           name: Build/prepare unit tests
           command: |
@@ -234,43 +245,39 @@ jobs:
     executor: build-executor
     parallelism: 1
     steps:
-      - build_setup
-      - enable_sccache
-      - restore-cargo-cache
-      - restore-sccache-cache
+      - prepare-for-build
       - run:
           name: Run all unit tests
           command: |
-            openssl genrsa -out $(pwd)/Enclave_private.pem -3 3072
-            export CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
-            export INGEST_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
-            export LEDGER_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
-            export VIEW_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
-
             cargo test
-
-            rm $(pwd)/Enclave_private.pem
       - run:
           name: Lint/fmt
           command: |
-            openssl genrsa -out $(pwd)/Enclave_private.pem -3 3072
-            export CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
-            export INGEST_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
-            export LEDGER_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
-            export VIEW_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
-
             ./tools/lint.sh
-
-            rm $(pwd)/Enclave_private.pem
       - save-cargo-cache
       - save-sccache-cache
+
+  # Build internal in debug mode
+  build-all-debug:
+    executor: build-executor
+    steps:
+      - prepare-for-build
+      - run:
+        name: Cargo build
+        command: |
+          cargo build
+
 
 workflows:
   version: 2
   # Build and run tests on a single container
-  run-all-tests:
+  build-and-run-all-tests:
     jobs:
+      # Run tests on a single container
       - run-all-tests
+
+      # Build everything in debug
+      - build-all-debug
 
   # Build and run tests in parallel - not needed at the moment since the test suite is fast enough.
   # build-and-run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ jobs:
       - check-dirty-git
 
   # Build internal in debug mode
-  build-all-debug:
+  build-all-and-lint-debug:
     executor: build-executor
     steps:
       - prepare-for-build
@@ -281,7 +281,7 @@ workflows:
       - run-all-tests
 
       # Build everything in debug
-      - build-all-debug
+      - build-all-and-lint-debug
 
   # Build and run tests in parallel - not needed at the moment since the test suite is fast enough.
   # build-and-run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,12 +251,6 @@ jobs:
           command: |
             cargo test
       - check-dirty-git
-      - run:
-          name: Lint/fmt
-          command: |
-            ./tools/lint.sh
-      - save-cargo-cache
-      - save-sccache-cache
 
   # Build internal in debug mode
   build-all-debug:
@@ -269,6 +263,14 @@ jobs:
             cargo build
       - check-dirty-git
 
+      # The lint and saving of caches happens here since this job is faster than the run-all-tests job.
+      # This results in shorter CI times.
+      - run:
+          name: Lint/fmt
+          command: |
+            ./tools/lint.sh
+      - save-cargo-cache
+      - save-sccache-cache
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ jobs:
             cargo test
       - check-dirty-git
 
-  # Build internal in debug mode
+  # Build and lint in debug mode
   build-all-and-lint-debug:
     executor: build-executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,7 @@ commands:
               echo "repo is dirty"
               git status
               exit 1
+            fi
 
 jobs:
   # A job that builds all the tests in the workspace, and stores them in a test-bins/ directory.


### PR DESCRIPTION
This PR makes a few changes to the CircleCI build:
- It adds a new job to run `cargo build` and not just `cargo test`. That should ensure everything builds appropriately.
- It adds back the git dirty check that wasn't properly being called.
- It DRYs the `Enclave_private.pem` file generation.
- It moves the lint and cache upload to the new build task since that one is much faster than the tests one.