### PR TITLE
Improvements to build instructions in README.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -89,7 +89,17 @@ The `SGX_MODE` environment variable configuration is also used throughout Intel 
 #### Building the enclave
 
 For technical reasons, the `consensus_enclave` must be in a separate workspace.
-Its build is invoked automatically if needed from the `consensus_service` build.
+It is also built using `cargo build`.
+
+The enclave build is invoked *automatically* if needed from the `consensus_service` `build.rs`.
 
 To reproducibly build the enclave, (get exactly the right MRENCLAVE value), you must build
 in the container.
+
+For local testing, you don't need to get exactly the right MRENCLAVE value. You can set up
+test networks with whatever MRENCLAVE your build produces, and clients that check this value
+using the Remote Attestation process.
+
+If you want to downlaod a prebuilt and properly-signed enclave, in order use `IAS_MODE=PROD`
+and participate in a production network, check out the `enclave-signing-material` instructions:
+https://github.com/mobilecoinofficial/mobilecoin/blob/master/consensus/service/BUILD.md#enclave-signing-material

--- a/BUILD.md
+++ b/BUILD.md
@@ -71,15 +71,18 @@ The clients and servers must all agree about this setting, or attestation will f
 `cargo` supports crate-level features, and feature unification across the build plan.
 `cargo` does not support any notion of "global project-wide configuration".
 
-In practice, it's too hard to get all the features on all the right crates, if every
-crate has an `sgx_mode` and `ias_mode` feature. Even if cargo had workspace-level
-features, which it doesn't, that wouldn't be good enough for us because our build requires using
-multiple workspaces, in order to keep the cargo features on some targets separated and not unified.
-Unifying cargo features across enclave targets and server targets will break the enclave builds.
+In practice, it's too hard invoke cargo to get all the features enables exactly correctly on
+all the right crates, if every crate has an `sgx_mode` and `ias_mode` feature.
 
-Making these environment variables, and making `build.rs` scripts that read them and set features
-on these crates, is the simplest way to make sure that there is one source of truth for these
-values for all the artifacts in the whole build.
+Even if cargo had workspace-level features, which it doesn't, that wouldn't be good enough for us
+because our build requires using multiple workspaces. We must keep the cargo features on some
+targets separated and not unified.
+Unifying cargo features across enclave targets and server targets will break the enclave builds.
+This is because the enclave builds in a special `no_std` environment.
+
+Making `SGX_MODE` and `IAS_MODE` environment variables, and making `build.rs` scripts that read
+them and set features on these crates as needed, is the simplest way to make sure that there is
+one source of truth for these values for all the artifacts in the whole build.
 
 The `SGX_MODE` environment variable configuration is also used throughout Intel SGX SDK examples.
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -71,7 +71,7 @@ The clients and servers must all agree about this setting, or attestation will f
 `cargo` supports crate-level features, and feature unification across the build plan.
 `cargo` does not support any notion of "global project-wide configuration".
 
-In practice, it's too hard invoke cargo to get all the features enables exactly correctly on
+In practice, it's too hard invoke cargo to get all the features enabled exactly correctly on
 all the right crates, if every crate has an `sgx_mode` and `ias_mode` feature.
 
 Even if cargo had workspace-level features, which it doesn't, that wouldn't be good enough for us
@@ -82,7 +82,7 @@ This is because the enclave builds in a special `no_std` environment.
 
 Making `SGX_MODE` and `IAS_MODE` environment variables, and making `build.rs` scripts that read
 them and set features on these crates as needed, is the simplest way to make sure that there is
-one source of truth for these values for all the artifacts in the whole build.
+one source of truth for these values for all of the artifacts in the whole build.
 
 The `SGX_MODE` environment variable configuration is also used throughout Intel SGX SDK examples.
 
@@ -100,6 +100,6 @@ For local testing, you don't need to get exactly the right MRENCLAVE value. You 
 test networks with whatever MRENCLAVE your build produces, and clients that check this value
 using the Remote Attestation process.
 
