### PR TITLE
Amount and signatures use CompressedRistretto

### DIFF
--- a/transaction/core/src/commitment.rs
+++ b/transaction/core/src/commitment.rs
@@ -1,0 +1,73 @@
+use crate::{
+    compressed_commitment::CompressedCommitment,
+    ring_signature::{Error, Scalar, GENERATORS},
+};
+use core::{convert::TryFrom, fmt};
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
+use digestible::Digestible;
+use mcserial::{
+    deduce_core_traits_from_public_bytes, prost_message_helper32, try_from_helper32, ReprBytes32,
+};
+use serde::{Deserialize, Serialize};
+
+/// A Pedersen commitment in uncompressed Ristretto format.
+#[derive(Copy, Clone, Default, Digestible)]
+pub struct Commitment {
+    /// A Pedersen commitment `v*G + b*H` to a quantity `v` with blinding `b`,
+    pub point: RistrettoPoint,
+}
+
+impl Commitment {
+    pub fn new(value: u64, blinding: Scalar) -> Self {
+        Self {
+            point: GENERATORS.commit(Scalar::from(value), blinding),
+        }
+    }
+}
+
+impl TryFrom<&CompressedCommitment> for Commitment {
+    type Error = crate::ring_signature::Error;
+
+    fn try_from(src: &CompressedCommitment) -> Result<Self, Self::Error> {
+        let point = src.point.decompress().ok_or(Error::InvalidCurvePoint)?;
+        Ok(Self { point })
+    }
+}
+
+impl fmt::Debug for Commitment {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Commitment({})",
+            hex_fmt::HexFmt(self.point.compress().as_bytes())
+        )
+    }
+}
+
+// impl AsRef<[u8; 32]> for Commitment {
+//     fn as_ref(&self) -> &[u8; 32] {
+//         self.point.compress().as_bytes()
+//     }
+// }
+//
+// // Implements Ord, PartialOrd, PartialEq, Hash. Requires AsRef<[u8;32]>.
+// deduce_core_traits_from_public_bytes! { Commitment }
+
+impl ReprBytes32 for Commitment {
+    type Error = Error;
+    fn to_bytes(&self) -> [u8; 32] {
+        self.point.compress().to_bytes()
+    }
+    fn from_bytes(src: &[u8; 32]) -> Result<Self, Error> {
+        let point = CompressedRistretto::from_slice(src)
+            .decompress()
+            .ok_or(Error::InvalidCurvePoint)?;
+        Ok(Self { point })
+    }
+}
+
+// Implements prost::Message. Requires Debug and ReprBytes32.
+prost_message_helper32! { Commitment }
+
+// Implements try_from<&[u8;32]> and try_from<&[u8]>. Requires ReprBytes32.
+try_from_helper32! { Commitment }

