### PR TITLE
Moves tombstone_block from Tx to TxPrefix

### DIFF
--- a/consensus/api/proto/external.proto
+++ b/consensus/api/proto/external.proto
@@ -119,6 +119,9 @@ message TxPrefix {
 
     // Fee paid to the foundation for this transaction
     uint64 fee = 3;
+
+    // The block index at which this transaction is no longer valid.
+    uint64 tombstone_block = 4;
 }
 
 message RingMLSAG {
@@ -137,11 +140,8 @@ message Tx {
     // The actual contents of the transaction.
     TxPrefix prefix = 1;
 
-    // The block index past which this submitted transaction is no longer valid.
-    uint64 tombstone_block = 2;
-
     // The RingCT signature on the prefix.
-    SignatureRctBulletproofs signature = 3;
+    SignatureRctBulletproofs signature = 2;
 }
 
 message TxHash {

--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -454,6 +454,8 @@ impl From<&tx::TxPrefix> for external::TxPrefix {
 
         tx_prefix.set_fee(source.fee);
 
+        tx_prefix.set_tombstone_block(source.tombstone_block);
+
         tx_prefix
     }
 }
@@ -479,6 +481,7 @@ impl TryFrom<&external::TxPrefix> for tx::TxPrefix {
             inputs,
             outputs,
             fee: source.get_fee(),
+            tombstone_block: source.get_tombstone_block(),
         };
         Ok(tx_prefix)
     }
@@ -489,7 +492,6 @@ impl From<&tx::Tx> for external::Tx {
     fn from(source: &tx::Tx) -> Self {
         let mut tx = external::Tx::new();
         tx.set_prefix(external::TxPrefix::from(&source.prefix));
-        tx.set_tombstone_block(source.tombstone_block);
         tx.set_signature(external::SignatureRctBulletproofs::from(&source.signature));
         tx
     }
@@ -501,14 +503,8 @@ impl TryFrom<&external::Tx> for tx::Tx {
 
     fn try_from(source: &external::Tx) -> Result<Self, Self::Error> {
         let prefix = tx::TxPrefix::try_from(source.get_prefix())?;
-        let tombstone_block = source.get_tombstone_block();
         let signature = SignatureRctBulletproofs::try_from(source.get_signature())?;
-
-        Ok(tx::Tx {
-            prefix,
-            tombstone_block,
-            signature,
-        })
+        Ok(tx::Tx { prefix, signature })
     }
 }
 

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -85,7 +85,7 @@ impl From<&Tx> for WellFormedTxContext {
         Self {
             tx_hash: tx.tx_hash(),
             fee: tx.prefix.fee,
-            tombstone_block: tx.tombstone_block,
+            tombstone_block: tx.prefix.tombstone_block,
             key_images: tx.key_images(),
             highest_indices: tx.get_membership_proof_highest_indices(),
         }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -664,7 +664,7 @@ impl<T: UserTxConnection + 'static> ServiceApi<T> {
         if let Err(err) = self.mobilecoind_db.update_attempted_spend(
             &utxo_ids,
             block_height,
-            tx_proposal.tx.tombstone_block,
+            tx_proposal.tx.prefix.tombstone_block,
         ) {
             log::error!(
                 self.logger,
@@ -683,7 +683,7 @@ impl<T: UserTxConnection + 'static> ServiceApi<T> {
                 .map(|utxo| (&utxo.key_image).into())
                 .collect(),
         ));
-        sender_tx_receipt.set_tombstone(tx_proposal.tx.tombstone_block);
+        sender_tx_receipt.set_tombstone(tx_proposal.tx.prefix.tombstone_block);
 
         // Construct receiver receipts.
         let receiver_tx_receipts: Vec<_> = tx_proposal
@@ -717,7 +717,7 @@ impl<T: UserTxConnection + 'static> ServiceApi<T> {
                 receiver_tx_receipt.set_receipient((&outlay.receiver).into());
                 receiver_tx_receipt.set_tx_public_key(tx_out.public_key.into());
                 receiver_tx_receipt.set_tx_out_hash(tx_out.hash().to_vec());
-                receiver_tx_receipt.set_tombstone(tx_proposal.tx.tombstone_block);
+                receiver_tx_receipt.set_tombstone(tx_proposal.tx.prefix.tombstone_block);
 
                 Ok(receiver_tx_receipt)
             })
@@ -1781,7 +1781,7 @@ mod test {
             // Sanity test tombstone block
             let num_blocks = ledger_db.num_blocks().unwrap();
             assert_eq!(
-                tx_proposal.get_tx().tombstone_block,
+                tx_proposal.get_tx().get_prefix().tombstone_block,
                 num_blocks + DEFAULT_NEW_TX_BLOCK_ATTEMPTS
             );
         }
@@ -2043,7 +2043,7 @@ mod test {
         // Sanity test tombstone block
         let num_blocks = ledger_db.num_blocks().unwrap();
         assert_eq!(
-            tx_proposal.tx.tombstone_block,
+            tx_proposal.tx.prefix.tombstone_block,
             num_blocks + DEFAULT_NEW_TX_BLOCK_ATTEMPTS
         );
     }