-If you want to downlaod a prebuilt and properly-signed enclave, in order use `IAS_MODE=PROD`
-and participate in a production network, check out the `enclave-signing-material` instructions:
+If you want to download a prebuilt enclave, signed using the production signing key, in order use `IAS_MODE=PROD`
+and participate in a production-environment network, check out the `enclave-signing-material` instructions:
 https://github.com/mobilecoinofficial/mobilecoin/blob/master/consensus/service/BUILD.md#enclave-signing-material

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,75 @@
+Build
+=====
+
+#### Build environment
+
+Services that create SGX enclaves depend on the Intel SGX SDK. This must be installed
+in the build environment, as well as the runtime environment.
+
+## Dockerized build
+
+An easy way to get this environment is to build in the docker image that we use for CI.
+The dockerfile for this image lives in `docker/Dockerfile`.
+
+You can use `./mob prompt` to pull this image, (or to build it locally), and get a prompt
+in this environment.
+
+```
+# From the root of the repo
+./mob prompt
+
+# At the container prompt
+cargo build
+```
+
+If you have SGX-enabled hardware (activated in BIOS, and with SGX kernel module installed),
+you can use `./mob prompt --hw` to get SGX in the container. Then you can both build and
+run the tests in `SGX_MODE=HW`. (See below for an explanation.)
+
+## No-docker build
+
+A docker-less build also works fine for development:
+- Follow instructions [consensus/service/BUILD.md](consensus/service/BUILD.md)
+- Set up your environment like the [Dockerfile](docker/Dockerfile)
+
+#### Build configuration
+
+There are two project-wide SGX-related configuration variables `SGX_MODE` and `IAS_MODE`.
+
+These are set by environment variables, and they must be the same for all artifacts,
+even those that don't depend directly on SGX. E.g. `mobilecoind` must have the same configuration
+as `consensus_service` for Intel Remote Attestation to work, otherwise an error will occur at runtime.
+
+For testing, you should usually use `SGX_MODE=SIM` and `IAS_MODE=DEV`.
+
+## SGX_MODE
+
+`SGX_MODE=SIM` means that the enclaves won't be "real" enclaves -- consensus service will link
+to Intel-provided "_sim" versions of the Intel SGX SDK, and the enclave will be loaded approximately
+like a shared library being `dlopen`'ed. This means that you will be able to use `gdb` and get
+backtraces normally through the enclave code. In this mode, the CPU does not securely compute
+measurements of the enclave, and attestation doesn't prove the integrity of the enclave.
+
+`SGX_MODE=HW` means that the real Intel libraries are used, and the enclave is loaded securely.
+This mode is required for Intel Remote Attestation to work and provide security.
+
+The clients and servers must all agree about this setting, or attestation will fail.
+
+## IAS_MODE
+
+`IAS_MODE=DEV` means that we will hit the Intel provided "dev endpoints" during remote attestation.
+These won't require the real production signing key in connection to the MRENCLAVE measurements.
+
+`IAS_MODE=PROD` means that we will hit the real Intel provided endpoints for remote attestation.
+
+In code, this discrepancy is largely handled by the `attest-net` crate.
+
+The clients and servers must all agree about this setting, or attestation will fail.
+
+#### Building the enclave
+
+For technical reasons, the `consensus_enclave` must be in a separate workspace.
+Its build is invoked automatically if needed from the `consensus_service` build.
+
+To reproducibly build the enclave, (get exactly the right MRENCLAVE value), you must build
+in the container.

--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ To validate the blockchain, see [The MobileCoin Daemon](#the-mobilecoin-daemon).
 
 This workspace is built with `cargo build`, and tested with `cargo test`.
 
-Some crates, such as consensus-service, build binaries that have special runtime requirements, such as Intel's Software Guard eXtensions (SGX). You will need to provide an environment variable to indicate whether to build for hardware mode (`HW`) or simulation mode (`SW`) mode, as well as which attestation service to use, e.g. `SGX_MODE=HW IAS_MODE=DEV cargo build`. You will find more information in the BUILD.md in these crates, for example, [consensus/service/BUILD.md](consensus/service/BUILD.md).
+Some crates depend on SGX, which creates build and runtime requirements. (Specifically, `consensus-service`.)
 
-To ease the process of building, we provide a tool which starts a docker container with all the correct dependencies, including the necessary versions of SGX and proto libraries.
+For detailed information about setting up a build environment, how enclaves are built, and configuring
+the build, check out [BUILD.md](BUILD.md).
 
-You can use it with the following:
+For a quick start, you can build in the same docker image that we use for CI, using the `mob` tool.
+This requires you to install docker.
 
 ```
 # From the root of the repo
@@ -50,8 +52,6 @@ You can use it with the following:
 # At the container prompt
 cargo build
 ```
-
-The consensus_enclave is a nested workspace, which is built with `cargo build.`
 
 #### License
 


### PR DESCRIPTION
This tries to reduce detail in README.md, and move that detail to a root-level BUILD.md. That detail is also expanded upon, to try to give a comprehensive overview of build environment, build configuration, and the enclave-related aspects