### PR TITLE
WIP make `cumulative_txo_count` part of the Block header

### DIFF
--- a/consensus/api/proto/blockchain.proto
+++ b/consensus/api/proto/blockchain.proto
@@ -38,6 +38,7 @@ message Block {
     uint32 version = 2;
     bytes parent_id = 3;
     uint64 index = 4;
+    uint64 cumulative_txo_count = 7;
     external.TxOutMembershipElement root_element = 5;
     bytes contents_hash = 6;
 }

--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -86,6 +86,7 @@ impl From<&transaction::Block> for blockchain::Block {
         block.set_version(other.version);
         block.set_parent_id(other.parent_id.as_ref().to_vec());
         block.set_index(other.index);
+        block.set_cumulative_txo_count(other.cumulative_txo_count);
         block.set_root_element((&other.root_element).into());
         block.set_contents_hash(other.contents_hash.as_ref().to_vec());
         block
@@ -108,6 +109,7 @@ impl TryFrom<&blockchain::Block> for transaction::Block {
             version: value.version,
             parent_id,
             index: value.index,
+            cumulative_txo_count: value.cumulative_txo_count,
             root_element,
             contents_hash,
         };
@@ -1022,6 +1024,7 @@ mod conversion_tests {
             version: 1,
             parent_id: transaction::BlockID::try_from(&[1u8; 32][..]).unwrap(),
             index: 99,
+            cumulative_txo_count: 666,
             root_element: TxOutMembershipElement {
                 range: Range::new(10, 20).unwrap(),
                 hash: TxOutMembershipHash::from([12u8; 32]),
@@ -1034,6 +1037,7 @@ mod conversion_tests {
         assert_eq!(block.get_version(), 1);
         assert_eq!(block.get_parent_id(), [1u8; 32]);
         assert_eq!(block.get_index(), 99);
+        assert_eq!(block.get_cumulative_txo_count(), 666);
         assert_eq!(block.get_root_element().get_range().get_from(), 10);
         assert_eq!(block.get_root_element().get_range().get_to(), 20);
         assert_eq!(block.get_root_element().get_hash().get_data(), &[12u8; 32]);

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -477,6 +477,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
             BLOCK_VERSION,
             &parent_block.id,
             parent_block.index + 1,
+            parent_block.cumulative_txo_count + redacted_transactions.len() as u64,
             &root_elements[0],
             &redacted_transactions,
         );

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -200,6 +200,7 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
             BLOCK_VERSION,
             &parent_block.id,
             parent_block.index + 1,
+            parent_block.cumulative_txo_count + redacted_transactions.len() as u64,
             &root_elements[0],
             &redacted_transactions,
         );

--- a/consensus/service/src/blockchain_api_service.rs
+++ b/consensus/service/src/blockchain_api_service.rs
@@ -191,6 +191,7 @@ mod tests {
                     BLOCK_VERSION,
                     &parent.id,
                     block_index,
+                    parent.cumulative_txo_count + redacted_transactions.len() as u64,
                     &Default::default(),
                     &redacted_transactions,
                 ),

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -518,6 +518,7 @@ mod ledger_db_test {
                     BLOCK_VERSION,
                     &parent.id,
                     block_index,
+                    parent.cumulative_txo_count + redacted_transactions.len() as u64,
                     &Default::default(),
                     &redacted_transactions,
                 ),
@@ -821,6 +822,7 @@ mod ledger_db_test {
             BLOCK_VERSION,
             &block_zero.id,
             1,
+            3,
             &Default::default(),
             &block_one_transactions,
         );
@@ -1167,6 +1169,7 @@ mod ledger_db_test {
             BLOCK_VERSION,
             &blocks[0].id,
             1,
+            3,
             &Default::default(),
             &redacted_transactions,
         );
@@ -1442,6 +1445,7 @@ mod ledger_db_test {
                 BLOCK_VERSION,
                 &bad_parent_id,
                 1,
+                1,
                 &Default::default(),
                 &redacted_transactions,
             );
@@ -1455,6 +1459,7 @@ mod ledger_db_test {
             let block_one_good = Block::new(
                 BLOCK_VERSION,
                 &block_zero.id,
+                1,
                 1,
                 &Default::default(),
                 &redacted_transactions,

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -236,10 +236,16 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, Vec<RedactedTx>)> 
             };
 
             let redacted_transactions = vec![redacted_tx];
+            // Compute cumulative_txo_count
+            let cumulative_txo_count = blocks_and_transactions[block_index - 1]
+                .0
+                .cumulative_txo_count
+                + redacted_transactions.len() as u64;
             let block = Block::new(
                 BLOCK_VERSION,
                 &parent_id,
                 block_index as u64,
+                cumulative_txo_count,
                 &TxOutMembershipElement::default(),
                 &redacted_transactions,
             );
@@ -290,6 +296,7 @@ mod tests {
                 block.version,
                 &block.parent_id,
                 block.index,
+                block.cumulative_txo_count,
                 &block.root_element,
                 &block.contents_hash,
             );

--- a/ledger/sync/src/ledger_sync_service.rs
+++ b/ledger/sync/src/ledger_sync_service.rs
@@ -703,6 +703,7 @@ fn identify_safe_blocks<L: Ledger>(
             block.version,
             &block.parent_id,
             block.index,
+            block.cumulative_txo_count,
             &block.root_element,
             &contents_hash,
         );

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1902,6 +1902,7 @@ mod test {
                 BLOCK_VERSION,
                 &parent.id,
                 num_blocks as BlockIndex,
+                parent.cumulative_txo_count + redacted_transactions.len() as u64,
                 &Default::default(),
                 &redacted_transactions,
             );

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -174,6 +174,7 @@ pub fn add_block_to_ledger_db(
             BLOCK_VERSION,
             &parent.id,
             num_blocks as BlockIndex,
+            parent.cumulative_txo_count + redacted_transactions.len() as u64,
             &Default::default(),
             &redacted_transactions,
         );

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -186,6 +186,7 @@ pub fn initialize_ledger<L: Ledger, R: RngCore + CryptoRng>(
                     BLOCK_VERSION,
                     &parent.as_ref().unwrap().id,
                     block_index,
+                    parent.as_ref().unwrap().cumulative_txo_count + 1,
                     &Default::default(),
                     &redacted_transactions,
                 );
@@ -249,6 +250,7 @@ pub fn get_blocks<T: Rng + RngCore + CryptoRng>(
 
     let mut results = Vec::<(Block, Vec<RedactedTx>)>::new();
     let mut last_block_id = initial_block_id;
+    let mut cumulative_txo_count = 0u64;
 
     for block_index in 0..n_blocks {
         let n_txs = rng.gen_range(min_txs_per_block, max_txs_per_block + 1);
@@ -269,6 +271,8 @@ pub fn get_blocks<T: Rng + RngCore + CryptoRng>(
             txs.push(tx);
         }
 
+        cumulative_txo_count += txs.len() as u64;
+
         // Fake proofs
         let root_element = TxOutMembershipElement {
             range: Range::new(0, block_index as u64).unwrap(),
@@ -279,6 +283,7 @@ pub fn get_blocks<T: Rng + RngCore + CryptoRng>(
             BLOCK_VERSION,
             &last_block_id,
             initial_block_index + block_index as u64,
+            cumulative_txo_count,
             &root_element,
             &txs,
         );

--- a/transaction/std/src/block_builder.rs
+++ b/transaction/std/src/block_builder.rs
@@ -52,10 +52,16 @@ impl BlockBuilder {
             .parent_block
             .as_ref()
             .map_or(0, |block| block.index + 1);
+        let new_cumulative_txo_count = self
+            .parent_block
+            .as_ref()
+            .map_or(0, |block| block.cumulative_txo_count)
+            + redacted_transactions.len() as u64;
         let block = Block::new(
             BLOCK_VERSION,
             &parent_id,
             new_block_index,
+            new_cumulative_txo_count,
             &self.root_element,
             &redacted_transactions,
         );

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -81,6 +81,7 @@ pub fn bootstrap_ledger(
                 BLOCK_VERSION,
                 &parent.id,
                 block_index,
+                parent.cumulative_txo_count + minting_transactions.len() as u64,
                 &Default::default(),
                 &minting_transactions,
             ),


### PR DESCRIPTION
This will greatly simplify some post-processing stuff that happens
to the blockchain, it will mean that a bunch of services that
we have don't have to process the entire blockchain in order to
get these counts, which will become important when the blockchain
gets big.

I would like to add some tests also that this gives a correct
and valid way of computing global indices of transactions, that
agrees with the way we were doing it before this way existed.