@@ -2167,7 +2167,7 @@ mod test {
 
             assert_eq!(
                 response.get_sender_tx_receipt().tombstone,
-                tx.tombstone_block
+                tx.prefix.tombstone_block
             );
 
             // Sanity the receiver receipts.
@@ -2181,7 +2181,7 @@ mod test {
                     PublicAddress::try_from(receipt.get_receipient()).unwrap()
                 );
 
-                assert_eq!(receipt.tombstone, tx.tombstone_block);
+                assert_eq!(receipt.tombstone, tx.prefix.tombstone_block);
             }
 
             assert_eq!(
@@ -2393,7 +2393,7 @@ mod test {
 
         assert_eq!(
             response.get_sender_tx_receipt().tombstone,
-            submitted_tx.tombstone_block
+            submitted_tx.prefix.tombstone_block
         );
 
         // Sanity the receiver receipts.
@@ -2407,7 +2407,7 @@ mod test {
                 PublicAddress::try_from(receipt.get_receipient()).unwrap()
             );
 
-            assert_eq!(receipt.tombstone, submitted_tx.tombstone_block);
+            assert_eq!(receipt.tombstone, submitted_tx.prefix.tombstone_block);
         }
 
         assert_eq!(

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -104,12 +104,8 @@ pub struct Tx {
     #[prost(message, required, tag = "1")]
     pub prefix: TxPrefix,
 
-    /// The block number at which this transaction is no longer considered valid.
-    #[prost(uint64, tag = "2")]
-    pub tombstone_block: u64,
-
     /// The transaction signature.
-    #[prost(message, required, tag = "3")]
+    #[prost(message, required, tag = "2")]
     pub signature: SignatureRctBulletproofs,
 }
 
@@ -160,6 +156,10 @@ pub struct TxPrefix {
     /// Fee paid to the foundation for this transaction
     #[prost(uint64, tag = "3")]
     pub fee: u64,
+
+    /// The block index at which this transaction is no longer valid.
+    #[prost(uint64, tag = "4")]
+    pub tombstone_block: u64,
 }
 
 impl TxPrefix {
@@ -169,11 +169,13 @@ impl TxPrefix {
     /// * `inputs` - Inputs spent by the transaction.
     /// * `outputs` - Outputs created by the transaction.
     /// * `fee` - Transaction fee.
-    pub fn new(inputs: Vec<TxIn>, outputs: Vec<TxOut>, fee: u64) -> TxPrefix {
+    /// * `tombstone_block` - The block index at which this transaction is no longer valid.
+    pub fn new(inputs: Vec<TxIn>, outputs: Vec<TxOut>, fee: u64, tombstone_block: u64) -> TxPrefix {
         TxPrefix {
             inputs,
             outputs,
             fee,
+            tombstone_block,
         }
     }
 
@@ -446,6 +448,7 @@ mod tests {
             inputs: vec![tx_in],
             outputs: vec![tx_out],
             fee: BASE_FEE,
+            tombstone_block: 23,
         };
 
         let mut buf = Vec::new();
@@ -458,11 +461,7 @@ mod tests {
         // TODO: use a meaningful signature.
         let signature = SignatureRctBulletproofs::default();
 
-        let tx = Tx {
-            prefix,
-            tombstone_block: 23u64,
-            signature,
-        };
+        let tx = Tx { prefix, signature };
 
         let mut buf = Vec::new();
         tx.encode(&mut buf).expect("failed to serialize into slice");

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -27,7 +27,7 @@ use rand_core::{CryptoRng, RngCore};
 /// * `tx` - A pending transaction.
 /// * `current_block_index` - The index of the current block that is being built.
 /// * `root_proofs` - Membership proofs for each input ring element contained in `tx`.
-/// * `
+/// * `csprng` - Cryptographically secure random number generator.
 pub fn validate<R: RngCore + CryptoRng>(
     tx: &Tx,
     current_block_index: u64,
@@ -50,7 +50,7 @@ pub fn validate<R: RngCore + CryptoRng>(
 
     validate_key_images_are_unique(&tx)?;
 
-    validate_tombstone(current_block_index, tx.tombstone_block)?;
+    validate_tombstone(current_block_index, tx.prefix.tombstone_block)?;
 
     // Note: The transaction must not contain a Key Image that has previously been spent.
     // This must be checked outside the enclave.

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -118,7 +118,7 @@ impl TransactionBuilder {
             })
             .collect();
 
-        let tx_prefix = TxPrefix::new(inputs, self.outputs.clone(), self.fee);
+        let tx_prefix = TxPrefix::new(inputs, self.outputs.clone(), self.fee, self.tombstone_block);
 
         let tx_prefix_hash = tx_prefix.hash();
         let message = tx_prefix_hash.as_bytes();
@@ -181,7 +181,6 @@ impl TransactionBuilder {
 
         Ok(Tx {
             prefix: tx_prefix,
-            tombstone_block: self.tombstone_block,
             signature,
         })
     }


### PR DESCRIPTION
Previously, the tombstone_block was not signed by the transaction signature, meaning that an attacker could potentially modify it.

This ensures that the tombstone_block is included in the prefix, which gets signed.