### PR TITLE
Checks that scalars in RingMLSAG are canonical

### DIFF
--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -259,6 +259,18 @@ impl RingMLSAG {
         // This ensures that each address and commitment encodes a valid Ristretto point.
         let decompressed_ring = decompress_ring(ring)?;
 
+        // Scalars must be canonical.
+        if !self.c_zero.scalar.is_canonical() {
+            return Err(Error::InvalidCurveScalar);
+        }
+
+        // Scalars must be canonical.
+        for response in &self.responses {
+            if !response.scalar.is_canonical() {
+                return Err(Error::InvalidCurveScalar);
+            }
+        }
+
         // Recompute challenges.
         let mut recomputed_c = vec![Scalar::zero(); ring.len()];
 


### PR DESCRIPTION
A scalar is "canonical" if it is less than the group order. Enforcing that scalars are canonical removes the possibility that a different scalar that is equivalent mod group order could be substituted in the signature.

As far as I know, our codebase only creates canonical scalars, so this check makes that "happy path" the only path.