### PR TITLE
MC-1330 Removes masked_blinding from Amount

### DIFF
--- a/consensus/api/proto/external.proto
+++ b/consensus/api/proto/external.proto
@@ -73,9 +73,6 @@ message Amount {
 
     // `masked_value = value XOR_8 Blake2B("value_mask" || shared_secret)`
     uint64 masked_value = 2;
-
-    // `masked_blinding = blinding + Blake2B("bliding_mask" || shared_secret))
-    CurveScalar masked_blinding = 3;
 }
 
 message EncryptedFogHint {

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -731,7 +731,7 @@ pub mod tx_out_store_tests {
     use tempdir::TempDir;
     use transaction::{
         account_keys::AccountKey, amount::Amount, encrypted_fog_hint::EncryptedFogHint,
-        onetime_keys::*, range::Range, ring_signature::Scalar, tx::TxOut,
+        onetime_keys::*, range::Range, tx::TxOut,
     };
 
     fn get_env() -> Environment {
@@ -757,20 +757,20 @@ pub mod tx_out_store_tests {
     pub fn get_tx_outs(num_tx_outs: u32) -> Vec<TxOut> {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let mut tx_outs: Vec<TxOut> = Vec::new();
-        let tx_secret_key = RistrettoPrivate::from_random(&mut rng);
         let recipient_account = AccountKey::random(&mut rng);
         let value: u64 = 100;
 
         for _i in 0..num_tx_outs {
+            let tx_private_key = RistrettoPrivate::from_random(&mut rng);
             let target_key =
-                create_onetime_public_key(&recipient_account.default_subaddress(), &tx_secret_key);
+                create_onetime_public_key(&recipient_account.default_subaddress(), &tx_private_key);
             let public_key = compute_tx_pubkey(
-                &tx_secret_key,
+                &tx_private_key,
                 recipient_account.default_subaddress().spend_public_key(),
             );
-            let shared_secret: RistrettoPublic = compute_shared_secret(&target_key, &tx_secret_key);
-            let blinding = Scalar::random(&mut rng);
-            let amount = Amount::new(value, blinding, &shared_secret).unwrap();
+            let shared_secret: RistrettoPublic =
+                compute_shared_secret(&target_key, &tx_private_key);
+            let amount = Amount::new(value, &shared_secret).unwrap();
             let tx_out = TxOut {
                 amount,
                 target_key: target_key.into(),

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -152,7 +152,7 @@ mod test {
     use keys::{FromRandom, RistrettoPublic};
     use ledger_db::Ledger;
     use rand::{rngs::StdRng, SeedableRng};
-    use transaction::{account_keys::AccountKey, amount::Amount, ring_signature::Scalar};
+    use transaction::{account_keys::AccountKey, amount::Amount};
     use transaction_test_utils::{create_ledger, create_transaction, initialize_ledger};
 
     #[test]
@@ -161,12 +161,7 @@ mod test {
 
         // Rust -> Proto
         let tx_out = TxOut {
-            amount: Amount::new(
-                1u64 << 13,
-                Scalar::from(9u64),
-                &RistrettoPublic::from_random(&mut rng),
-            )
-            .unwrap(),
+            amount: Amount::new(1u64 << 13, &RistrettoPublic::from_random(&mut rng)).unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
             e_account_hint: (&[0u8; 128]).into(),
@@ -250,12 +245,7 @@ mod test {
 
         let utxo = {
             let tx_out = TxOut {
-                amount: Amount::new(
-                    1u64 << 13,
-                    Scalar::from(9u64),
-                    &RistrettoPublic::from_random(&mut rng),
-                )
-                .unwrap(),
+                amount: Amount::new(1u64 << 13, &RistrettoPublic::from_random(&mut rng)).unwrap(),
                 target_key: RistrettoPublic::from_random(&mut rng).into(),
                 public_key: RistrettoPublic::from_random(&mut rng).into(),
                 e_account_hint: (&[0u8; 128]).into(),

--- a/transaction/core/src/amount.rs
+++ b/transaction/core/src/amount.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 /// Errors that can occur when constructing an amount.
 #[derive(Debug, Fail, Eq, PartialEq)]
 pub enum AmountError {
-    /// The masked value, masked blinding, or shared secret are not consistent with the commitment.
+    /// The masked value, blinding, or shared secret are not consistent with the commitment.
     #[fail(display = "Inconsistent Commitment")]
     InconsistentCommitment,
 }
@@ -32,7 +32,7 @@ pub enum AmountError {
 const VALUE_MASK: &str = "amount_value_mask";
 
 /// Blinding mask hash function domain separator.
-const BLINDING_MASK: &str = "amount_blinding_mask";
+const BLINDING_MASK: &str = "amount_blinding";
 
 // The "blinding factor" in a Pedersen commitment.
 pub type Blinding = CurveScalar;
@@ -47,10 +47,6 @@ pub struct Amount {
     /// `masked_value = value XOR_8 Blake2B(value_mask | shared_secret)`
     #[prost(uint64, required, tag = "2")]
     pub masked_value: u64,
-
-    /// `masked_blinding = blinding + Blake2B(blinding_mask | shared_secret))
-    #[prost(message, required, tag = "3")]
-    pub masked_blinding: CurveScalar,
 }
 
 impl Amount {
@@ -59,14 +55,12 @@ impl Amount {
     ///
     /// # Arguments
     /// * `value` - The committed value `v`, in picoMOB.
-    /// * `blinding` - The blinding `b`.
     /// * `shared_secret` - The shared secret, e.g. `rB` for transaction private key `r` and recipient public key `B`.
     #[inline]
-    pub fn new(
-        value: u64,
-        blinding: Scalar,
-        shared_secret: &RistrettoPublic,
-    ) -> Result<Amount, AmountError> {
+    pub fn new(value: u64, shared_secret: &RistrettoPublic) -> Result<Amount, AmountError> {
+        // The blinding is `Blake2B("blinding" | shared_secret)`
+        let blinding: Scalar = get_blinding(shared_secret);
+
         // Pedersen commitment `v*G + b*H`.
         let commitment = CompressedCommitment::new(value, blinding);
 
@@ -81,16 +75,9 @@ impl Amount {
             value ^ mask
         };
 
-        // `b + Blake2B("blinding_mask" | shared_secret)`
-        let masked_blinding: Scalar = {
-            let mask = get_blinding_mask(&shared_secret);
-            blinding + mask
-        };
-
         Ok(Amount {
             commitment,
             masked_value,
-            masked_blinding: Blinding::from(masked_blinding),
         })
     }
 
@@ -102,7 +89,7 @@ impl Amount {
     /// * `shared_secret` - The shared secret, e.g. `rB`.
     pub fn get_value(&self, shared_secret: &RistrettoPublic) -> Result<(u64, Scalar), AmountError> {
         let value: u64 = self.unmask_value(shared_secret);
-        let blinding = self.unmask_blinding(shared_secret);
+        let blinding = get_blinding(shared_secret);
 
         let expected_commitment = CompressedCommitment::new(value, blinding);
         if self.commitment != expected_commitment {
@@ -124,13 +111,6 @@ impl Amount {
         };
         self.masked_value ^ mask
     }
-
-    /// Reveals masked_blinding.
-    fn unmask_blinding(&self, shared_secret: &RistrettoPublic) -> Scalar {
-        let mask = get_blinding_mask(shared_secret);
-        let masked_blinding: Scalar = self.masked_blinding.into();
-        masked_blinding - mask
-    }
 }
 
 /// Computes `Blake2B(value_mask | shared_secret)`.
@@ -144,11 +124,11 @@ fn get_value_mask(shared_secret: &RistrettoPublic) -> Scalar {
     Scalar::from_hash(hasher)
 }
 
-/// Computes `Blake2B(blinding_mask | shared_secret)`.
+/// Computes `Blake2B("blinding" | shared_secret)`.
 ///
 /// # Arguments
 /// * `shared_secret` - The shared secret, e.g. `rB`.
-fn get_blinding_mask(shared_secret: &RistrettoPublic) -> Scalar {
+fn get_blinding(shared_secret: &RistrettoPublic) -> Scalar {
     let mut hasher = Blake2b::new();
     hasher.input(&BLINDING_MASK);
     hasher.input(&shared_secret.to_bytes());
@@ -158,7 +138,7 @@ fn get_blinding_mask(shared_secret: &RistrettoPublic) -> Scalar {
 #[cfg(test)]
 mod amount_tests {
     use crate::{
-        amount::{Amount, AmountError},
+        amount::{get_blinding, Amount, AmountError},
         proptest_fixtures::*,
         ring_signature::{Scalar, GENERATORS},
         CompressedCommitment,
@@ -171,9 +151,8 @@ mod amount_tests {
             /// Amount::new() should return Ok for valid values and blindings.
             fn test_new_ok(
                 value in any::<u64>(),
-                blinding in arbitrary_scalar(),
                 shared_secret in arbitrary_ristretto_public()) {
-                assert!(Amount::new(value, blinding, &shared_secret).is_ok());
+                assert!(Amount::new(value, &shared_secret).is_ok());
             }
 
             #[test]
@@ -181,9 +160,9 @@ mod amount_tests {
             /// amount.commitment should agree with the value and blinding.
             fn test_commitment(
                 value in any::<u64>(),
-                blinding in arbitrary_scalar(),
                 shared_secret in arbitrary_ristretto_public()) {
-                    let amount = Amount::new(value, blinding,  &shared_secret).unwrap();
+                    let amount = Amount::new(value, &shared_secret).unwrap();
+                    let blinding = get_blinding(&shared_secret);
                     let expected_commitment = CompressedCommitment::new(value, blinding.into());
                     assert_eq!(amount.commitment, expected_commitment);
             }
@@ -192,11 +171,9 @@ mod amount_tests {
             /// amount.unmask_value should return the value used to construct the amount.
             fn test_unmask_value(
                 value in any::<u64>(),
-                blinding in arbitrary_scalar(),
                 shared_secret in arbitrary_ristretto_public())
             {
-
-                let amount = Amount::new(value, blinding,  &shared_secret).unwrap();
+                let amount = Amount::new(value, &shared_secret).unwrap();
                 assert_eq!(
                     value,
                     amount.unmask_value(&shared_secret)
@@ -204,28 +181,13 @@ mod amount_tests {
             }
 
             #[test]
-            /// amount.unmask_blinding should return the blinding used to construct the amount.
-            fn test_unmask_blinding(
-                value in any::<u64>(),
-                blinding in arbitrary_scalar(),
-                shared_secret in arbitrary_ristretto_public())
-            {
-                let amount = Amount::new(value, blinding,  &shared_secret).unwrap();
-                assert_eq!(
-                    amount.unmask_blinding(&shared_secret),
-                    blinding
-                );
-            }
-
-            #[test]
             /// get_value should return the correct value and blinding.
             fn test_get_value_ok(
                 value in any::<u64>(),
-                blinding in arbitrary_scalar(),
                 shared_secret in arbitrary_ristretto_public()) {
-
-                let amount = Amount::new(value, blinding,  &shared_secret).unwrap();
+                let amount = Amount::new(value, &shared_secret).unwrap();
                 let result = amount.get_value(&shared_secret);
+                let blinding = get_blinding(&shared_secret);
                 let expected = Ok((value, blinding));
                 assert_eq!(result, expected);
             }
@@ -236,29 +198,12 @@ mod amount_tests {
             fn test_get_value_incorrect_masked_value(
                 value in any::<u64>(),
                 other_masked_value in any::<u64>(),
-                blinding in arbitrary_scalar(),
                 shared_secret in arbitrary_ristretto_public())
             {
                 // Mutate amount to use a different masked value.
-                // With overwhelming probability, amount.masked_value won't equal other_masked_value.
-                let mut amount = Amount::new(value, blinding, &shared_secret).unwrap();
+                // With high probability, amount.masked_value won't equal other_masked_value.
+                let mut amount = Amount::new(value, &shared_secret).unwrap();
                 amount.masked_value = other_masked_value;
-                let result = amount.get_value(&shared_secret);
-                let expected = Err(AmountError::InconsistentCommitment);
-                assert_eq!(result, expected);
-            }
-
-            #[test]
-            /// get_value should return InconsistentCommitment if the masked blinding is incorrect.
-            fn test_get_value_incorrect_blinding(
-                value in any::<u64>(),
-                blinding in arbitrary_scalar(),
-                other_masked_blinding in arbitrary_curve_scalar(),
-                shared_secret in arbitrary_ristretto_public())
-            {
-                // Mutate amount to use a other_masked_blinding.
-                let mut amount = Amount::new(value, blinding, &shared_secret).unwrap();
-                amount.masked_blinding = other_masked_blinding;
                 let result = amount.get_value(&shared_secret);
                 let expected = Err(AmountError::InconsistentCommitment);
                 assert_eq!(result, expected);
@@ -268,11 +213,10 @@ mod amount_tests {
             /// get_value should return an Error if shared_secret is incorrect.
             fn test_get_value_invalid_shared_secret(
                 value in any::<u64>(),
-                blinding in arbitrary_scalar(),
                 shared_secret in arbitrary_ristretto_public(),
                 other_shared_secret in arbitrary_ristretto_public(),
             ) {
-                let amount = Amount::new(value, blinding,  &shared_secret).unwrap();
+                let amount = Amount::new(value,  &shared_secret).unwrap();
                 let result = amount.get_value(&other_shared_secret);
                 let expected = Err(AmountError::InconsistentCommitment);
                 assert_eq!(result, expected);

--- a/transaction/core/src/proptest_fixtures.rs
+++ b/transaction/core/src/proptest_fixtures.rs
@@ -28,7 +28,7 @@ pub fn arbitrary_ristretto_public() -> impl Strategy<Value = RistrettoPublic> {
 prop_compose! {
     /// Generates an arbitrary amount with value in [0,max_value].
     pub fn arbitrary_amount(max_value: u64, shared_secret: RistrettoPublic)
-                (value in 0..=max_value, blinding in arbitrary_scalar()) -> Amount {
-            Amount::new(value,  blinding, &shared_secret).unwrap()
+                (value in 0..=max_value) -> Amount {
+            Amount::new(value, &shared_secret).unwrap()
     }
 }

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -271,14 +271,14 @@ impl TxOut {
         recipient: &PublicAddress,
         tx_private_key: &RistrettoPrivate,
         hint: EncryptedFogHint,
-        rng: &mut RNG,
+        _rng: &mut RNG,
     ) -> Result<Self, AmountError> {
         let target_key = create_onetime_public_key(recipient, tx_private_key).into();
         let public_key = compute_tx_pubkey(tx_private_key, recipient.spend_public_key()).into();
 
         let amount = {
             let shared_secret = compute_shared_secret(recipient.view_public_key(), tx_private_key);
-            Amount::new(value, Scalar::random(rng), &shared_secret)
+            Amount::new(value, &shared_secret)
         }?;
 
         Ok(TxOut {
@@ -423,8 +423,7 @@ mod tests {
             let shared_secret = RistrettoPublic::from_random(&mut rng);
             let target_key = RistrettoPublic::from_random(&mut rng).into();
             let public_key = RistrettoPublic::from_random(&mut rng).into();
-            let blinding = Scalar::from_bytes_mod_order([77u8; 32]);
-            let amount = Amount::new(23u64, blinding, &shared_secret).unwrap();
+            let amount = Amount::new(23u64, &shared_secret).unwrap();
             TxOut {
                 amount,
                 target_key,


### PR DESCRIPTION
The Amount blinding is now derived from the output shared secret, which allows us to remove the `masked_blinding` field in Amount.