--- a/transaction/core/src/compressed_commitment.rs
+++ b/transaction/core/src/compressed_commitment.rs
@@ -1,0 +1,71 @@
+use crate::{
+    commitment::Commitment,
+    ring_signature::{Error, Scalar, GENERATORS},
+};
+use core::{convert::TryFrom, fmt};
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
+use digestible::Digestible;
+use mcserial::{
+    deduce_core_traits_from_public_bytes, prost_message_helper32, try_from_helper32, ReprBytes32,
+};
+use serde::{Deserialize, Serialize};
+
+/// A Pedersen commitment in compressed Ristretto format.
+#[derive(Copy, Clone, Default, Eq, Serialize, Deserialize, Digestible)]
+pub struct CompressedCommitment {
+    /// A Pedersen commitment `v*G + b*H` to a quantity `v` with blinding `b`,
+    pub point: CompressedRistretto,
+}
+
+impl CompressedCommitment {
+    pub fn new(value: u64, blinding: Scalar) -> Self {
+        Self {
+            point: GENERATORS.commit(Scalar::from(value), blinding).compress(),
+        }
+    }
+}
+
+impl From<&Commitment> for CompressedCommitment {
+    fn from(src: &Commitment) -> Self {
+        Self {
+            point: src.point.compress(),
+        }
+    }
+}
+
+impl fmt::Debug for CompressedCommitment {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "CompressedCommitment({})",
+            hex_fmt::HexFmt(self.point.as_bytes())
+        )
+    }
+}
+
+impl AsRef<[u8; 32]> for CompressedCommitment {
+    fn as_ref(&self) -> &[u8; 32] {
+        self.point.as_bytes()
+    }
+}
+
+// Implements Ord, PartialOrd, PartialEq, Hash. Requires AsRef<[u8;32]>.
+deduce_core_traits_from_public_bytes! { CompressedCommitment }
+
+impl ReprBytes32 for CompressedCommitment {
+    type Error = Error;
+    fn to_bytes(&self) -> [u8; 32] {
+        self.point.to_bytes()
+    }
+    fn from_bytes(src: &[u8; 32]) -> Result<Self, Error> {
+        Ok(Self {
+            point: CompressedRistretto::from_slice(src),
+        })
+    }
+}
+
+// Implements prost::Message. Requires Debug and ReprBytes32.
+prost_message_helper32! { CompressedCommitment }
+
+// Implements try_from<&[u8;32]> and try_from<&[u8]>. Requires ReprBytes32.
+try_from_helper32! { CompressedCommitment }

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -20,6 +20,8 @@ pub mod account_keys;
 pub mod amount;
 pub mod blake2b_256;
 mod block;
+mod commitment;
+mod compressed_commitment;
 pub mod constants;
 pub mod encrypted_fog_hint;
 pub mod fog_hint;
@@ -37,6 +39,8 @@ pub mod view_key;
 pub mod proptest_fixtures;
 
 pub use block::*;
