### PR TITLE
[Minor] Fix double ref

### DIFF
--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -52,5 +52,5 @@ pub fn get_tx_out_shared_secret(
     view_key: &RistrettoPrivate,
     tx_public_key: &RistrettoPublic,
 ) -> RistrettoPublic {
-    compute_shared_secret(tx_public_key, &view_key)
+    compute_shared_secret(tx_public_key, view_key)
 }


### PR DESCRIPTION
`view_key` is already of type `&RistrettoPrivate`, which is the type `compute_shared_secret` accepts as a parameter, therefore `view_key` doesn't need to be ref'd.