### PR TITLE
Minor cleanup for Amount

### DIFF
--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -25,7 +25,7 @@ use transaction::{
     encrypted_fog_hint::EncryptedFogHint,
     range::Range,
     ring_signature::{
-        Blinding, CurvePoint, CurveScalar, Error as RingSigError, KeyImage, RingMLSAG,
+        CurvePoint, CurveScalar, Error as RingSigError, KeyImage, RingMLSAG,
         SignatureRctBulletproofs,
     },
     tx,
@@ -560,7 +560,7 @@ impl TryFrom<&external::Amount> for Amount {
 
         let masked_value = source.get_masked_value();
 
-        let masked_blinding: Blinding = {
+        let masked_blinding: CurveScalar = {
             let bytes = source.get_masked_blinding().get_data();
             vec_to_curve_scalar(bytes)?
         };
@@ -914,14 +914,14 @@ pub fn block_num_to_s3block_path(block_index: transaction::BlockIndex) -> PathBu
 mod conversion_tests {
     extern crate rand;
 
-    use self::rand::{rngs::StdRng, SeedableRng};
+    use self::rand::{rngs::StdRng, RngCore, SeedableRng};
     use super::*;
     use curve25519_dalek::ristretto::RistrettoPoint;
     use keys::FromRandom;
     use transaction::{
         account_keys::{AccountKey, PublicAddress},
         onetime_keys::recover_onetime_private_key,
-        ring_signature::Blinding,
+        ring_signature::Scalar,
         tx::{Tx, TxOut, TxOutMembershipProof},
     };
     use transaction_std::*;
@@ -1104,7 +1104,7 @@ mod conversion_tests {
         let source = tx::TxOut {
             amount: Amount::new(
                 1u64 << 13,
-                Blinding::from(9u64),
+                Scalar::random(&mut rng),
                 &RistrettoPublic::from_random(&mut rng),
             )
             .unwrap(),
@@ -1135,8 +1135,8 @@ mod conversion_tests {
         let source: RedactedTx = {
             let tx_out_a = tx::TxOut {
                 amount: Amount::new(
-                    1u64 << 17,
-                    Blinding::from(9u64),
+                    rng.next_u64(),
+                    Scalar::random(&mut rng),
                     &RistrettoPublic::from_random(&mut rng),
                 )
                 .unwrap(),
@@ -1147,8 +1147,8 @@ mod conversion_tests {
 
             let tx_out_b = tx::TxOut {
                 amount: Amount::new(
-                    1u64 << 18,
-                    Blinding::from(9u64),
+                    rng.next_u64(),
+                    Scalar::random(&mut rng),
                     &RistrettoPublic::from_random(&mut rng),
                 )
                 .unwrap(),

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -43,7 +43,7 @@ use transaction::{
     blake2b_256::Blake2b256,
     constants::{FEE_SPEND_PUBLIC_KEY, FEE_VIEW_PUBLIC_KEY},
     onetime_keys::{compute_shared_secret, compute_tx_pubkey, create_onetime_public_key},
-    ring_signature::{Blinding, KeyImage, Scalar},
+    ring_signature::{KeyImage, Scalar},
     tx::{Tx, TxOut, TxOutMembershipProof},
     Block, BlockContents, BlockSignature, RedactedTx, BLOCK_VERSION,
 };
@@ -456,7 +456,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
 
             // This private key is generated from the hash of all transactions in this block.
             // This ensures that all nodes generate the same fee output transaction.
-            Blinding::from_bytes_mod_order(hash_value)
+            Scalar::from_bytes_mod_order(hash_value)
         };
 
         let total_fee: u64 = transactions.iter().map(|tx| tx.prefix.fee).sum();
@@ -495,11 +495,11 @@ impl ConsensusEnclave for SgxConsensusEnclave {
 /// # Arguments:
 /// * `tx_private_key` - Transaction key used to output the aggregate fee.
 /// * `total_fee` - The sum of all fees in the block.
-/// * `blinding` - The` Blinding` value to use for constructing the Amount.
+/// * `blinding` - The blinding to use for constructing the Amount.
 fn mint_aggregate_fee(
     tx_private_key: &RistrettoPrivate,
     total_fee: u64,
-    blinding: Blinding,
+    blinding: Scalar,
 ) -> Result<TxOut> {
     let fee_recipient = PublicAddress::new(
         &RistrettoPublic::try_from(&FEE_SPEND_PUBLIC_KEY).unwrap(),

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -731,7 +731,7 @@ pub mod tx_out_store_tests {
     use tempdir::TempDir;
     use transaction::{
         account_keys::AccountKey, amount::Amount, encrypted_fog_hint::EncryptedFogHint,
-        onetime_keys::*, range::Range, ring_signature::Blinding, tx::TxOut,
+        onetime_keys::*, range::Range, ring_signature::Scalar, tx::TxOut,
     };
 
     fn get_env() -> Environment {
@@ -769,7 +769,7 @@ pub mod tx_out_store_tests {
                 recipient_account.default_subaddress().spend_public_key(),
             );
             let shared_secret: RistrettoPublic = compute_shared_secret(&target_key, &tx_secret_key);
-            let blinding = Blinding::from_random(&mut rng);
+            let blinding = Scalar::random(&mut rng);
             let amount = Amount::new(value, blinding, &shared_secret).unwrap();
             let tx_out = TxOut {
                 amount,

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -152,7 +152,7 @@ mod test {
     use keys::{FromRandom, RistrettoPublic};
     use ledger_db::Ledger;
     use rand::{rngs::StdRng, SeedableRng};
-    use transaction::{account_keys::AccountKey, amount::Amount, ring_signature::Blinding};
+    use transaction::{account_keys::AccountKey, amount::Amount, ring_signature::Scalar};
     use transaction_test_utils::{create_ledger, create_transaction, initialize_ledger};
 
     #[test]
@@ -163,7 +163,7 @@ mod test {
         let tx_out = TxOut {
             amount: Amount::new(
                 1u64 << 13,
-                Blinding::from(9u64),
+                Scalar::from(9u64),
                 &RistrettoPublic::from_random(&mut rng),
             )
             .unwrap(),
@@ -252,7 +252,7 @@ mod test {
             let tx_out = TxOut {
                 amount: Amount::new(
                     1u64 << 13,
-                    Blinding::from(9u64),
+                    Scalar::from(9u64),
                     &RistrettoPublic::from_random(&mut rng),
                 )
                 .unwrap(),

--- a/transaction/core/src/amount.rs
+++ b/transaction/core/src/amount.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(test, allow(clippy::unnecessary_operation))]
 
 use crate::{
-    ring_signature::{Blinding, CurveScalar, GENERATORS},
+    ring_signature::{CurveScalar, GENERATORS},
     CompressedCommitment,
 };
 use blake2::{Blake2b, Digest};
@@ -33,6 +33,9 @@ const VALUE_MASK: &str = "amount_value_mask";
 
 /// Blinding mask hash function domain separator.
 const BLINDING_MASK: &str = "amount_blinding_mask";
+
+// The "blinding factor" in a Pedersen commitment.
+pub type Blinding = CurveScalar;
 
 /// A commitment to an amount of MobileCoin, denominated in picoMOB.
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Message, Digestible)]

--- a/transaction/core/src/proptest_fixtures.rs
+++ b/transaction/core/src/proptest_fixtures.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use crate::{
-    amount::Amount,
-    ring_signature::{Blinding, CurveScalar},
+    amount::{Amount, Blinding},
+    ring_signature::CurveScalar,
 };
 use curve25519_dalek::scalar::Scalar;
 use keys::{RistrettoPrivate, RistrettoPublic};

--- a/transaction/core/src/proptest_fixtures.rs
+++ b/transaction/core/src/proptest_fixtures.rs
@@ -1,9 +1,6 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
-use crate::{
-    amount::{Amount, Blinding},
-    ring_signature::CurveScalar,
-};
+use crate::{amount::Amount, ring_signature::CurveScalar};
 use curve25519_dalek::scalar::Scalar;
 use keys::{RistrettoPrivate, RistrettoPublic};
 use proptest::prelude::*;
@@ -16,11 +13,6 @@ pub fn arbitrary_scalar() -> impl Strategy<Value = Scalar> {
 /// Generates an arbitrary CurveScalar.
 pub fn arbitrary_curve_scalar() -> impl Strategy<Value = CurveScalar> {
     arbitrary_scalar().prop_map(CurveScalar::from)
-}
-
-/// Generates an arbitrary blinding.
-pub fn arbitrary_blinding() -> impl Strategy<Value = Blinding> {
-    arbitrary_curve_scalar()
 }
 
 /// Generates an arbitrary RistrettoPrivate key.
@@ -36,7 +28,7 @@ pub fn arbitrary_ristretto_public() -> impl Strategy<Value = RistrettoPublic> {
 prop_compose! {
     /// Generates an arbitrary amount with value in [0,max_value].
     pub fn arbitrary_amount(max_value: u64, shared_secret: RistrettoPublic)
-                (value in 0..=max_value, blinding in arbitrary_blinding()) -> Amount {
+                (value in 0..=max_value, blinding in arbitrary_scalar()) -> Amount {
             Amount::new(value,  blinding, &shared_secret).unwrap()
     }
 }

--- a/transaction/core/src/range_proofs/mod.rs
+++ b/transaction/core/src/range_proofs/mod.rs
@@ -23,7 +23,7 @@ const DOMAIN_SEPARATOR_LABEL: &[u8] = b"mobilecoin_range_proof";
 /// `blindings` - Pedersen commitment blinding for each value.
 ///
 /// # Returns
-/// The proof and the (padded) vector of Pedersen commitments from `values` and `blindings`.
+/// The proof and the Pedersen commitments from `values` and `blindings` (padded to a power of 2).
 pub fn generate_range_proofs<T: RngCore + CryptoRng>(
     values: &[u64],
     blindings: &[Scalar],

--- a/transaction/core/src/range_proofs/mod.rs
+++ b/transaction/core/src/range_proofs/mod.rs
@@ -8,7 +8,10 @@ use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
 
 pub mod error;
-use crate::ring_signature::{Blinding, BP_GENERATORS, GENERATORS};
+use crate::{
+    amount::Blinding,
+    ring_signature::{BP_GENERATORS, GENERATORS},
+};
 use error::Error;
 
 /// The domain separation label should be unique for each application.

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -24,7 +24,7 @@ use crate::{
     commitment::Commitment,
     compressed_commitment::CompressedCommitment,
     onetime_keys::compute_key_image,
-    ring_signature::{Blinding, CurveScalar, Error, KeyImage, Scalar, GENERATORS},
+    ring_signature::{CurveScalar, Error, KeyImage, Scalar, GENERATORS},
 };
 
 fn hash_to_point(ristretto_public: &RistrettoPublic) -> RistrettoPoint {

--- a/transaction/core/src/ring_signature/mod.rs
+++ b/transaction/core/src/ring_signature/mod.rs
@@ -37,9 +37,3 @@ lazy_static! {
     pub static ref BP_GENERATORS: BulletproofGens =
         BulletproofGens::new(64, MAX_INPUTS as usize + MAX_OUTPUTS as usize);
 }
-
-// The "blinding factor" in a Pedersen commitment.
-pub type Blinding = CurveScalar;
-
-/// An output's one-time public address.
-pub type Address = RistrettoPublic;

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -30,11 +30,12 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    amount::Blinding,
     commitment::Commitment,
     compressed_commitment::CompressedCommitment,
     onetime_keys::compute_key_image,
     range_proofs::{check_range_proofs, generate_range_proofs},
-    ring_signature::{mlsag::RingMLSAG, Blinding, Error, KeyImage, Scalar, GENERATORS},
+    ring_signature::{mlsag::RingMLSAG, Error, KeyImage, Scalar, GENERATORS},
 };
 
 /// An RCT_TYPE_BULLETPROOFS_2 signature.
@@ -336,9 +337,10 @@ mod rct_bulletproofs_tests {
     use rand::{rngs::StdRng, CryptoRng, SeedableRng};
 
     use crate::{
+        amount::Blinding,
         proptest_fixtures::*,
         range_proofs::generate_range_proofs,
-        ring_signature::{Blinding, Error, KeyImage, SignatureRctBulletproofs, GENERATORS},
+        ring_signature::{Error, KeyImage, SignatureRctBulletproofs, GENERATORS},
     };
 
     use super::sign_with_balance_check;

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -30,7 +30,6 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    amount::Blinding,
     commitment::Commitment,
     compressed_commitment::CompressedCommitment,
     onetime_keys::compute_key_image,
@@ -285,10 +284,10 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
         .collect();
 
     let (range_proof, commitments) = {
-        let values_and_blindings: Vec<(u64, Blinding)> = pseudo_output_values_and_blindings
+        let values_and_blindings: Vec<(u64, Scalar)> = pseudo_output_values_and_blindings
             .iter()
             .chain(output_values_and_blindings.iter())
-            .map(|(value, blinding)| (*value, Blinding::from(*blinding)))
+            .map(|(value, blinding)| (*value, *blinding))
             .collect();
 
         let (values, blindings): (Vec<_>, Vec<_>) = values_and_blindings.into_iter().unzip();
@@ -337,7 +336,6 @@ mod rct_bulletproofs_tests {
     use rand::{rngs::StdRng, CryptoRng, SeedableRng};
 
     use crate::{
-        amount::Blinding,
         proptest_fixtures::*,
         range_proofs::generate_range_proofs,
         ring_signature::{Error, KeyImage, SignatureRctBulletproofs, GENERATORS},
@@ -644,9 +642,9 @@ mod rct_bulletproofs_tests {
             // Modify the range proof
             let wrong_range_proof = {
                 let values = [13; 6];
-                let blindings: Vec<Blinding> = values
+                let blindings: Vec<Scalar> = values
                     .iter()
-                    .map(|_value| Blinding::from(Scalar::random(&mut rng)))
+                    .map(|_value| Scalar::random(&mut rng))
                     .collect();
                 let (range_proof, _commitments) =
                     generate_range_proofs(&values, &blindings, &mut rng).unwrap();

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -16,13 +16,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     account_keys::PublicAddress,
-    amount::{Amount, AmountError},
+    amount::{Amount, AmountError, Blinding},
     blake2b_256::Blake2b256,
     constants::RING_SIZE,
     encrypted_fog_hint::EncryptedFogHint,
     onetime_keys::{compute_shared_secret, compute_tx_pubkey, create_onetime_public_key},
     range::Range,
-    ring_signature::{Blinding, KeyImage, SignatureRctBulletproofs, GENERATORS},
+    ring_signature::{KeyImage, SignatureRctBulletproofs, GENERATORS},
     CompressedCommitment, RedactedTx,
 };
 
@@ -408,10 +408,10 @@ mod tests {
 
     use crate::{
         account_keys::AccountKey,
-        amount::Amount,
+        amount::{Amount, Blinding},
         constants::{BASE_FEE, FEE_SPEND_PUBLIC_KEY, FEE_VIEW_PRIVATE_KEY, FEE_VIEW_PUBLIC_KEY},
         encrypted_fog_hint::EncryptedFogHint,
-        ring_signature::{Blinding, CurvePoint, CurveScalar, KeyImage, SignatureRctBulletproofs},
+        ring_signature::{CurvePoint, CurveScalar, KeyImage, SignatureRctBulletproofs},
         tx::{Tx, TxIn, TxOut, TxPrefix},
     };
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     account_keys::PublicAddress,
-    amount::{Amount, AmountError, Blinding},
+    amount::{Amount, AmountError},
     blake2b_256::Blake2b256,
     constants::RING_SIZE,
     encrypted_fog_hint::EncryptedFogHint,
@@ -278,7 +278,7 @@ impl TxOut {
 
         let amount = {
             let shared_secret = compute_shared_secret(recipient.view_public_key(), tx_private_key);
-            Amount::new(value, Blinding::from_random(rng), &shared_secret)
+            Amount::new(value, Scalar::random(rng), &shared_secret)
         }?;
 
         Ok(TxOut {
@@ -408,10 +408,10 @@ mod tests {
 
     use crate::{
         account_keys::AccountKey,
-        amount::{Amount, Blinding},
+        amount::Amount,
         constants::{BASE_FEE, FEE_SPEND_PUBLIC_KEY, FEE_VIEW_PRIVATE_KEY, FEE_VIEW_PUBLIC_KEY},
         encrypted_fog_hint::EncryptedFogHint,
-        ring_signature::{CurvePoint, CurveScalar, KeyImage, SignatureRctBulletproofs},
+        ring_signature::{CurvePoint, CurveScalar, KeyImage, Scalar, SignatureRctBulletproofs},
         tx::{Tx, TxIn, TxOut, TxPrefix},
     };
 
@@ -422,7 +422,7 @@ mod tests {
             let shared_secret = RistrettoPublic::from(*CurvePoint::from(2).as_ref());
             let target_key = RistrettoPublic::from(*CurvePoint::from(3).as_ref()).into();
             let public_key = RistrettoPublic::from(*CurvePoint::from(3).as_ref()).into();
-            let blinding = Blinding::from_bytes_mod_order([77u8; 32]);
+            let blinding = Scalar::from_bytes_mod_order([77u8; 32]);
             let amount = Amount::new(23u64, blinding, &shared_secret).unwrap();
             TxOut {
                 amount,

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -149,7 +149,7 @@ impl TransactionBuilder {
                 &input_credential.view_private_key,
             );
             let (value, blinding) = amount.get_value(&shared_secret)?;
-            input_secrets.push((onetime_private_key, value, blinding.into()));
+            input_secrets.push((onetime_private_key, value, blinding));
         }
 
         let mut output_values_and_blindings: Vec<(u64, Scalar)> = tx_prefix
@@ -162,7 +162,7 @@ impl TransactionBuilder {
                 let (value, blinding) = amount
                     .get_value(shared_secret)
                     .expect("TransactionBuilder created an invalid Amount");
-                (value, blinding.into())
+                (value, blinding)
             })
             .collect();
 


### PR DESCRIPTION
The main change here is removing the type alias "Blinding", and letting Amount::new take the blinding as a plain old Scalar. 

I think this removes an irritating layer of indirection ("Blinding is a type alias for CurveScalar which is a Prost-friendly wrapper for Scalar") in several places where a Prost-friendly type is not required, like in the non-public methods of Amount.
