### PR TITLE
TinyMOB --> PicoMOB

### DIFF
--- a/transaction/core/src/constants.rs
+++ b/transaction/core/src/constants.rs
@@ -12,24 +12,19 @@ pub const MIN_RING_SIZE: usize = 11;
 pub const MAX_RING_SIZE: usize = 11;
 
 /// Each transaction must contain no more than this many inputs (rings).
-// TODO: Tweak this based on performance measurements.
 pub const MAX_INPUTS: u16 = 16;
 
 /// Each transaction must contain no more than this many outputs.
-// TODO: Tweak this based on performance measurements/subaddress limitations.
 pub const MAX_OUTPUTS: u16 = 16;
 
 /// Maximum number of blocks in the future a transaction's tombstone block can be set to.
 pub const MAX_TOMBSTONE_BLOCKS: u64 = 100;
 
-/// We are contractually obligated to create 250 million mobile coins (MOB)
-pub const MAX_MOB: u64 = 250_000_000;
+/// The MobileCoin network will contain a fixed supply of 250 million mobilecoins (MOB).
+pub const TOTAL_MOB: u64 = 250_000_000;
 
-/// 1 MOB = 2^{TINY_MOB_EXPONENT} TinyMOB
-pub const TINY_MOB_EXPONENT: u8 = 34;
-
-/// The maximum number of MOB, denominated in TinyMOB.
-pub const MAX_TINY_MOB: u64 = MAX_MOB << TINY_MOB_EXPONENT;
+/// Minimum allowed fee, denominated in picoMOB.
+pub const BASE_FEE: u64 = 10;
 
 cfg_if::cfg_if! {
     if #[cfg(any(test, feature="test-net-fee-keys"))] {
@@ -38,7 +33,7 @@ cfg_if::cfg_if! {
         ///   let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         ///   let foundation_account_key = AccountKey::random(&mut rng);
         ///
-        /// This is available in the `generate_test_foundation_key` utilitiy.
+        /// This is available in the `generate_test_foundation_key` utility.
         pub const FEE_SPEND_PUBLIC_KEY: [u8; 32] = [
             160, 79, 78, 17, 132, 143, 209, 245, 178, 242, 129, 141, 206, 68, 64, 194, 71, 138, 167, 101,
             214, 0, 76, 82, 159, 44, 114, 209, 83, 142, 35, 50,
@@ -61,6 +56,3 @@ cfg_if::cfg_if! {
         compile_error!("must specify either main-net-fee-keys or test-net-fee-keys feature");
     }
 }
-
-/// Minimum allowed fee.
-pub const BASE_FEE: u64 = 10;

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -54,7 +54,7 @@ impl TransactionBuilder {
     /// Add an output to the transaction.
     ///
     /// # Arguments
-    /// * `value` - The value of this output.
+    /// * `value` - The value of this output, in picoMOB.
     /// * `recipient` - The recipient's public address
     /// * `recipient_fog_ingest_key` - The recipient's fog server's public key
     /// * `rng` - RNG used to generate blinding for commitment
@@ -86,7 +86,7 @@ impl TransactionBuilder {
     /// Sets the transaction fee.
     ///
     /// # Arguments
-    /// * `fee` - Transaction fee.
+    /// * `fee` - Transaction fee, in picoMOB.
     pub fn set_fee(&mut self, fee: u64) {
         self.fee = fee;
     }
@@ -197,7 +197,7 @@ impl Default for TransactionBuilder {
 /// Creates a TxOut that sends `value` to `recipient`.
 ///
 /// # Arguments
-/// * `value` - Value of the output.
+/// * `value` - Value of the output, in picoMOB.
 /// * `recipient` - Recipient's address.
 /// * `ingest_pubkey` - The public key for the recipients fog server, if any
 /// * `rng` -


### PR DESCRIPTION
This removes remaining mention of tinyMOB as a denomination of mobilecoin, and updates comments to refer to picoMOB.