+pub use commitment::*;
+pub use compressed_commitment::*;
 pub use redacted_tx::RedactedTx;
 
 /// Get the shared secret for a transaction output.

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -126,7 +126,7 @@ impl RingMLSAG {
     //
     // # Arguments
     // * `message` - Message to be signed.
-    // * `ring` - A ring of input onetime addresses and uncompressed amount commitments.
+    // * `ring` - A ring of input onetime addresses and amount commitments.
     // * `real_index` - The index in the ring of the real input.
     // * `onetime_private_key` - The real input's private key.
     // * `value` - Value of the real input.
@@ -163,7 +163,7 @@ impl RingMLSAG {
     //
     // # Arguments
     // * `message` - Message to be signed.
-    // * `ring` - A ring of input onetime addresses and uncompressed amount commitments.
+    // * `ring` - A ring of input onetime addresses and amount commitments.
     // * `real_index` - The index in the ring of the real input.
     // * `onetime_private_key` - The real input's private key.
     // * `value` - Value of the real input.

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -3,12 +3,12 @@
 extern crate alloc;
 
 use alloc::{vec, vec::Vec};
-use core::convert::TryInto;
+use core::convert::{TryFrom, TryInto};
 
 use blake2::{Blake2b, Digest};
-use curve25519_dalek::ristretto::RistrettoPoint;
+use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use digestible::Digestible;
-use keys::RistrettoPrivate;
+use keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
 use mcserial::{
     prost::{
         bytes::{Buf, BufMut},
@@ -21,15 +21,17 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    commitment::Commitment,
+    compressed_commitment::CompressedCommitment,
     onetime_keys::compute_key_image,
     ring_signature::{
         encoding::{read_u8_32, write_u8_32},
-        Address, Blinding, Commitment, Error, KeyImage, Scalar, GENERATORS,
+        Blinding, Error, KeyImage, Scalar, GENERATORS,
     },
 };
 
-fn hash_to_point(address: &Address) -> RistrettoPoint {
-    RistrettoPoint::hash_from_bytes::<Blake2b>(&address.to_bytes())
+fn hash_to_point(ristretto_public: &RistrettoPublic) -> RistrettoPoint {
+    RistrettoPoint::hash_from_bytes::<Blake2b>(&ristretto_public.to_bytes())
 }
 
 /// MLSAG for a ring of public keys and amount commitments.
@@ -124,7 +126,7 @@ impl RingMLSAG {
     //
     // # Arguments
     // * `message` - Message to be signed.
-    // * `ring` - A ring of input onetime addresses and amount commitments.
+    // * `ring` - A ring of input onetime addresses and uncompressed amount commitments.
     // * `real_index` - The index in the ring of the real input.
     // * `onetime_private_key` - The real input's private key.
     // * `value` - Value of the real input.
@@ -133,7 +135,7 @@ impl RingMLSAG {
     // * `rng` - Randomness.
     pub fn sign<CSPRNG: RngCore + CryptoRng>(
         message: &[u8; 32],
-        ring: &[(Address, Commitment)],
+        ring: &[(CompressedRistrettoPublic, CompressedCommitment)],
         real_index: usize,
         onetime_private_key: &RistrettoPrivate,
         value: u64,
@@ -161,7 +163,7 @@ impl RingMLSAG {
     //
     // # Arguments
     // * `message` - Message to be signed.
-    // * `ring` - A ring of input onetime addresses and amount commitments.
+    // * `ring` - A ring of input onetime addresses and uncompressed amount commitments.
     // * `real_index` - The index in the ring of the real input.
     // * `onetime_private_key` - The real input's private key.
     // * `value` - Value of the real input.
@@ -171,7 +173,7 @@ impl RingMLSAG {
     // * `rng` - Randomness.
     fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
         message: &[u8; 32],
-        ring: &[(Address, Commitment)],
+        ring: &[(CompressedRistrettoPublic, CompressedCommitment)],
         real_index: usize,
         onetime_private_key: &RistrettoPrivate,
         value: u64,
@@ -190,11 +192,20 @@ impl RingMLSAG {
         let H = GENERATORS.B_blinding;
 
         let key_image = compute_key_image(onetime_private_key);
+
         // The uncompressed key_image.
         let I: RistrettoPoint = key_image.try_into().expect("key_image should decompress");
 
-        let output_commitment =
-            Commitment::from(GENERATORS.commit(Scalar::from(value), *output_blinding));
+        // Uncompressed output commitment.
+        let output_commitment: Commitment = Commitment::new(value, *output_blinding);
+
+        // Ring must decompress.
+        let mut decompressed_ring: Vec<(RistrettoPublic, Commitment)> = Vec::new();
+        for (compressed_address, compressed_commitment) in ring {
+            let ristretto_public = RistrettoPublic::try_from(compressed_address)?;
+            let commitment = Commitment::try_from(compressed_commitment)?;
+            decompressed_ring.push((ristretto_public, commitment));
+        }
 
         // Challenges `c_0, ... c_{ring_size - 1}`.
         let mut c: Vec<Scalar> = vec![Scalar::zero(); ring_size];
@@ -215,7 +226,7 @@ impl RingMLSAG {
         for n in 0..ring_size {
             // Iterate around the ring, starting at real_index.
             let i = (real_index + n) % ring_size;
-            let (P_i, input_commitment) = &ring[i];
+            let (P_i, input_commitment) = &decompressed_ring[i];
 
             let (L0, R0, L1) = if i == real_index {
                 // c_{i+1} = Hn( m | alpha_0 * G | alpha_0 * Hp(P_i) | alpha_1 * H )
@@ -241,7 +252,8 @@ impl RingMLSAG {
 
                 let L0 = r[2 * i] * G + c[i] * P_i.as_ref();
                 let R0 = r[2 * i] * hash_to_point(&P_i) + c[i] * I;
-                let L1 = r[2 * i + 1] * H + c[i] * (output_commitment.0 - input_commitment.0);
+                let L1 =
+                    r[2 * i + 1] * H + c[i] * (output_commitment.point - input_commitment.point);
                 (L0, R0, L1)
             };
 
@@ -264,8 +276,8 @@ impl RingMLSAG {
         r[2 * real_index + 1] = alpha_1 - c[real_index] * z;
 
         if check_value_is_preserved {
-            let input_commitment = ring[real_index].1;
-            let difference: RistrettoPoint = output_commitment.0 - input_commitment.0;
+            let (_, input_commitment) = decompressed_ring[real_index];
+            let difference: RistrettoPoint = output_commitment.point - input_commitment.point;
             if difference != (z * H) {
                 return Err(Error::ValueNotConserved);
             }
@@ -287,8 +299,8 @@ impl RingMLSAG {
     pub fn verify(
         &self,
         message: &[u8; 32],
-        ring: &[(Address, Commitment)],
-        output_commitment: &Commitment,
+        ring: &[(CompressedRistrettoPublic, CompressedCommitment)],
+        output_commitment: &CompressedCommitment,
     ) -> Result<(), Error> {
         let ring_size = ring.len();
         // `responses` must contain `2 * ring_size` elements.
@@ -306,10 +318,21 @@ impl RingMLSAG {
             .map_err(|_e| Error::InvalidKeyImage)?;
         let r = &self.responses;
 
+        // Output commitment must decompress.
+        let output_commitment: Commitment = Commitment::try_from(output_commitment)?;
+
+        // Ring must decompress.
+        let mut decompressed_ring: Vec<(RistrettoPublic, Commitment)> = Vec::new();
+        for (compressed_address, compressed_commitment) in ring {
+            let ristretto_public = RistrettoPublic::try_from(compressed_address)?;
+            let commitment = Commitment::try_from(compressed_commitment)?;
+            decompressed_ring.push((ristretto_public, commitment));
+        }
+
         // Recompute challenges.
         let mut recomputed_c = vec![Scalar::zero(); ring.len()];
 
-        for (i, (P_i, input_commitment)) in ring.iter().enumerate() {
+        for (i, (P_i, input_commitment)) in decompressed_ring.iter().enumerate() {
             let c_i = if i == 0 {
                 // Initialize loop using the signature's c_0 term.
                 self.c_zero
@@ -326,8 +349,8 @@ impl RingMLSAG {
             // * Z_i is the i^th "commitment to zero" = output_commitment - i^th input_commitment.
 
             let L0 = r[2 * i] * G + c_i * P_i.as_ref();
-            let R0 = r[2 * i] * hash_to_point(&P_i) + c_i * I;
-            let L1 = r[2 * i + 1] * H + c_i * (output_commitment.0 - input_commitment.0);
+            let R0 = r[2 * i] * hash_to_point(P_i) + c_i * I;
+            let L1 = r[2 * i + 1] * H + c_i * (output_commitment.point - input_commitment.point);
 
             recomputed_c[(i + 1) % ring_size] = {
                 let mut hasher = Blake2b::new();
@@ -351,7 +374,7 @@ impl RingMLSAG {
 mod mlsag_tests {
     use alloc::vec::Vec;
 
-    use keys::{FromRandom, RistrettoPrivate, RistrettoPublic};
+    use keys::{CompressedRistrettoPublic, FromRandom, RistrettoPrivate, RistrettoPublic};
     use rand_core::RngCore;
 
     use proptest::{array::uniform32, prelude::*};
@@ -360,7 +383,8 @@ mod mlsag_tests {
     use crate::{
         onetime_keys::compute_key_image,
         proptest_fixtures::*,
-        ring_signature::{mlsag::RingMLSAG, Address, Commitment, Error, Scalar, GENERATORS},
+        ring_signature::{mlsag::RingMLSAG, Error, Scalar, GENERATORS},
+        CompressedCommitment,
     };
 
     extern crate std;
@@ -368,7 +392,7 @@ mod mlsag_tests {
     #[derive(Debug)]
     struct RingMLSAGParameters {
         message: [u8; 32],
-        ring: Vec<(Address, Commitment)>,
+        ring: Vec<(CompressedRistrettoPublic, CompressedCommitment)>,
         real_index: usize,
         onetime_private_key: RistrettoPrivate,
         value: u64,
@@ -385,24 +409,25 @@ mod mlsag_tests {
             let mut message = [0u8; 32];
             rng.fill_bytes(&mut message);
 
-            let mut ring: Vec<(Address, Commitment)> = Vec::new();
+            let mut ring: Vec<(CompressedRistrettoPublic, CompressedCommitment)> = Vec::new();
             for _i in 0..num_mixins {
-                let address = RistrettoPublic::from_random(rng);
+                let address = CompressedRistrettoPublic::from(RistrettoPublic::from_random(rng));
                 let commitment = {
-                    let value = Scalar::from(rng.next_u64());
+                    let value = rng.next_u64();
                     let blinding = Scalar::random(rng);
-                    Commitment::from(GENERATORS.commit(value, blinding))
+                    CompressedCommitment::new(value, blinding)
                 };
                 ring.push((address, commitment));
             }
 
             // The real input.
             let onetime_private_key = RistrettoPrivate::from_random(rng);
-            let onetime_public_key = RistrettoPublic::from(&onetime_private_key);
+            let onetime_public_key =
+                CompressedRistrettoPublic::from(RistrettoPublic::from(&onetime_private_key));
 
             let value = rng.next_u64();
             let blinding = Scalar::random(rng);
-            let commitment = Commitment::from(GENERATORS.commit(Scalar::from(value), blinding));
+            let commitment = CompressedCommitment::new(value, blinding);
 
             let real_index = rng.next_u64() as usize % (num_mixins + 1);
             ring.insert(real_index, (onetime_public_key, commitment));
@@ -561,11 +586,7 @@ mod mlsag_tests {
             )
             .unwrap();
 
-            let output_commitment = {
-                let value = Scalar::from(params.value);
-                let blinding = params.pseudo_output_blinding;
-                Commitment::from(GENERATORS.commit(value, blinding))
-            };
+            let output_commitment = CompressedCommitment::new(params.value, params.pseudo_output_blinding);
 
             assert!(signature
                 .verify(&params.message, &params.ring, &output_commitment)
@@ -595,11 +616,7 @@ mod mlsag_tests {
             )
             .unwrap();
 
-            let output_commitment = {
-                let value = Scalar::from(params.value);
-                let blinding = params.pseudo_output_blinding;
-                Commitment::from(GENERATORS.commit(value, blinding))
-            };
+            let output_commitment = CompressedCommitment::new(params.value, params.pseudo_output_blinding);
 
             match signature.verify(&params.message, &params.ring, &output_commitment) {
                 Err(Error::InvalidSignature) => {} // This is expected.
@@ -634,10 +651,7 @@ mod mlsag_tests {
                 )
                 .unwrap();
 
-                let output_commitment = {
-                    let blinding = params.pseudo_output_blinding;
-                    Commitment::from(GENERATORS.commit(Scalar::from(wrong_value), blinding))
-                };
+                let output_commitment = CompressedCommitment::new(wrong_value, params.pseudo_output_blinding);
 
                 let result =
                     invalid_signature.verify(&params.message, &params.ring, &output_commitment);
@@ -666,10 +680,7 @@ mod mlsag_tests {
                 )
                 .unwrap();
 
-                let output_commitment = {
-                    let value = Scalar::from(params.value);
-                    Commitment::from(GENERATORS.commit(value, wrong_blinding))
-                };
+                let output_commitment = CompressedCommitment::new(params.value, wrong_blinding);
 
                 let result =
                     invalid_signature.verify(&params.message, &params.ring, &output_commitment);
@@ -707,11 +718,7 @@ mod mlsag_tests {
             let wrong_key_image = compute_key_image(&RistrettoPrivate::from_random(&mut rng));
             signature.key_image = wrong_key_image;
 
-            let output_commitment = {
-                let value = Scalar::from(params.value);
-                let blinding = params.pseudo_output_blinding;
-                Commitment::from(GENERATORS.commit(value, blinding))
-            };
+            let output_commitment = CompressedCommitment::new(params.value, params.pseudo_output_blinding);
 
             match signature.verify(&params.message, &params.ring, &output_commitment) {
                 Err(Error::InvalidSignature) => {} // This is expected.
@@ -745,11 +752,7 @@ mod mlsag_tests {
             let mut wrong_message = [0u8; 32];
             rng.fill_bytes(&mut wrong_message);
 
-            let output_commitment = {
-                let value = Scalar::from(params.value);
-                let blinding = params.pseudo_output_blinding;
-                Commitment::from(GENERATORS.commit(value, blinding))
-            };
+            let output_commitment = CompressedCommitment::new(params.value, params.pseudo_output_blinding);
 
             let result = signature.verify(&wrong_message, &params.ring, &output_commitment);
 
@@ -781,16 +784,12 @@ mod mlsag_tests {
             )
             .unwrap();
 
-            let output_commitment = {
-                let value = Scalar::from(params.value);
-                let blinding = params.pseudo_output_blinding;
-                Commitment::from(GENERATORS.commit(value, blinding))
-            };
+            let output_commitment = CompressedCommitment::new(params.value, params.pseudo_output_blinding);
 
             // Modify a ring element's public key.
             {
                 let index = (rng.next_u64() as usize) % num_mixins;
-                params.ring[index].0 = RistrettoPublic::from_random(&mut rng);
+                params.ring[index].0 = CompressedRistrettoPublic::from(RistrettoPublic::from_random(&mut rng));
 
                 let result = signature.verify(&params.message, &params.ring, &output_commitment);
 
@@ -802,10 +801,10 @@ mod mlsag_tests {
 
             // Modify a ring element's amount commitment.
             {
-                let value = Scalar::from(rng.next_u64());
-                let blinding = Scalar::random(&mut rng);
                 let index = (rng.next_u64() as usize) % num_mixins;
-                params.ring[index].1 = Commitment::from(GENERATORS.commit(value, blinding));
+                let value = rng.next_u64();
+                let blinding = Scalar::random(&mut rng);
+                params.ring[index].1 = CompressedCommitment::new(value, blinding);
 
                 let result = signature.verify(&params.message, &params.ring, &output_commitment);
 
@@ -840,11 +839,7 @@ mod mlsag_tests {
 
             // The output_commitment should match the value and pseudo_output_blinding used by the signature.
             // Here, the output_commitment uses a different value.
-            let wrong_output_commitment = {
-                let value = Scalar::random(&mut rng);
-                let blinding = params.pseudo_output_blinding;
-                Commitment::from(GENERATORS.commit(value, blinding))
-            };
+            let wrong_output_commitment = CompressedCommitment::new(rng.next_u64(), params.pseudo_output_blinding);
 
             let result = signature.verify(&params.message, &params.ring, &wrong_output_commitment);
 
@@ -876,11 +871,7 @@ mod mlsag_tests {
             )
             .unwrap();
 
-            let output_commitment = {
-                let value = Scalar::from(params.value);
-                let blinding = params.pseudo_output_blinding;
-                Commitment::from(GENERATORS.commit(value, blinding))
-            };
+            let output_commitment = CompressedCommitment::new(params.value, params.pseudo_output_blinding);
 
             // Modify the signature to have too few responses.
             {

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -311,17 +311,20 @@ impl RingMLSAG {
         let G = GENERATORS.B;
         let H = GENERATORS.B_blinding;
 
-        // The uncompressed key image.
+        // The key image must decompress.
+        // This ensures that the key image encodes a valid Ristretto point.
         let I: RistrettoPoint = self
             .key_image
             .try_into()
             .map_err(|_e| Error::InvalidKeyImage)?;
+
         let r = &self.responses;
 
         // Output commitment must decompress.
         let output_commitment: Commitment = Commitment::try_from(output_commitment)?;
 
         // Ring must decompress.
+        // This ensures that each address and commitment encodes a valid Ristretto point.
         let mut decompressed_ring: Vec<(RistrettoPublic, Commitment)> = Vec::new();
         for (compressed_address, compressed_commitment) in ring {
             let ristretto_public = RistrettoPublic::try_from(compressed_address)?;

--- a/transaction/core/src/ring_signature/mod.rs
+++ b/transaction/core/src/ring_signature/mod.rs
@@ -39,9 +39,6 @@ lazy_static! {
         BulletproofGens::new(64, MAX_INPUTS as usize + MAX_OUTPUTS as usize);
 }
 
-/// A Pedersen commitment.
-pub type Commitment = CurvePoint;
-
 // The "blinding factor" in a Pedersen commitment.
 pub type Blinding = CurveScalar;
 

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -215,6 +215,7 @@ impl SignatureRctBulletproofs {
         }
 
         // output_commitments must decompress.
+        // This ensures that each commitment encodes a valid Ristretto point.
         let mut decompressed_output_commitments: Vec<Commitment> = Vec::new();
         for output_commitment in output_commitments {
             let commitment = Commitment::try_from(output_commitment)?;
@@ -222,6 +223,7 @@ impl SignatureRctBulletproofs {
         }
 
         // pseudo_output_commitments must decompress.
+        // This ensures that each commitment encodes a valid Ristretto point.
         let mut decompressed_pseudo_output_commitments: Vec<Commitment> = Vec::new();
         for pseudo_output in &self.pseudo_output_commitments {
             let point = pseudo_output.decompress().ok_or(Error::InvalidCurvePoint)?;

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -21,8 +21,8 @@ use crate::{
     encrypted_fog_hint::EncryptedFogHint,
     onetime_keys::{compute_shared_secret, compute_tx_pubkey, create_onetime_public_key},
     range::Range,
-    ring_signature::{Blinding, Commitment, KeyImage, SignatureRctBulletproofs, GENERATORS},
-    RedactedTx,
+    ring_signature::{Blinding, KeyImage, SignatureRctBulletproofs, GENERATORS},
+    CompressedCommitment, RedactedTx,
 };
 
 /// Transaction hash length, in bytes.
@@ -204,8 +204,8 @@ impl TxPrefix {
     }
 
     /// Get all output commitments (including explicit outputs and the implicit fee output).
-    pub fn output_commitments(&self) -> Vec<Commitment> {
-        let mut commitments: Vec<Commitment> = self
+    pub fn output_commitments(&self) -> Vec<CompressedCommitment> {
+        let mut commitments: Vec<CompressedCommitment> = self
             .outputs
             .iter()
             .map(|output| output.amount.commitment)
@@ -213,7 +213,7 @@ impl TxPrefix {
 
         let fee_commitment = {
             let (value, blinding) = self.fee_value_and_blinding();
-            Commitment::from(GENERATORS.commit(Scalar::from(value), blinding))
+            CompressedCommitment::new(value, blinding)
         };
         commitments.push(fee_commitment);
         commitments

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -4,21 +4,21 @@
 //!
 //! See https://cryptonote.org/img/cryptonote_transaction.png
 
-use keys::{FromRandom, RistrettoPrivate, RistrettoPublic};
+use keys::{CompressedRistrettoPublic, FromRandom, RistrettoPrivate, RistrettoPublic};
 use std::collections::HashSet;
 
 use crate::{InputCredentials, TxBuilderError};
 use curve25519_dalek::scalar::Scalar;
 use rand_core::{CryptoRng, RngCore};
-use std::convert::TryFrom;
 use transaction::{
     account_keys::PublicAddress,
     constants::BASE_FEE,
     encrypted_fog_hint::EncryptedFogHint,
     fog_hint::FogHint,
     onetime_keys::compute_shared_secret,
-    ring_signature::{Address, Commitment, SignatureRctBulletproofs},
+    ring_signature::SignatureRctBulletproofs,
     tx::{Tx, TxIn, TxOut, TxPrefix},
+    CompressedCommitment,
 };
 
 /// Helper utility for building and signing a CryptoNote-style transaction.
@@ -54,7 +54,7 @@ impl TransactionBuilder {
     /// Add an output to the transaction.
     ///
     /// # Arguments
-    /// * `value` - The value of this output, in picoMOB.
+    /// * `value` - The value of this output.
     /// * `recipient` - The recipient's public address
     /// * `recipient_fog_ingest_key` - The recipient's fog server's public key
     /// * `rng` - RNG used to generate blinding for commitment
@@ -86,7 +86,7 @@ impl TransactionBuilder {
     /// Sets the transaction fee.
     ///
     /// # Arguments
-    /// * `fee` - Transaction fee, in picoMOB.
+    /// * `fee` - Transaction fee.
     pub fn set_fee(&mut self, fee: u64) {
         self.fee = fee;
     }
@@ -123,14 +123,13 @@ impl TransactionBuilder {
         let tx_prefix_hash = tx_prefix.hash();
         let message = tx_prefix_hash.as_bytes();
 
-        let mut rings: Vec<Vec<(Address, Commitment)>> = Vec::new();
-        for tx_in in &tx_prefix.inputs {
-            let mut ring: Vec<(Address, Commitment)> = Vec::new();
-            for tx_out in &tx_in.ring {
-                let address = RistrettoPublic::try_from(&tx_out.target_key)?;
-                let commitment = tx_out.amount.commitment;
-                ring.push((address, commitment));
-            }
+        let mut rings: Vec<Vec<(CompressedRistrettoPublic, CompressedCommitment)>> = Vec::new();
+        for input in &tx_prefix.inputs {
+            let ring: Vec<(CompressedRistrettoPublic, CompressedCommitment)> = input
+                .ring
+                .iter()
+                .map(|tx_out| (tx_out.target_key, tx_out.amount.commitment))
+                .collect();
             rings.push(ring);
         }
 
@@ -197,7 +196,7 @@ impl Default for TransactionBuilder {
 /// Creates a TxOut that sends `value` to `recipient`.
 ///
 /// # Arguments
-/// * `value` - Value of the output, in picoMOB.
+/// * `value` - Value of the output.
 /// * `recipient` - Recipient's address.
 /// * `ingest_pubkey` - The public key for the recipients fog server, if any
 /// * `rng` -

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -54,7 +54,7 @@ impl TransactionBuilder {
     /// Add an output to the transaction.
     ///
     /// # Arguments
-    /// * `value` - The value of this output.
+    /// * `value` - The value of this output, in picoMOB.
     /// * `recipient` - The recipient's public address
     /// * `recipient_fog_ingest_key` - The recipient's fog server's public key
     /// * `rng` - RNG used to generate blinding for commitment
@@ -86,7 +86,7 @@ impl TransactionBuilder {
     /// Sets the transaction fee.
     ///
     /// # Arguments
-    /// * `fee` - Transaction fee.
+    /// * `fee` - Transaction fee, in picoMOB.
     pub fn set_fee(&mut self, fee: u64) {
         self.fee = fee;
     }
@@ -196,7 +196,7 @@ impl Default for TransactionBuilder {
 /// Creates a TxOut that sends `value` to `recipient`.
 ///
 /// # Arguments
-/// * `value` - Value of the output.
+/// * `value` - Value of the output, in picoMOB.
 /// * `recipient` - Recipient's address.
 /// * `ingest_pubkey` - The public key for the recipients fog server, if any
 /// * `rng` -


### PR DESCRIPTION
Previously, Amount.commitment was a RistrettoPoint (type aliased as "Commitment'), while the rest of the transaction members are CompressedRistretto. Using RistrettoPoint in Amount causes unnecessary compress and decompress operations. For example, computing the hash, digest, serialization, or deserialization of a Tx involves compressing the Amount commitment for each ring element and transaction output.

This PR adds the newtypes Commitment and CompressedCommitment, and updates Amount to use CompressedCommitment. This should prevent most of the unnecessary compress/decompress operations related to Amount.

This also changes SignatureRctBulletproof's sign and verify methods to take one-time addresses and amount commitments in compressed form (CompressedRistrettoPublic and CompressedCommitment). I think this nicely encapsulates the compress/decompress logic close to where it is used.