### PR TITLE
Fix import of `core` module

### DIFF
--- a/util/encodings/src/base64.rs
+++ b/util/encodings/src/base64.rs
@@ -3,7 +3,7 @@
 //! To/From Hex traits
 
 use alloc::{string::String, vec::Vec};
-use failure::_core::cmp::max;
+use core::cmp::max;
 
 /// A trait to support reading a string as hex.
 pub trait FromBase64: Sized {


### PR DESCRIPTION
Import is mistakenly using `failure::_core` instead of `core`. This PR fixes that.