### PR TITLE
MC-1144 mc-sgx-core-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
  "attest-trusted 0.1.0",
  "common 0.1.0",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "keys 0.1.0",
  "mcnoise 0.1.0",
  "mcrand 1.0.0",
@@ -129,7 +129,7 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "common 0.1.0",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -161,7 +161,7 @@ dependencies = [
  "attest-net 0.1.0",
  "common 0.1.0",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "keys 0.1.0",
  "mc-encodings 0.1.0",
  "mcnoise 0.1.0",
@@ -198,7 +198,7 @@ version = "0.1.0"
 dependencies = [
  "attest 0.1.0",
  "attest-ake 0.1.0",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mcnoise 0.1.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sgx_compat 1.0.0",
@@ -211,7 +211,7 @@ dependencies = [
  "attest 0.1.0",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "common 0.1.0",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.2)",
  "mc-encodings 0.1.0",
  "pem 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -229,7 +229,7 @@ version = "0.1.0"
 dependencies = [
  "attest 0.1.0",
  "common 0.1.0",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (git+https://github.com/mobilecoinofficial/prost?rev=4e1905329369ca7a1cac3eda978ee9379167ee95)",
  "sgx_compat 1.0.0",
  "sgx_types 1.0.1",
@@ -310,6 +310,15 @@ dependencies = [
 name = "binascii"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bincode"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bindgen"
@@ -661,7 +670,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "digestible 0.1.0",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -724,7 +733,7 @@ dependencies = [
  "attest-enclave-api 0.1.0",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "common 0.1.0",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "keys 0.1.0",
  "mcnoise 0.1.0",
  "mcserial 0.1.0",
@@ -818,7 +827,7 @@ dependencies = [
  "consensus-enclave 1.0.0",
  "consensus-enclave-mock 1.0.0",
  "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpc-util 1.0.0",
@@ -896,7 +905,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "publicsuffix 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1226,7 +1235,7 @@ name = "dotenv"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1309,16 +1318,16 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure_derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1997,7 +2006,7 @@ dependencies = [
  "digestible 0.1.0",
  "ed25519 1.0.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.3 (git+https://github.com/cbeck88/ed25519-dalek?rev=c0b0ab31d3572de6fb01d6b4a4f052784034b0b2)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mcserial 0.1.0",
  "pem 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2029,7 +2038,7 @@ version = "0.1.0"
 dependencies = [
  "common 0.1.0",
  "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "keys 0.1.0",
  "lmdb 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mcrand 1.0.0",
@@ -2050,7 +2059,7 @@ dependencies = [
  "common 0.1.0",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ledger-db 0.1.0",
  "mobilecoin-api 0.1.1",
  "protobuf 2.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2072,7 +2081,7 @@ dependencies = [
  "common 0.1.0",
  "consensus-enclave-measurement 1.0.0",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "keys 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2225,7 +2234,7 @@ dependencies = [
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "common 0.1.0",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "keys 0.1.0",
  "mcserial 0.1.0",
@@ -2250,7 +2259,7 @@ dependencies = [
  "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "keys 0.1.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2262,8 +2271,54 @@ name = "mc-encodings"
 version = "0.1.0"
 dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mc-sgx-core-types"
+version = "2.9.0"
+dependencies = [
+ "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mc-encodings 0.1.0",
+ "mc-sgx-core-types-sys 2.9.0",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mc-sgx-core-types-sys"
+version = "2.9.0"
+dependencies = [
+ "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mcbuild-utils 0.2.0",
+]
+
+[[package]]
+name = "mc-sgx-epid-sys"
+version = "2.9.0"
+dependencies = [
+ "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mc-sgx-core-types-sys 2.9.0",
+ "mc-sgx-epid-types-sys 2.9.0",
+ "mcbuild-sgx-utils 0.2.0",
+ "mcbuild-utils 0.2.0",
+]
+
+[[package]]
+name = "mc-sgx-epid-types-sys"
+version = "2.9.0"
+dependencies = [
+ "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mc-sgx-core-types-sys 2.9.0",
+ "mcbuild-utils 0.2.0",
 ]
 
 [[package]]
@@ -2287,7 +2342,7 @@ version = "0.1.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.2)",
  "mbedtls-sys-auto 2.18.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.2)",
  "mcbuild-sgx-utils 0.2.0",
@@ -2302,7 +2357,7 @@ version = "0.2.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mcbuild-utils 0.2.0",
 ]
@@ -2312,7 +2367,7 @@ name = "mcbuild-utils"
 version = "0.2.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2327,7 +2382,7 @@ dependencies = [
  "attest-ake 0.1.0",
  "attest-api 0.1.1",
  "common 0.1.0",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "host-cert 0.1.0",
  "keys 0.1.0",
@@ -2372,7 +2427,7 @@ dependencies = [
  "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "keys 0.1.0",
@@ -2406,44 +2461,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "mcsgx-core-types-sys"
-version = "2.9.0"
-dependencies = [
- "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mcbuild-utils 0.2.0",
-]
-
-[[package]]
-name = "mcsgx-epid-sys"
-version = "2.9.0"
-dependencies = [
- "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mcbuild-sgx-utils 0.2.0",
- "mcbuild-utils 0.2.0",
- "mcsgx-core-types-sys 2.9.0",
- "mcsgx-epid-types-sys 2.9.0",
-]
-
-[[package]]
-name = "mcsgx-epid-types-sys"
-version = "2.9.0"
-dependencies = [
- "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mcbuild-utils 0.2.0",
- "mcsgx-core-types-sys 2.9.0",
-]
-
-[[package]]
 name = "mcuri"
 version = "0.1.0"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "common 0.1.0",
  "ed25519 1.0.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "host-cert 0.1.0",
  "keys 0.1.0",
@@ -2487,7 +2511,7 @@ name = "message-cipher"
 version = "0.1.0"
 dependencies = [
  "aes-gcm 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mcserial 0.1.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2661,7 +2685,7 @@ dependencies = [
  "consensus-enclave-measurement 1.0.0",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "digestible 0.1.0",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpc-util 1.0.0",
  "grpcio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2854,7 +2878,7 @@ dependencies = [
  "consensus-enclave-api 0.1.0",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519 1.0.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "keys 0.1.0",
  "ledger-db 0.1.0",
@@ -2902,7 +2926,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3189,7 +3213,7 @@ name = "protoc-grpcio"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-compiler 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen 2.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3894,7 +3918,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "httpdate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "im 14.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3916,7 +3940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "debugid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4037,7 +4061,7 @@ dependencies = [
 name = "sgx_css"
 version = "0.1.0"
 dependencies = [
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4863,7 +4887,7 @@ dependencies = [
  "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digestible 0.1.0",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4895,7 +4919,7 @@ dependencies = [
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "common 0.1.0",
  "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "keys 0.1.0",
  "mcserial 0.1.0",
@@ -5389,6 +5413,7 @@ dependencies = [
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bigint 4.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ebecac13b3c745150d7b6c3ea7572d372f09d627c2077e893bf26c5c7f70d282"
 "checksum binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
+"checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 "checksum bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ebd71393f1ec0509b553aa012b9b58e81dadbdff7130bd3b8cba576e69b32f75"
 "checksum bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
@@ -5471,8 +5496,8 @@ dependencies = [
 "checksum encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
-"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
-"checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
+"checksum failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
+"checksum failure_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-core-types"
-version = "2.9.0"
+version = "0.1.3"
 dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2285,14 +2285,14 @@ dependencies = [
  "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-encodings 0.1.0",
- "mc-sgx-core-types-sys 2.9.0",
+ "mc-sgx-core-types-sys 0.1.3",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-sgx-core-types-sys"
-version = "2.9.0"
+version = "0.1.3"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2301,23 +2301,23 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-epid-sys"
-version = "2.9.0"
+version = "0.1.3"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-sgx-core-types-sys 2.9.0",
- "mc-sgx-epid-types-sys 2.9.0",
+ "mc-sgx-core-types-sys 0.1.3",
+ "mc-sgx-epid-types-sys 0.1.3",
  "mcbuild-sgx-utils 0.2.0",
  "mcbuild-utils 0.2.0",
 ]
 
 [[package]]
 name = "mc-sgx-epid-types-sys"
-version = "2.9.0"
+version = "0.1.3"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-sgx-core-types-sys 2.9.0",
+ "mc-sgx-core-types-sys 0.1.3",
  "mcbuild-utils 0.2.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "mobilecoind/api",
     "peers",
     "peers/test-utils",
+    "sgx/core-types",
     "sgx/core-types-sys",
     "sgx/epid-sys",
     "sgx/epid-types-sys",

--- a/attest/core/src/quote.rs
+++ b/attest/core/src/quote.rs
@@ -420,7 +420,7 @@ impl ToBase64 for Quote {
 }
 
 impl ToX64 for Quote {
-    fn to_x64_bytes(&self, dest: &mut [u8]) -> Result<usize, usize> {
+    fn to_x64(&self, dest: &mut [u8]) -> Result<usize, usize> {
         let required_len = self.intel_size();
         if dest.len() < required_len {
             Err(required_len)

--- a/attest/core/src/traits.rs
+++ b/attest/core/src/traits.rs
@@ -190,7 +190,7 @@ macro_rules! impl_sgx_wrapper_reqs {
         }
 
         impl $crate::traits::ToX64 for $wrapper {
-            fn to_x64_bytes(&self, dest: &mut [u8]) -> core::result::Result<usize, usize> {
+            fn to_x64(&self, dest: &mut [u8]) -> core::result::Result<usize, usize> {
                 use $crate::traits::{IntelLayout, SgxWrapperType};
 
                 let len = self.intel_size();

--- a/hooks/install_git_settings.sh
+++ b/hooks/install_git_settings.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+ROOT=`git rev-parse --show-toplevel`
+
+echo -n "Installing pre-commit hook..."
+
+# symlink the precommit hook into .git/hooks
+# see https://stackoverflow.com/questions/4592838/symbolic-link-to-a-hook-in-git
+ln -s -f "$ROOT/hooks/pre-commit" "$ROOT/.git/hooks/pre-commit"
+echo " Done."
+
+echo -n "Installing 'theirs' merge driver..."
+# define a 'theirs' merge driver which uses unix false utility to always choose
+# theirs. In .gitattributes we apply this to Cargo.lock files
+git config --local merge.theirs.driver false
+echo " Done."

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Inspired by https://github.com/google/tarpc/blob/master/hooks/pre-commit
+#
+# Pre-commit hook for the mobilenode repository. To use this hook, copy it or
+# add a symlink to it in .git/hooks in your repository root
+#
+# This precommit checks the following:
+# 1. All filenames are ascii
+# 2. There is no bad whitespace
+# 3. rustfmt is installed
+# 4. rustfmt is a noop on files that are in the index
+#
+# Options:
+#
+# - SKIP_RUSTFMT, default = 0
+#
+#   Set this to 1 to skip running rustfmt
+#
+# Note that these options are most useful for testing the hooks themselves. Use git commit
+# --no-verify to skip the pre-commit hook altogether.
+
+BOLD='\033[33;1m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+PREFIX="${GREEN}[PRECOMMIT]${NC}"
+FAILURE="${RED}FAILED${NC}"
+WARNING="${RED}[WARNING]${NC}"
+SKIPPED="${YELLOW}SKIPPED${NC}"
+SUCCESS="${GREEN}ok${NC}"
+
+GITROOT=$(git rev-parse --show-toplevel)
+pushd "$GITROOT" >/dev/null 2>&1
+
+if git rev-parse --verify HEAD &>/dev/null
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+FAILED=0
+
+printf "${PREFIX} Checking that all filenames are ascii ... "
+# Note that the use of brackets around a tr range is ok here, (it's
+# even required, for portability to Solaris 10's /usr/bin/tr), since
+# the square bracket bytes happen to fall in the designated range.
+if test $(git diff --cached --name-only --diff-filter=A -z $against | LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	FAILED=1
+	printf "${FAILURE}\n"
+else
+	printf "${SUCCESS}\n"
+fi
+
+printf "${PREFIX} Checking for bad whitespace ... "
+WHITESPACE_OUTPUT=$(git diff-index --color=always --check --cached $against -- 2>&1 | grep -v '^[^a-zA-Z]' | egrep -v '^sgx/sgx_(tcrypto|urts|types)' | grep -v '.*.patch' )
+if [[ -n "$WHITESPACE_OUTPUT" ]]; then
+	FAILED=1
+	printf "${FAILURE}\n"
+
+	echo -e "$WHITESPACE_OUTPUT"
+else
+	printf "${SUCCESS}\n"
+fi
+
+printf "${PREFIX} Checking for rustfmt ... "
+cargo fmt --version
+if [ $? == 0 ]; then
+	printf "${SUCCESS}\n"
+else
+	printf "${FAILURE}\n"
+	popd >/dev/null 2>&1
+	exit 1
+fi
+
+CARGOFMT="cargo fmt -- --unstable-features --skip-children"
+
+# Just check that running rustfmt doesn't do anything to the file. I do this instead of
+# modifying the file because I don't want to mess with the developer's index, which may
+# not only contain discrete files.
+printf "${PREFIX} Checking formatting ... "
+FMTRESULT=0
+diff=""
+for file in $(git diff --name-only --cached --diff-filter=d | egrep -v '^sgx/sgx_(tcrypto|urts|types)');
+do
+	if [[ ${file: -3} == ".rs" ]]; then
+		newdiff=$($CARGOFMT --check $file | grep '^Diff in ' | awk -F' ' '{print $3;}')
+		if [[ -n "$newdiff" ]]; then
+			for filename in $newdiff; do
+				diff="$filename\n$diff"
+			done
+		fi
+	fi
+done
+
+if [[ "${SKIP_RUSTFMT}" == 1 ]]; then
+	printf "${SKIPPED}\n"$?
+elif [[ -n "$diff" ]]; then
+	FAILED=1
+	printf "${FAILURE}\n"
+	echo -e "\033[33;1mFiles Needing Rustfmt:\033[0m"
+	echo -e "$diff" | sort -u
+	if [[ -n "$(which tty)" ]] && [[ -n "$(tty)" ]]; then
+		exec < /dev/tty
+		echo "Do you want to fix all these files automatically? (y/N) "
+		read YESNO
+		if [[ -n "$YESNO" ]] && [[ "$(echo "${YESNO:0:1}" | tr '[[:lower:]]' '[[:upper:]]')" = "Y" ]]; then
+			echo -e "$diff" | while read file; do
+				$CARGOFMT $file
+			done
+			echo "You should attempt this commit again to pick up these changes."
+		else
+			echo -e "Run ${BOLD}$CARGOFMT -- <file>${NC} to format the files you have staged."
+		fi
+		exec <&-
+	else
+		echo -e "Run ${BOLD}$CARGOFMT -- <file>${NC} to format the files you have staged."
+	fi
+else
+	printf "${SUCCESS}\n"
+fi
+
+popd >/dev/null 2>&1
+exit ${FAILED}

--- a/sgx/core-types-sys/Cargo.toml
+++ b/sgx/core-types-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-core-types-sys"
-version = "2.9.0"
+version = "0.1.3"
 authors = ["MobileCoin"]
 description = "Core FFI types for Intel SGX SDK."
 readme = "README.md"

--- a/sgx/core-types-sys/Cargo.toml
+++ b/sgx/core-types-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mcsgx-core-types-sys"
+name = "mc-sgx-core-types-sys"
 version = "2.9.0"
 authors = ["MobileCoin"]
 description = "Core FFI types for Intel SGX SDK."

--- a/sgx/core-types-sys/README.md
+++ b/sgx/core-types-sys/README.md
@@ -1,1 +1,3 @@
-This crate provides no-std FFI types used by the Intel SGX attestation process: notably `sgx_status_t`, `sgx_report_t`, and `sgx_target_info_t`. These types are not intended to be used directly, but rather wrapped by the `mcsgx-core` crate, which will provide safe, rusty access to them and their contents.
+FFI structures used by the Intel SGX process.
+
+This no-std crate provides FFI types used by the Intel SGX attestation process: notably `sgx_status_t`, `sgx_report_t`, and `sgx_target_info_t` and their members. These types are not intended to be used directly, but rather wrapped by the `mc-sgx-core-types` crate, which will provide safe, rusty access to their contents.

--- a/sgx/core-types-sys/build.rs
+++ b/sgx/core-types-sys/build.rs
@@ -2,8 +2,43 @@
 
 //! Build script to generate bindings for the Intel SGX SDK core FFI types
 
-use bindgen::Builder;
+use bindgen::{
+    callbacks::{IntKind, ParseCallbacks},
+    Builder,
+};
 use mcbuild_utils::Environment;
+
+#[derive(Debug)]
+struct Callbacks;
+
+impl ParseCallbacks for Callbacks {
+    fn int_macro(&self, name: &str, _value: i64) -> Option<IntKind> {
+        if name.ends_with("_SIZE") || name.ends_with("_BYTES") {
+            Some(IntKind::Custom {
+                name: "usize",
+                is_signed: false,
+            })
+        } else if name.starts_with("SGX_KEYSELECT_") || name.starts_with("SGX_KEYPOLICY_") {
+            Some(IntKind::U16)
+        } else {
+            None
+        }
+    }
+
+    fn item_name(&self, name: &str) -> Option<String> {
+        if name == "_status_t" {
+            Some("sgx_status_t".to_owned())
+        } else if name.starts_with("_sgx_") {
+            Some(name[1..].to_owned())
+        } else if name.starts_with('_') {
+            let mut retval = "sgx".to_owned();
+            retval.push_str(name);
+            Some(retval)
+        } else {
+            None
+        }
+    }
+}
 
 fn main() {
     let env = Environment::default();
@@ -31,6 +66,8 @@ fn main() {
         .derive_partialord(true)
         .header(eid_header)
         .header(sgx_header)
+        .parse_callbacks(Box::new(Callbacks))
+        .prepend_enum_name(false)
         .use_core()
         .whitelist_recursively(false)
         .whitelist_var("SGX_.*")
@@ -45,26 +82,16 @@ fn main() {
         .whitelist_type("_sgx_report_data_t")
         .whitelist_type("_status_t")
         .whitelist_type("_target_info_t")
-        .whitelist_type("sgx_attributes_t")
         .whitelist_type("sgx_config_id_t")
         .whitelist_type("sgx_config_svn_t")
-        .whitelist_type("sgx_cpu_svn_t")
         .whitelist_type("sgx_enclave_id_t")
         .whitelist_type("sgx_isv_svn_t")
         .whitelist_type("sgx_isvext_prod_id_t")
         .whitelist_type("sgx_isvfamily_id_t")
         .whitelist_type("sgx_key_128bit_t")
-        .whitelist_type("sgx_key_id_t")
-        .whitelist_type("sgx_key_request_t")
         .whitelist_type("sgx_mac_t")
-        .whitelist_type("sgx_measurement_t")
-        .whitelist_type("sgx_misc_attribute_t")
         .whitelist_type("sgx_misc_select_t")
         .whitelist_type("sgx_prod_id_t")
-        .whitelist_type("sgx_target_info_t")
-        .whitelist_type("sgx_report_t")
-        .whitelist_type("sgx_report_body_t")
-        .whitelist_type("sgx_report_data_t")
         .whitelist_type("sgx_status_t")
         .generate()
         .expect("Unable to generate bindings")

--- a/sgx/core-types/Cargo.toml
+++ b/sgx/core-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-core-types"
-version = "2.9.0"
+version = "0.1.3"
 authors = ["James Cape <james@mobilecoin.com>"]
 description = "Core Rust types for Intel SGX SDK."
 readme = "README.md"
@@ -17,7 +17,7 @@ ias-dev = []
 
 [dependencies]
 mc-encodings = { path = "../../util/encodings" }
-mc-sgx-core-types-sys = { version = "=2.9.0", path = "../core-types-sys" }
+mc-sgx-core-types-sys = { path = "../core-types-sys" }
 
 binascii = "0.1.4"
 bitflags = "1.2.1"

--- a/sgx/core-types/Cargo.toml
+++ b/sgx/core-types/Cargo.toml
@@ -12,8 +12,6 @@ std = [
     "failure/std",
     "serde/std"
 ]
-sgx-sim = []
-ias-dev = []
 
 [dependencies]
 mc-encodings = { path = "../../util/encodings" }

--- a/sgx/core-types/Cargo.toml
+++ b/sgx/core-types/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "mc-sgx-core-types"
+version = "2.9.0"
+authors = ["James Cape <james@mobilecoin.com>"]
+description = "Core Rust types for Intel SGX SDK."
+readme = "README.md"
+edition = "2018"
+
+[features]
+default = ["std"]
+std = [
+    "failure/std",
+    "serde/std"
+]
+sgx-sim = []
+ias-dev = []
+
+[dependencies]
+mc-encodings = { path = "../../util/encodings" }
+mc-sgx-core-types-sys = { version = "=2.9.0", path = "../core-types-sys" }
+
+binascii = "0.1.4"
+bitflags = "1.2.1"
+failure = { version = "0.1.7", default-features = false, features = ["derive"] }
+hex_fmt = "0.3"
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+subtle = { version = "2.1", default-features = false }
+
+[dev-dependencies]
+bincode = "1.2"

--- a/sgx/core-types/README.md
+++ b/sgx/core-types/README.md
@@ -1,0 +1,3 @@
+Use the Intel SGX SDK with ideomatic rust.
+
+This crate provides rust versions for the core SGX FFI types.

--- a/sgx/core-types/src/_macros.rs
+++ b/sgx/core-types/src/_macros.rs
@@ -419,7 +419,7 @@ macro_rules! impl_ffi_wrapper {
 
         impl $crate::_macros::ConstantTimeEq for $wrapper {
             fn ct_eq(&self, other: &Self) -> subtle::Choice {
-                (&self.0).$fieldname[..].ct_eq(&(other.0).$fieldname[..])
+                (self.0).$fieldname[..].ct_eq(&(other.0).$fieldname[..])
             }
         }
 
@@ -485,19 +485,19 @@ macro_rules! impl_ffi_wrapper {
 
         impl core::hash::Hash for $wrapper {
             fn hash<H: core::hash::Hasher>(&self, hasher: &mut H) {
-                (&self.0).$fieldname[..].hash(hasher)
+                (self.0).$fieldname[..].hash(hasher)
             }
         }
 
         impl Ord for $wrapper {
             fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-                (&self.0).$fieldname[..].cmp(&(&other.0).$fieldname[..])
+                (self.0).$fieldname[..].cmp(&(other.0).$fieldname[..])
             }
         }
 
         impl PartialEq for $wrapper {
             fn eq(&self, other: &Self) -> bool {
-                (&self.0).$fieldname[..] == (&other.0).$fieldname[..]
+                (self.0).$fieldname[..] == (other.0).$fieldname[..]
             }
         }
 

--- a/sgx/core-types/src/_macros.rs
+++ b/sgx/core-types/src/_macros.rs
@@ -1,0 +1,547 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! Macros and re-exports to support a common interface across all FFI-wrapping SGX types.
+
+// Re-export macros our macros are using
+pub use alloc::format as _alloc_format;
+
+// Re-export types our macros are using
+pub use alloc::vec::Vec;
+pub use binascii::{b64decode, b64encode, bin2hex, hex2bin};
+pub use hex_fmt::HexFmt;
+pub use mc_encodings::{
+    base64_buffer_size, base64_size, Error as EncodingError, FromBase64, FromHex, FromX64,
+    IntelLayout, ToBase64, ToHex, ToX64,
+};
+pub use serde::{
+    de::{
+        Deserialize, DeserializeOwned, Deserializer, Error as DeserializeError, SeqAccess, Visitor,
+    },
+    ser::{Error as SerializeError, Serialize, Serializer},
+};
+pub use subtle::{Choice, ConstantTimeEq};
+
+use core::{
+    fmt::{Debug, Display},
+    hash::Hash,
+};
+
+/// A helper marker trait which SGX-wrapper newtypes should implement to ensure a consistent API.
+///
+/// Note that types which are not `repr(transparent)` newtypes should manually implement
+/// `AsRef<FFI>` and `AsMut<FFI>`.
+pub trait FfiWrapper<FFI>:
+    AsRef<FFI>
+    + AsMut<FFI>
+    + Clone
+    + Debug
+    + Default
+    + DeserializeOwned
+    + Display
+    + Eq
+    + From<FFI>
+    + FromX64
+    + Hash
+    + Into<FFI>
+    + Ord
+    + PartialEq
+    + PartialOrd
+    + Serialize
+    + ToX64
+    + for<'any> From<&'any FFI>
+{
+}
+
+/// A boilerplate macro which implements the FFI-type-related traits required by the
+/// FfiWrapper trait.
+#[macro_export]
+macro_rules! impl_ffi_wrapper_base {
+    ($($wrapper:ident, $inner:ty, $size:ident;)*) => {$(
+        impl AsMut<$inner> for $wrapper {
+            fn as_mut(&mut self) -> &mut $inner {
+                &mut self.0
+            }
+        }
+
+        impl AsRef<$inner> for $wrapper {
+            fn as_ref(&self) -> &$inner {
+                &self.0
+            }
+        }
+
+        impl Clone for $wrapper {
+            fn clone(&self) -> Self {
+                Self::from(&self.0)
+            }
+        }
+
+        impl<'de> $crate::_macros::Deserialize<'de> for $wrapper {
+            fn deserialize<D: $crate::_macros::Deserializer<'de>>(deserializer: D) -> core::result::Result<Self, D::Error> {
+                struct ByteVisitor;
+
+                impl<'de> $crate::_macros::Visitor<'de> for ByteVisitor {
+                    type Value = $wrapper;
+
+                    fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                        write!(f, "byte contents of {}", stringify!($wrapper))
+                    }
+
+                    fn visit_borrowed_bytes<E: $crate::_macros::DeserializeError>(
+                        self,
+                        value: &'de [u8],
+                    ) -> core::result::Result<Self::Value, E> {
+                        use $crate::_macros::FromX64;
+                        Self::Value::from_x64(value)
+                            .map_err(|convert_error| {
+                                E::custom(
+                                    $crate::_macros::_alloc_format!(
+                                        "Could not parse {}/{} bytes: {}",
+                                        value.len(),
+                                        <Self::Value as $crate::_macros::IntelLayout>::X86_64_CSIZE,
+                                        convert_error
+                                    )
+                                )
+                            })
+                    }
+
+                    fn visit_bytes<E: $crate::_macros::DeserializeError>(
+                        self,
+                        value: &[u8],
+                    ) -> core::result::Result<Self::Value, E> {
+                        use $crate::_macros::FromX64;
+
+                        Self::Value::from_x64(value)
+                            .map_err(|convert_error| {
+                                E::custom(
+                                    $crate::_macros::_alloc_format!(
+                                        "Could not parse {}/{} bytes: {}",
+                                        value.len(),
+                                        <Self::Value as $crate::_macros::IntelLayout>::X86_64_CSIZE,
+                                        convert_error
+                                    )
+                                )
+                            })
+                    }
+
+                    fn visit_seq<A: $crate::_macros::SeqAccess<'de>>(
+                        self,
+                        mut seq: A,
+                    ) -> core::result::Result<Self::Value, A::Error>
+                    where
+                        A::Error: $crate::_macros::DeserializeError
+                    {
+                        use $crate::_macros::FromX64;
+
+                        let mut bytes =
+                            $crate::_macros::Vec::<u8>::with_capacity(seq.size_hint().unwrap_or(1024usize));
+                        loop {
+                            match seq.next_element()? {
+                                Some(byte) => bytes.push(byte),
+                                None => break,
+                            }
+                        }
+
+                        let bytelen = bytes.len();
+                        Self::Value::from_x64(bytes.as_mut_slice())
+                            .map_err(|convert_error| {
+                                use $crate::_macros::DeserializeError;
+
+                                A::Error::custom(
+                                    $crate::_macros::_alloc_format!(
+                                        "Could not parse {}/{} bytes: {}",
+                                        bytelen,
+                                        <Self::Value as $crate::_macros::IntelLayout>::X86_64_CSIZE,
+                                        convert_error
+                                    )
+                                )
+                            })
+                    }
+                }
+
+                struct NewtypeVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for NewtypeVisitor {
+                    type Value = $wrapper;
+
+                    fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                        write!(f, "struct {}", stringify!($wrapper))
+                    }
+
+                    fn visit_newtype_struct<D: $crate::_macros::Deserializer<'de>>(
+                        self,
+                        deserializer: D,
+                    ) -> core::result::Result<Self::Value, D::Error> {
+                        deserializer.deserialize_bytes(ByteVisitor)
+                    }
+                }
+
+                deserializer.deserialize_newtype_struct(stringify!($wrapper), NewtypeVisitor)
+            }
+        }
+
+        impl Eq for $wrapper {}
+
+        impl From<$inner> for $wrapper {
+            fn from(src: $inner) -> Self {
+                Self(src)
+            }
+        }
+
+        impl $crate::_macros::IntelLayout for $wrapper {
+            const X86_64_CSIZE: usize = $size as usize;
+        }
+
+        impl Into<$inner> for $wrapper {
+            fn into(self) -> $inner {
+                self.0
+            }
+        }
+
+        impl PartialOrd for $wrapper {
+            fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+    )*}
+}
+
+/// A boilerplate macro which implements Serde's Serialize trait for a type which implements the
+/// ToX64 trait already.
+#[macro_export]
+macro_rules! impl_serialize_to_x64 {
+    ($($wrapper:ident, $size:ident;)*) => {$(
+        impl $crate::_macros::Serialize for $wrapper {
+            fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+            where
+                S: $crate::_macros::Serializer
+            {
+                use $crate::_macros::ToX64;
+
+                let mut bytes = [0u8; $size as usize];
+                self.to_x64(&mut bytes[..])
+                    .map_err(|_e| {
+                        use $crate::_macros::SerializeError;
+                        S::Error::custom("Invalid size given to impl_serialize_for_x64 macro")
+                    })?;
+                serializer.serialize_newtype_struct(stringify!($wrapper), &bytes[..])
+            }
+        }
+    )*}
+}
+
+/// A boilerplate macro which implements the FfiWrapper type and its dependencies for a newtype
+/// structure which wraps an FFI type.
+#[macro_export]
+macro_rules! impl_ffi_wrapper {
+    ($($wrapper:ident, $inner:ty, $size:ident;)*) => {$(
+        $crate::impl_ffi_wrapper_base! {
+            $wrapper, $inner, $size;
+        }
+
+        impl AsRef<[u8]> for $wrapper {
+            fn as_ref(&self) -> &[u8] {
+                &self.0[..]
+            }
+        }
+
+        impl AsMut<[u8]> for $wrapper {
+            fn as_mut(&mut self) -> &mut [u8] {
+                &mut self.0[..]
+            }
+        }
+
+        impl $crate::_macros::ConstantTimeEq for $wrapper {
+            fn ct_eq(&self, other: &Self) -> $crate::_macros::Choice {
+                self.0[..].ct_eq(&other.0[..])
+            }
+        }
+
+        impl core::fmt::Debug for $wrapper {
+            fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(formatter, "{}: {}", stringify!($wrapper), $crate::_macros::HexFmt(&self))
+            }
+        }
+
+        impl core::fmt::Display for $wrapper {
+            fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(formatter, "{}", $crate::_macros::HexFmt(&self))
+            }
+        }
+
+        impl From<&$inner> for $wrapper {
+            fn from(src: &$inner) -> Self {
+                let mut new_inner = [0u8; $size];
+                new_inner.copy_from_slice(&src[..]);
+                Self::from(new_inner)
+            }
+        }
+
+        impl $crate::_macros::FromBase64 for $wrapper {
+            type Error = $crate::_macros::EncodingError;
+
+            fn from_base64(s: &str) -> core::result::Result<Self, $crate::_macros::EncodingError> {
+                if s.len() % 4 != 0 {
+                    return Err($crate::_macros::EncodingError::InvalidInputLength);
+                }
+
+                // Don't try to decode any base64 string that's larger than our size limits or smaller
+                // than our minimum size
+                if s.len() != $crate::_macros::base64_size($size) {
+                    return Err($crate::_macros::EncodingError::InvalidInputLength);
+                }
+
+                // Create an output buffer of at least MINSIZE bytes
+                let mut retval = Self::default();
+                $crate::_macros::b64decode(s.as_bytes(), &mut retval.0[..])?;
+                Ok(retval)
+            }
+        }
+
+        impl $crate::_macros::FromHex for $wrapper {
+            type Error = $crate::_macros::EncodingError;
+
+            fn from_hex(s: &str) -> core::result::Result<Self, $crate::_macros::EncodingError> {
+                if s.len() % 2 != 0 {
+                    return Err($crate::_macros::EncodingError::InvalidInputLength);
+                }
+
+                if s.len() / 2 != $size {
+                    return Err($crate::_macros::EncodingError::InvalidInputLength);
+                }
+
+                let mut retval = Self::default();
+                $crate::_macros::hex2bin(s.as_bytes(), &mut retval.0[..])?;
+                Ok(retval)
+            }
+        }
+
+        impl<'src> $crate::_macros::FromX64 for $wrapper {
+            type Error = $crate::_macros::EncodingError;
+
+            fn from_x64(src: &[u8]) -> core::result::Result<Self, $crate::_macros::EncodingError> {
+                if src.len() < $size {
+                    return Err($crate::_macros::EncodingError::InvalidInputLength);
+                }
+                let mut retval = Self::default();
+                retval.0[..].copy_from_slice(&src[..$size]);
+                Ok(retval)
+            }
+        }
+
+        impl core::hash::Hash for $wrapper {
+            fn hash<H: core::hash::Hasher>(&self, hasher: &mut H) {
+                (&self.0[..]).hash(hasher)
+            }
+        }
+
+        impl Ord for $wrapper {
+            fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+                (&self.0[..]).cmp(&other.0[..])
+            }
+        }
+
+        impl PartialEq for $wrapper {
+            fn eq(&self, other: &Self) -> bool {
+                &self.0[..] == &other.0[..]
+            }
+        }
+
+        impl $crate::_macros::Serialize for $wrapper {
+            fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+            where
+                S: $crate::_macros::Serializer
+            {
+                serializer.serialize_newtype_struct(stringify!($wrapper), &self.0[..])
+            }
+        }
+
+        impl $crate::_macros::ToBase64 for $wrapper {
+            fn to_base64(&self, dest: &mut [u8]) -> core::result::Result<usize, usize> {
+                let required_buffer_len = $crate::_macros::base64_buffer_size($size);
+                if dest.len() < required_buffer_len {
+                    Err(required_buffer_len)
+                } else {
+                    match $crate::_macros::b64encode(&self.0[..], dest) {
+                        Ok(buffer) => Ok(buffer.len()),
+                        Err(_convert) => Err(required_buffer_len)
+                    }
+                }
+            }
+        }
+
+        impl $crate::_macros::ToHex for $wrapper {
+            fn to_hex(&self, dest: &mut [u8]) -> core::result::Result<usize, usize> {
+                match $crate::_macros::bin2hex(&self.0[..], dest) {
+                    Ok(buffer) => Ok(buffer.len()),
+                    Err(_e) => Err($size * 2),
+                }
+            }
+        }
+
+        impl $crate::_macros::ToX64 for $wrapper {
+            fn to_x64(&self, dest: &mut [u8]) -> core::result::Result<usize, usize> {
+                if dest.len() < $size {
+                    return Err($size);
+                }
+                dest[..$size].copy_from_slice(&self.0[..$size]);
+                Ok($size)
+            }
+        }
+    )*};
+    ($($wrapper:ident, $inner:ty, $size:ident, $fieldname:ident;)*) => {$(
+        $crate::impl_ffi_wrapper_base! {
+            $wrapper, $inner, $size;
+        }
+
+        impl AsRef<[u8]> for $wrapper {
+            fn as_ref(&self) -> &[u8] {
+                &(self.0).$fieldname[..]
+            }
+        }
+
+        impl AsMut<[u8]> for $wrapper {
+            fn as_mut(&mut self) -> &mut [u8] {
+                &mut (self.0).$fieldname[..]
+            }
+        }
+
+        impl core::fmt::Debug for $wrapper {
+            fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(formatter, "{}: {}", stringify!($wrapper), $crate::_macros::HexFmt(&self))
+            }
+        }
+
+        impl core::fmt::Display for $wrapper {
+            fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(formatter, "{}", $crate::_macros::HexFmt(&self))
+            }
+        }
+
+        impl $crate::_macros::ConstantTimeEq for $wrapper {
+            fn ct_eq(&self, other: &Self) -> subtle::Choice {
+                (&self.0).$fieldname[..].ct_eq(&(other.0).$fieldname[..])
+            }
+        }
+
+        impl From<&$inner> for $wrapper {
+            fn from(src: &$inner) -> Self {
+                let mut new_inner = <$inner>::default();
+                new_inner.$fieldname.copy_from_slice(&src.$fieldname[..]);
+                Self::from(new_inner)
+            }
+        }
+
+        impl $crate::_macros::FromBase64 for $wrapper {
+            type Error = $crate::_macros::EncodingError;
+
+            fn from_base64(s: &str) -> core::result::Result<Self, $crate::_macros::EncodingError> {
+                if s.len() % 4 != 0 {
+                    return Err($crate::_macros::EncodingError::InvalidInputLength);
+                }
+
+                // Don't try to decode any base64 string that's smaller than our minimum size
+                if s.len() < $crate::_macros::base64_size($size) {
+                    return Err($crate::_macros::EncodingError::InvalidInputLength);
+                }
+
+                // Create an output buffer of at least MINSIZE bytes
+                let mut retval = Self::default();
+                $crate::_macros::b64decode(s.as_bytes(), &mut (retval.0).$fieldname[..])?;
+                Ok(retval)
+            }
+        }
+
+        impl $crate::_macros::FromHex for $wrapper {
+            type Error = $crate::_macros::EncodingError;
+
+            fn from_hex(s: &str) -> core::result::Result<Self, $crate::_macros::EncodingError> {
+                if s.len() % 2 != 0 {
+                    return Err($crate::_macros::EncodingError::InvalidInputLength);
+                }
+
+                if s.len() / 2 != $size {
+                    return Err($crate::_macros::EncodingError::InvalidInputLength);
+                }
+
+                let mut retval = Self::default();
+                $crate::_macros::hex2bin(s.as_bytes(), &mut (retval.0).$fieldname[..])?;
+                Ok(retval)
+            }
+        }
+
+        impl $crate::_macros::FromX64 for $wrapper {
+            type Error = $crate::_macros::EncodingError;
+
+            fn from_x64(src: &[u8]) -> core::result::Result<Self, Self::Error> {
+                if src.len() < $size {
+                    return Err($crate::_macros::EncodingError::InvalidInputLength);
+                }
+
+                let mut retval = $wrapper::default();
+                &(retval.0).$fieldname[..].copy_from_slice(&src[..$size]);
+                Ok(retval)
+            }
+        }
+
+        impl core::hash::Hash for $wrapper {
+            fn hash<H: core::hash::Hasher>(&self, hasher: &mut H) {
+                (&self.0).$fieldname[..].hash(hasher)
+            }
+        }
+
+        impl Ord for $wrapper {
+            fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+                (&self.0).$fieldname[..].cmp(&(&other.0).$fieldname[..])
+            }
+        }
+
+        impl PartialEq for $wrapper {
+            fn eq(&self, other: &Self) -> bool {
+                (&self.0).$fieldname[..] == (&other.0).$fieldname[..]
+            }
+        }
+
+        impl $crate::_macros::Serialize for $wrapper {
+            fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+            where
+                S: $crate::_macros::Serializer
+            {
+                serializer.serialize_newtype_struct(stringify!($wrapper), &(self.0).$fieldname[..])
+            }
+        }
+
+        impl $crate::_macros::ToBase64 for $wrapper {
+            fn to_base64(&self, dest: &mut [u8]) -> core::result::Result<usize, usize> {
+                let required_buffer_len = $crate::_macros::base64_buffer_size($size);
+                if dest.len() < required_buffer_len {
+                    Err(required_buffer_len)
+                } else {
+                    match $crate::_macros::b64encode(&(self.0).$fieldname[..], dest) {
+                        Ok(buffer) => Ok(buffer.len()),
+                        Err(_convert) => Err(required_buffer_len)
+                    }
+                }
+            }
+        }
+
+        impl $crate::_macros::ToHex for $wrapper {
+            fn to_hex(&self, dest: &mut [u8]) -> core::result::Result<usize, usize> {
+                match $crate::_macros::bin2hex(&(self.0).$fieldname[..], dest) {
+                    Ok(buffer) => Ok(buffer.len()),
+                    Err(_e) => Err($size * 2),
+                }
+            }
+        }
+
+        impl $crate::_macros::ToX64 for $wrapper {
+            fn to_x64(&self, dest: &mut [u8]) -> core::result::Result<usize, usize> {
+                if dest.len() < $size {
+                    return Err($size);
+                }
+
+                &dest[..$size].copy_from_slice(&(self.0).$fieldname[..]);
+                Ok($size)
+            }
+        }
+    )*}
+}

--- a/sgx/core-types/src/attributes.rs
+++ b/sgx/core-types/src/attributes.rs
@@ -1,0 +1,246 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! The wrapper type for an sgx_attributes_t
+
+use crate::{_macros::FfiWrapper, impl_ffi_wrapper_base, impl_serialize_to_x64};
+use bitflags::bitflags;
+use core::{
+    cmp::Ordering,
+    convert::TryInto,
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    hash::{Hash, Hasher},
+};
+use mc_encodings::{Error as EncodingError, FromX64, ToX64, INTEL_U64_SIZE};
+use mc_sgx_core_types_sys::sgx_attributes_t;
+
+bitflags! {
+    /// A set of bitflags which can be set on an attributes structure.
+    pub struct AttributeFlags: u64 {
+        const INITIALIZED = 0x0000_0000_0000_0001;
+        const DEBUG = 0x0000_0000_0000_0002;
+        const MODE_64_BIT = 0x0000_0000_0000_0004;
+        const PROVISION_KEY = 0x0000_0000_0000_0010;
+        const ENCLAVE_INIT_TOKEN = 0x0000_0000_0000_0020;
+        const KSS = 0x0000_0000_0000_0080;
+    }
+}
+
+impl Display for AttributeFlags {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        let mut previous = if self.contains(AttributeFlags::INITIALIZED) {
+            write!(f, "Initialized")?;
+            true
+        } else {
+            false
+        };
+
+        if self.contains(AttributeFlags::DEBUG) {
+            if previous {
+                write!(f, ", ")?;
+            }
+            write!(f, "Debug")?;
+            previous = true;
+        }
+
+        if self.contains(AttributeFlags::MODE_64_BIT) {
+            if previous {
+                write!(f, ", ")?;
+            }
+            write!(f, "64-bit")?;
+            previous = true;
+        } else {
+            if previous {
+                write!(f, ", ")?;
+            }
+            write!(f, "32-bit")?;
+            previous = true;
+        }
+
+        if self.contains(AttributeFlags::PROVISION_KEY) {
+            if previous {
+                write!(f, ", ")?;
+            }
+            write!(f, "Provision key")?;
+            previous = true;
+        }
+
+        if self.contains(AttributeFlags::ENCLAVE_INIT_TOKEN) {
+            if previous {
+                write!(f, ", ")?;
+            }
+            write!(f, "Enclave initialization token")?;
+            previous = true;
+        }
+
+        if self.contains(AttributeFlags::KSS) {
+            if previous {
+                write!(f, ", ")?;
+            }
+            write!(f, "Extended Product ID")?;
+        }
+
+        Ok(())
+    }
+}
+
+bitflags! {
+    /// The flags which can be set on an X-Feature Request Mask.
+    pub struct AttributeXfeatures: u64 {
+        const LEGACY = 0x0000_0000_0000_0003;
+        const AVX = 0x0000_0000_0000_0006;
+    }
+}
+
+impl Display for AttributeXfeatures {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        let previous = if self.contains(AttributeXfeatures::LEGACY) {
+            write!(f, "Legacy AVX")?;
+            true
+        } else {
+            false
+        };
+
+        if self.contains(AttributeXfeatures::AVX) {
+            if previous {
+                write!(f, ", ")?;
+            }
+            write!(f, "AVX")?;
+        }
+
+        Ok(())
+    }
+}
+
+const FLAGS_START: usize = 0;
+const FLAGS_END: usize = FLAGS_START + INTEL_U64_SIZE;
+const XFRM_START: usize = FLAGS_END;
+const XFRM_END: usize = XFRM_START + INTEL_U64_SIZE;
+
+/// The size of the x64 representation of [Attributes], in bytes.
+pub const ATTRIBUTES_SIZE: usize = XFRM_END;
+
+/// A type indicating the attribute flags used by an enclave.
+#[derive(Default)]
+#[repr(transparent)]
+pub struct Attributes(sgx_attributes_t);
+
+impl Attributes {
+    /// Retrieve the enclave flags.
+    pub fn flags(&self) -> AttributeFlags {
+        AttributeFlags::from_bits(self.0.flags).unwrap()
+    }
+
+    /// Retrieve the enclave X-Features Request Mask.
+    pub fn xfrm(&self) -> AttributeXfeatures {
+        AttributeXfeatures::from_bits(self.0.xfrm).unwrap()
+    }
+}
+
+impl_ffi_wrapper_base! {
+    Attributes, sgx_attributes_t, ATTRIBUTES_SIZE;
+}
+
+impl_serialize_to_x64! {
+    Attributes, ATTRIBUTES_SIZE;
+}
+
+impl Debug for Attributes {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(
+            f,
+            "Attributes: {{ flags: 0x{:08x}, xfrm: 0x{:08x} }}",
+            self.0.flags, self.0.xfrm
+        )
+    }
+}
+
+impl Display for Attributes {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{} | {}", self.flags(), self.xfrm())
+    }
+}
+
+impl From<&sgx_attributes_t> for Attributes {
+    fn from(src: &sgx_attributes_t) -> Attributes {
+        Self(sgx_attributes_t {
+            flags: src.flags,
+            xfrm: src.xfrm,
+        })
+    }
+}
+
+impl FromX64 for Attributes {
+    type Error = EncodingError;
+
+    fn from_x64(src: &[u8]) -> Result<Self, EncodingError> {
+        if src.len() < ATTRIBUTES_SIZE {
+            return Err(EncodingError::InvalidInputLength);
+        }
+
+        let flags = u64::from_le_bytes((&src[FLAGS_START..FLAGS_END]).try_into().unwrap());
+        AttributeFlags::from_bits(flags).ok_or(EncodingError::InvalidInput)?;
+
+        let xfrm = u64::from_le_bytes((&src[XFRM_START..XFRM_END]).try_into().unwrap());
+        AttributeXfeatures::from_bits(xfrm).ok_or(EncodingError::InvalidInput)?;
+
+        Ok(Self(sgx_attributes_t { flags, xfrm }))
+    }
+}
+
+impl Hash for Attributes {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        "Attributes".hash(hasher);
+        self.0.flags.hash(hasher);
+        self.0.xfrm.hash(hasher);
+    }
+}
+
+impl Ord for Attributes {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.0.flags.cmp(&other.0.flags) {
+            Ordering::Equal => self.0.xfrm.cmp(&other.0.xfrm),
+            other => other,
+        }
+    }
+}
+
+impl PartialEq for Attributes {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.flags == other.0.flags && self.0.xfrm == other.0.xfrm
+    }
+}
+
+impl ToX64 for Attributes {
+    fn to_x64(&self, dest: &mut [u8]) -> Result<usize, usize> {
+        if dest.len() < ATTRIBUTES_SIZE {
+            return Err(ATTRIBUTES_SIZE);
+        }
+
+        dest[FLAGS_START..FLAGS_END].copy_from_slice(&self.0.flags.to_le_bytes());
+        dest[XFRM_START..XFRM_END].copy_from_slice(&self.0.xfrm.to_le_bytes());
+        Ok(ATTRIBUTES_SIZE)
+    }
+}
+
+impl FfiWrapper<sgx_attributes_t> for Attributes {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bincode::{deserialize, serialize};
+
+    #[test]
+    fn serde() {
+        let src = sgx_attributes_t {
+            flags: 0x0102_0304_0506_0708,
+            xfrm: 0x0807_0605_0403_0201,
+        };
+
+        let attrs = Attributes::from(&src);
+        let bytes = serialize(&attrs).expect("Could not serialize attributes");
+        let attrs2: Attributes = deserialize(&bytes).expect("Could not deserialize attributes");
+        assert_eq!(attrs, attrs2);
+        assert_eq!(0x0102_0304_0506_0708, attrs2.flags().bits);
+        assert_eq!(0x0807_0605_0403_0201, attrs2.xfrm().bits);
+    }
+}

--- a/sgx/core-types/src/config_id.rs
+++ b/sgx/core-types/src/config_id.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! Enclave CONFIGID.
+
+use crate::impl_ffi_wrapper;
+use mc_sgx_core_types_sys::sgx_config_id_t;
+
+/// The size of the x64 representation of[ConfigId], in bytes.
+pub use mc_sgx_core_types_sys::SGX_CONFIGID_SIZE as CONFIG_ID_SIZE;
+
+/// The SGX configuration ID data type.
+///
+/// A rust-friendly alternative to sgx_config_id_t, which contains the enclave CONFIGID, which is
+/// used "to derive some keys" according to the SGX Developer Reference.
+#[repr(transparent)]
+pub struct ConfigId(sgx_config_id_t);
+
+impl_ffi_wrapper! {
+    ConfigId, sgx_config_id_t, CONFIG_ID_SIZE;
+}
+
+impl Default for ConfigId {
+    fn default() -> Self {
+        Self([0u8; CONFIG_ID_SIZE])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bincode::{deserialize, serialize};
+
+    #[test]
+    fn test_serde() {
+        let src = [
+            0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+            46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+        ];
+
+        let cid: ConfigId = (&src).into();
+        let cidser = serialize(&cid).expect("Could not serialize ConfigId");
+        let cid2: ConfigId = deserialize(&cidser).expect("Could not deserialize ConfigId");
+        assert_eq!(cid, cid2);
+        let dest: sgx_config_id_t = cid2.into();
+        assert_eq!(&src[..], &dest[..]);
+    }
+}

--- a/sgx/core-types/src/cpu_svn.rs
+++ b/sgx/core-types/src/cpu_svn.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! This is the FFI wrapper type for sgx_cpu_svn_t
+
+use crate::impl_ffi_wrapper;
+use mc_sgx_core_types_sys::sgx_cpu_svn_t;
+
+/// The size of the x64 representation of [CpuSecurityVersion], in bytes.
+pub use mc_sgx_core_types_sys::SGX_CPUSVN_SIZE as CPU_SECURITY_VERSION_SIZE;
+
+/// A CPU security version.
+///
+/// This value is used in key SGX SDK key derivation.
+#[derive(Default)]
+#[repr(transparent)]
+pub struct CpuSecurityVersion(sgx_cpu_svn_t);
+
+impl_ffi_wrapper! {
+    CpuSecurityVersion, sgx_cpu_svn_t, CPU_SECURITY_VERSION_SIZE, svn;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bincode::{deserialize, serialize};
+
+    #[test]
+    fn test_serde() {
+        let src = sgx_cpu_svn_t {
+            svn: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+        };
+
+        let svn: CpuSecurityVersion = src.into();
+        let serialized = serialize(&svn).expect("Could not serialize cpu_svn");
+        let svn2: CpuSecurityVersion =
+            deserialize(&serialized).expect("Could not deserialize cpu_svn");
+        assert_eq!(svn, svn2);
+    }
+}

--- a/sgx/core-types/src/error.rs
+++ b/sgx/core-types/src/error.rs
@@ -1,0 +1,419 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! SGX Error types
+
+use core::{convert::TryFrom, result::Result as StdResult};
+use failure::Fail;
+use mc_sgx_core_types_sys::{
+    sgx_status_t, SGX_ERROR_AE_INVALID_EPIDBLOB, SGX_ERROR_AE_SESSION_INVALID,
+    SGX_ERROR_ATT_KEY_CERTIFICATION_FAILURE, SGX_ERROR_ATT_KEY_UNINITIALIZED, SGX_ERROR_BUSY,
+    SGX_ERROR_DEVICE_BUSY, SGX_ERROR_ECALL_NOT_ALLOWED, SGX_ERROR_ENCLAVE_CRASHED,
+    SGX_ERROR_ENCLAVE_FILE_ACCESS, SGX_ERROR_ENCLAVE_LOST, SGX_ERROR_EPID_MEMBER_REVOKED,
+    SGX_ERROR_FEATURE_NOT_SUPPORTED, SGX_ERROR_FILE_BAD_STATUS,
+    SGX_ERROR_FILE_CANT_OPEN_RECOVERY_FILE, SGX_ERROR_FILE_CANT_WRITE_RECOVERY_FILE,
+    SGX_ERROR_FILE_CLOSE_FAILED, SGX_ERROR_FILE_FLUSH_FAILED, SGX_ERROR_FILE_NAME_MISMATCH,
+    SGX_ERROR_FILE_NOT_SGX_FILE, SGX_ERROR_FILE_NO_KEY_ID, SGX_ERROR_FILE_RECOVERY_NEEDED,
+    SGX_ERROR_INVALID_ATTRIBUTE, SGX_ERROR_INVALID_ATT_KEY_CERT_DATA, SGX_ERROR_INVALID_CPUSVN,
+    SGX_ERROR_INVALID_ENCLAVE, SGX_ERROR_INVALID_ENCLAVE_ID, SGX_ERROR_INVALID_FUNCTION,
+    SGX_ERROR_INVALID_ISVSVN, SGX_ERROR_INVALID_KEYNAME, SGX_ERROR_INVALID_LAUNCH_TOKEN,
+    SGX_ERROR_INVALID_METADATA, SGX_ERROR_INVALID_MISC, SGX_ERROR_INVALID_PARAMETER,
+    SGX_ERROR_INVALID_SIGNATURE, SGX_ERROR_INVALID_STATE, SGX_ERROR_INVALID_VERSION,
+    SGX_ERROR_KDF_MISMATCH, SGX_ERROR_MAC_MISMATCH, SGX_ERROR_MC_NOT_FOUND,
+    SGX_ERROR_MC_NO_ACCESS_RIGHT, SGX_ERROR_MC_OVER_QUOTA, SGX_ERROR_MC_USED_UP,
+    SGX_ERROR_MEMORY_MAP_CONFLICT, SGX_ERROR_MODE_INCOMPATIBLE, SGX_ERROR_NDEBUG_ENCLAVE,
+    SGX_ERROR_NETWORK_FAILURE, SGX_ERROR_NO_DEVICE, SGX_ERROR_NO_PRIVILEGE,
+    SGX_ERROR_OCALL_NOT_ALLOWED, SGX_ERROR_OUT_OF_EPC, SGX_ERROR_OUT_OF_MEMORY,
+    SGX_ERROR_OUT_OF_TCS, SGX_ERROR_PCL_ENCRYPTED, SGX_ERROR_PCL_GUID_MISMATCH,
+    SGX_ERROR_PCL_MAC_MISMATCH, SGX_ERROR_PCL_NOT_ENCRYPTED, SGX_ERROR_PCL_SHA_MISMATCH,
+    SGX_ERROR_PLATFORM_CERT_UNAVAILABLE, SGX_ERROR_SERVICE_INVALID_PRIVILEGE,
+    SGX_ERROR_SERVICE_TIMEOUT, SGX_ERROR_SERVICE_UNAVAILABLE, SGX_ERROR_STACK_OVERRUN,
+    SGX_ERROR_UNDEFINED_SYMBOL, SGX_ERROR_UNEXPECTED, SGX_ERROR_UNRECOGNIZED_PLATFORM,
+    SGX_ERROR_UNSUPPORTED_ATT_KEY_ID, SGX_ERROR_UNSUPPORTED_CONFIG, SGX_ERROR_UPDATE_NEEDED,
+    SGX_INTERNAL_ERROR_ENCLAVE_CREATE_INTERRUPTED, SGX_PTHREAD_EXIT,
+};
+use serde::{Deserialize, Serialize};
+
+/// A type alias for an SGX result.
+pub type Result<T> = StdResult<T, Error>;
+
+/// A enumeration of SGX errors.
+///
+/// Those listed here are the ones which are identified in the `sgx_status_t` enum, in order of
+/// the actual value. Note that values are grouped (numerically) into the following general
+/// sections:
+///
+///  1. `0x0000-0x0fff`: Generic errors.
+///  2. `0x1000-0x1fff`: Fatal runtime errors.
+///  3. `0x2000-0x2fff`: Enclave creation errors.
+///  4. `0x3000-0x3fff`: Local attestation/report verification errors.
+///  5. `0x4000-0x4fff`: Errors when communicating with the Architectural Enclave Service Manager (AESM).
+///  6. `0x5000-0x5fff`: Errors internal to AESM.
+///  7. `0x6000-0x6fff`: Errors with the encrypted enclave loader.
+///  8. `0x7000-0x7fff`: Errors with the "SGX Encrypted FS" utility.
+///  9. `0x8000-0x8fff`: Attestation key errors.
+/// 10. `0xf000-0xffff`: Internal (to SGX) errors.
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, Eq, Fail, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub enum Error {
+    // 0x0001 - 0x0fff: Generic errors
+    /// `0x0001`, An unexpected error.
+    #[fail(display = "An unexpected error")]
+    Unexpected = SGX_ERROR_UNEXPECTED,
+    /// The parameter is incorrect (`0x0002`).
+    #[fail(display = "The parameter is incorrect")]
+    InvalidParameter = SGX_ERROR_INVALID_PARAMETER,
+    /// There is not enough memory available to complete this operation (`0x0003`).
+    #[fail(display = "There is not enough memory available to complete this operation")]
+    OutOfMemory = SGX_ERROR_OUT_OF_MEMORY,
+    /// The enclave was lost after power transition or used in a child process created by fork() (`0x0004`).
+    #[fail(
+        display = "The enclave was lost after power transition or used in a child process created by fork()"
+    )]
+    EnclaveLost = SGX_ERROR_ENCLAVE_LOST,
+    /// The API is invoked in incorrect order or state (`0x0005`).
+    #[fail(display = "The API is invoked in incorrect order or state")]
+    InvalidState = SGX_ERROR_INVALID_STATE,
+    /// The feature is not supported (`0x0008`).
+    #[fail(display = "The feature is not supported")]
+    FeatureNotSupported = SGX_ERROR_FEATURE_NOT_SUPPORTED,
+    /// A thread in the enclave exited (`0x0009`)
+    #[fail(display = "A thread in the enclave exited")]
+    ThreadExit = SGX_PTHREAD_EXIT,
+
+    // 0x1001 - 0x1fff: Fatal runtime errors
+    /// The ECALL or OCALL function index is incorrect (`0x1001`).
+    #[fail(display = "The ECALL or OCALL function index is incorrect")]
+    InvalidFunction = SGX_ERROR_INVALID_FUNCTION,
+    /// The enclave is out of Thread Control Structures (`0x1003`).
+    #[fail(display = "The enclave is out of TCS")]
+    OutOfTcs = SGX_ERROR_OUT_OF_TCS,
+    /// The enclave crashed (`0x1006`).
+    #[fail(display = "The enclave crashed")]
+    EnclaveCrashed = SGX_ERROR_ENCLAVE_CRASHED,
+    /// ECALL is not allowed at this time (`0x1007`).
+    ///
+    /// Possible reasons include:
+    ///
+    ///  * ECALL is not public.
+    ///  * ECALL is blocked by the dynamic entry table.
+    ///  * A nested ECALL is not allowed during global initialization.
+    #[fail(
+        display = "ECALL not allowed because it is not public, blocked by a dynamic entry table, or nested during global initialization"
+    )]
+    EcallNotAllowed = SGX_ERROR_ECALL_NOT_ALLOWED,
+    /// OCALL is not allowed during exception handling (`0x1008`).
+    #[fail(display = "OCALL is not allowed during exception handling")]
+    OcallNotAllowed = SGX_ERROR_OCALL_NOT_ALLOWED,
+    /// Stack overrun occurs within the enclave (`0x1009`).
+    #[fail(display = "Stack overrun occurs within the enclave")]
+    StackOverrun = SGX_ERROR_STACK_OVERRUN,
+
+    // 0x2000 - 0x2fff: Enclave construction errors
+    /// The enclave contains an undefined symbol (`0x2000`).
+    #[fail(display = "The enclave contains an undefined symbol")]
+    UndefinedSymbol = SGX_ERROR_UNDEFINED_SYMBOL,
+    /// The enclave image has been corrupted (`0x2001`).
+    #[fail(display = "The enclave image has been corrupted")]
+    InvalidEnclave = SGX_ERROR_INVALID_ENCLAVE,
+    /// The enclave ID is invalid (`0x2002`).
+    #[fail(display = "The enclave ID is invalid")]
+    InvalidEnclaveId = SGX_ERROR_INVALID_ENCLAVE_ID,
+    /// The signature for the enclave is invalid (`0x2003`).
+    #[fail(display = "The signature for the enclave is invalid")]
+    InvalidSignature = SGX_ERROR_INVALID_SIGNATURE,
+    /// The enclave was signed as a production enclave, and cannot be instantiated as debuggable (`0x2004`).
+    #[fail(
+        display = "The enclave was signed as a production enclave, and cannot be instantiated as debuggable"
+    )]
+    NdebugEnclave = SGX_ERROR_NDEBUG_ENCLAVE,
+    /// There is not enough EPC (encrypted page cache) available to load the enclave or one of the Architecture Enclaves needed to complete the operation requested (`0x2005`).
+    #[fail(
+        display = "There is not enough EPC (encrypted memory) available to load the enclave or one of the Architecture Enclaves needed to complete the operation requested"
+    )]
+    OutOfEpc = SGX_ERROR_OUT_OF_EPC,
+    /// Cannot open the device (`0x2006`).
+    #[fail(display = "Cannot open the device")]
+    NoDevice = SGX_ERROR_NO_DEVICE,
+    /// Page mapping failed in the driver (`0x2007`).
+    #[fail(display = "Page mapping failed in the driver")]
+    MemoryMapConflict = SGX_ERROR_MEMORY_MAP_CONFLICT,
+    /// The metadata is incorrect (`0x2009`).
+    #[fail(display = "The metadata is incorrect")]
+    InvalidMetadata = SGX_ERROR_INVALID_METADATA,
+    /// The device is busy (`0x200C`)
+    #[fail(display = "Device is busy")]
+    DeviceBusy = SGX_ERROR_DEVICE_BUSY,
+    /// Metadata version is inconsistent between uRTS and `sgx_sign` or the uRTS is incompatible with the current platform (`0x200D`).
+    #[fail(
+        display = "Metadata version is inconsistent between uRTS and `sgx_sign` or the uRTS is incompatible with the current platform"
+    )]
+    InvalidVersion = SGX_ERROR_INVALID_VERSION,
+    /// The target enclave mode (either 32 vs. 64-bit, or hardware vs. simulation) is incompatible with the untrusted mode (`0x200E`).
+    #[fail(
+        display = "The target enclave mode (either 32 vs. 64-bit, or hardware vs. simulation) is incompatible with the untrusted mode"
+    )]
+    ModeIncompatible = SGX_ERROR_MODE_INCOMPATIBLE,
+    /// Cannot open the enclave file (`0x200F`).
+    #[fail(display = "Cannot open the enclave file")]
+    EnclaveFileAccess = SGX_ERROR_ENCLAVE_FILE_ACCESS,
+    /// The MiscSelect or MiscMask settings are incorrect (`0x2010`).
+    #[fail(display = "The MiscSelect or MiscMask settings are incorrect")]
+    InvalidMisc = SGX_ERROR_INVALID_MISC,
+    /// The launch token is incorrect (`0x2011`).
+    #[fail(display = "The launch token is incorrect")]
+    InvalidLaunchToken = SGX_ERROR_INVALID_LAUNCH_TOKEN,
+
+    // 0x3001-0x3fff: Report verification
+    /// Report verification error (`0x3001`).
+    #[fail(display = "Report verification error")]
+    MacMismatch = SGX_ERROR_MAC_MISMATCH,
+    /// The enclave is not authorized (`0x3002`).
+    #[fail(display = "The enclave is not authorized")]
+    InvalidAttribute = SGX_ERROR_INVALID_ATTRIBUTE,
+    /// The CPU security version of this platform is too old (`0x3003`).
+    #[fail(display = "The CPU security version of this platform is too old")]
+    InvalidCpuSvn = SGX_ERROR_INVALID_CPUSVN,
+    /// The enclave security version is too old (`0x3004`).
+    #[fail(display = "The enclave security version is too old")]
+    InvalidIsvSvn = SGX_ERROR_INVALID_ISVSVN,
+    /// Unsupported key name value (`0x3005`).
+    #[fail(display = "Unsupported key name value")]
+    InvalidKeyname = SGX_ERROR_INVALID_KEYNAME,
+
+    // 0x4000 - 0x4fff: AESM
+    /// Architectural Enclave service does not respond or the requested service is not supported (`0x4001`).
+    #[fail(
+        display = "Architectural Enclave service does not respond or the requested service is not supported"
+    )]
+    ServiceUnavailable = SGX_ERROR_SERVICE_UNAVAILABLE,
+    /// The request to the Architectural Enclave service timed out (`0x4002`).
+    #[fail(display = "The request to the Architectural Enclave service timed out")]
+    ServiceTimeout = SGX_ERROR_SERVICE_TIMEOUT,
+    /// Intel EPID blob verification error (`0x4003`).
+    #[fail(display = "Intel EPID blob verification error")]
+    AeInvalidEpidblob = SGX_ERROR_AE_INVALID_EPIDBLOB,
+    /// Enclave has no privilege to get a launch token (`0x4004`).
+    #[fail(display = "Enclave has no privilege to get a launch token")]
+    ServiceInvalidPrivilege = SGX_ERROR_SERVICE_INVALID_PRIVILEGE,
+    /// The EPID group membership has been revoked  (`0x4005`).
+    ///
+    /// The platform is not trusted,and will not be trusted even if updated.
+    #[fail(
+        display = "The EPID group membership has been revoked, and the platform cannot be trusted, even with updates"
+    )]
+    EpidMemberRevoked = SGX_ERROR_EPID_MEMBER_REVOKED,
+    /// Intel SGX requires update (`0x4006`).
+    #[fail(display = "Intel SGX requires update")]
+    UpdateNeeded = SGX_ERROR_UPDATE_NEEDED,
+    /// Network or proxy issue (`0x4007`).
+    #[fail(display = "Network or proxy issue")]
+    NetworkFailure = SGX_ERROR_NETWORK_FAILURE,
+    /// The Architectural Enclave session is invalid or ended by the server (`0x4008`).
+    #[fail(display = "The session is invalid or ended by the server")]
+    AeSessionInvalid = SGX_ERROR_AE_SESSION_INVALID,
+    /// The requested service is temporarily not available (`0x400A`).
+    #[fail(display = "The requested service is temporarily not available")]
+    Busy = SGX_ERROR_BUSY,
+    /// The Monotonic Counter does not exist or has been invalidated (`0x400C`).
+    #[fail(display = "The Monotonic Counter does not exist or has been invalidated")]
+    McNotFound = SGX_ERROR_MC_NOT_FOUND,
+    /// The caller does not have the access right to the specified Virtual Monotonic Counter (`0x400D`).
+    #[fail(
+        display = "The caller does not have the access right to the specified Virtual Monotonic Counter"
+    )]
+    McNoAccessRight = SGX_ERROR_MC_NO_ACCESS_RIGHT,
+    /// No monotonic counter is available (`0x400E`).
+    #[fail(display = "No monotonic counter is available")]
+    McUsedUp = SGX_ERROR_MC_USED_UP,
+    /// Monotonic counters reached quote limit (`0x400F`).
+    #[fail(display = "Monotonic counters reached quote limit")]
+    McOverQuota = SGX_ERROR_MC_OVER_QUOTA,
+    /// Key derivation function did not match during key exchange (`0x4011`).
+    #[fail(display = "Key derivation function did not match during key exchange")]
+    KdfMismatch = SGX_ERROR_KDF_MISMATCH,
+    /// Intel EPID provisioning failed because the platform is not recognized by the back-end server (`0x4012`).
+    #[fail(
+        display = "Intel EPID provisioning failed because the platform is not recognized by the back-end server"
+    )]
+    UnrecognizedPlatform = SGX_ERROR_UNRECOGNIZED_PLATFORM,
+    /// There are unsupported bits in the config (`0x4013`).
+    #[fail(display = "There are unsupported bits in the config")]
+    UnsupportedConfig = SGX_ERROR_UNSUPPORTED_CONFIG,
+
+    // 0x5000 - 0x5fff: AESM-internal errors
+    /// The application does not have the privilege needed to read UEFI variables (`0x5002`).
+    #[fail(display = "The application does not have the privilege needed to read UEFI variables")]
+    NoPrivilege = SGX_ERROR_NO_PRIVILEGE,
+
+    // 0x6000 - 0x6fff: Encrypted Enclaves
+    /// Trying to load an encrypted enclave using API or parameters for plaintext enclaves (`0x6001`).
+    #[fail(
+        display = "Trying to load an encrypted enclave using API or parameters for plaintext enclaves"
+    )]
+    PclEncrypted = SGX_ERROR_PCL_ENCRYPTED,
+    /// Trying to load an enclave that is not encrypted with using API or parameters for encrypted enclaves (`0x6002`).
+    #[fail(
+        display = "Trying to load an enclave that is not encrypted with using API or parameters for encrypted enclaves"
+    )]
+    PclNotEncrypted = SGX_ERROR_PCL_NOT_ENCRYPTED,
+    /// The runtime AES-GCM-128 MAC result of an encrypted section does not match the one used at build time (`0x6003`).
+    #[fail(
+        display = "The runtime AES-GCM-128 MAC result of an encrypted section does not match the one used at build time"
+    )]
+    PclMacMismatch = SGX_ERROR_PCL_MAC_MISMATCH,
+    /// The runtime SHA256 hash of the decryption key does not match the one used at build time (`0x6004`).
+    #[fail(
+        display = "The runtime SHA256 hash of the decryption key does not match the one used at build time"
+    )]
+    PclShaMismatch = SGX_ERROR_PCL_SHA_MISMATCH,
+    /// The GUID in the decryption key sealed blob does not match the one used at build time (`0x6005`).
+    #[fail(
+        display = "The GUID in the decryption key sealed blob does not match the one used at build time"
+    )]
+    PclGuidMismatch = SGX_ERROR_PCL_GUID_MISMATCH,
+
+    // 0x7000 - 0x7fff: SGX Encrypted FS
+    /// The file is in a bad status, run sgx_clearerr to try and fix it (`0x7001`).
+    #[fail(display = "The file is in a bad status, run sgx_clearerr to try and fix it")]
+    FileBadStatus = SGX_ERROR_FILE_BAD_STATUS,
+    /// The Key ID field is all zeroes, the encryption key cannot be regenerated (`0x7002`).
+    #[fail(display = "The Key ID field is all zeroes, the encryption key cannot be regenerated")]
+    FileNoKeyId = SGX_ERROR_FILE_NO_KEY_ID,
+    /// The current file name is different from the original file name (substitution attack) (`0x7003`).
+    #[fail(
+        display = "The current file name is different from the original file name (substitution attack)"
+    )]
+    FileNameMismatch = SGX_ERROR_FILE_NAME_MISMATCH,
+    /// The file is not an Intel SGX file (`0x7004`).
+    #[fail(display = "The file is not an Intel SGX file")]
+    FileNotSgxFile = SGX_ERROR_FILE_NOT_SGX_FILE,
+    /// A recovery file cannot be opened, so the flush operation cannot continue (`0x7005`).
+    #[fail(display = "A recovery file cannot be opened, so the flush operation cannot continue")]
+    FileCantOpenRecoveryFile = SGX_ERROR_FILE_CANT_OPEN_RECOVERY_FILE,
+    /// A recovery file cannot be written, so the flush operation cannot continue (`0x7006`).
+    #[fail(display = "A recovery file cannot be written, so the flush operation cannot continue")]
+    FileCantWriteRecoveryFile = SGX_ERROR_FILE_CANT_WRITE_RECOVERY_FILE,
+    /// When opening the file, recovery is needed, but the recovery process failed (`0x7007`).
+    #[fail(display = "When opening the file, recovery is needed, but the recovery process failed")]
+    FileRecoveryNeeded = SGX_ERROR_FILE_RECOVERY_NEEDED,
+    /// The fflush() operation failed (`0x7008`).
+    #[fail(display = "The fflush() operation failed")]
+    FileFlushFailed = SGX_ERROR_FILE_FLUSH_FAILED,
+    /// The fclose() operation failed (`0x7009`).
+    #[fail(display = "The fclose() operation failed")]
+    FileCloseFailed = SGX_ERROR_FILE_CLOSE_FAILED,
+
+    // 0x8000-0x8fff: Custom Attestation support
+    /// Platform quoting infrastructure does not support the key (`0x8001`)
+    #[fail(display = "Platform quoting infrastructure does not support the key")]
+    UnsupportedAttKeyId = SGX_ERROR_UNSUPPORTED_ATT_KEY_ID,
+    /// Failed to generate and certify the attestation key (`0x8002`).
+    #[fail(display = "Failed to generate and certify the attestation key")]
+    AttKeyCertificationFailure = SGX_ERROR_ATT_KEY_CERTIFICATION_FAILURE,
+    /// The platform quoting infrastructure does not have the attestation key available to generate a quote (`0x8003`).
+    #[fail(
+        display = "The platform quoting infrastructure does not have the attestation key available to generate a quote"
+    )]
+    AttKeyUninitialized = SGX_ERROR_ATT_KEY_UNINITIALIZED,
+    /// The data returned by sgx_get_quote_config() is invalid (`0x8004`).
+    #[fail(display = "The data returned by sgx_get_quote_config() is invalid")]
+    InvalidAttKeyCertData = SGX_ERROR_INVALID_ATT_KEY_CERT_DATA,
+    /// The PCK cert for the platform is not available (`0x8005`).
+    #[fail(display = "The PCK cert for the platform is not available")]
+    PlatformCertUnavailable = SGX_ERROR_PLATFORM_CERT_UNAVAILABLE,
+
+    // 0xf000-0xffff: Internal-to-SGX errors
+    /// The ioctl for enclave_create unexpectedly failed with EINTR (`0xf000`).
+    #[fail(display = "The ioctl for enclave_create unexpectedly failed with EINTR")]
+    EnclaveCreateInterrupted = SGX_INTERNAL_ERROR_ENCLAVE_CREATE_INTERRUPTED,
+}
+
+impl TryFrom<sgx_status_t> for Error {
+    type Error = ();
+
+    fn try_from(src: sgx_status_t) -> StdResult<Error, ()> {
+        match src {
+            0x0001 => Ok(Error::Unexpected),
+            0x0002 => Ok(Error::InvalidParameter),
+            0x0003 => Ok(Error::OutOfMemory),
+            0x0004 => Ok(Error::EnclaveLost),
+            0x0005 => Ok(Error::InvalidState),
+            0x0008 => Ok(Error::FeatureNotSupported),
+            0x0009 => Ok(Error::ThreadExit),
+
+            0x1001 => Ok(Error::InvalidFunction),
+            0x1003 => Ok(Error::OutOfTcs),
+            0x1006 => Ok(Error::EnclaveCrashed),
+            0x1007 => Ok(Error::EcallNotAllowed),
+            0x1008 => Ok(Error::OcallNotAllowed),
+            0x1009 => Ok(Error::StackOverrun),
+
+            0x2000 => Ok(Error::UndefinedSymbol),
+            0x2001 => Ok(Error::InvalidEnclave),
+            0x2002 => Ok(Error::InvalidEnclaveId),
+            0x2003 => Ok(Error::InvalidSignature),
+            0x2004 => Ok(Error::NdebugEnclave),
+            0x2005 => Ok(Error::OutOfEpc),
+            0x2006 => Ok(Error::NoDevice),
+            0x2007 => Ok(Error::MemoryMapConflict),
+            0x2009 => Ok(Error::InvalidMetadata),
+            0x200c => Ok(Error::DeviceBusy),
+            0x200d => Ok(Error::InvalidVersion),
+            0x200e => Ok(Error::ModeIncompatible),
+            0x200f => Ok(Error::EnclaveFileAccess),
+            0x2010 => Ok(Error::InvalidMisc),
+            0x2011 => Ok(Error::InvalidLaunchToken),
+
+            0x3001 => Ok(Error::MacMismatch),
+            0x3002 => Ok(Error::InvalidAttribute),
+            0x3003 => Ok(Error::InvalidCpuSvn),
+            0x3004 => Ok(Error::InvalidIsvSvn),
+            0x3005 => Ok(Error::InvalidKeyname),
+
+            0x4001 => Ok(Error::ServiceUnavailable),
+            0x4002 => Ok(Error::ServiceTimeout),
+            0x4003 => Ok(Error::AeInvalidEpidblob),
+            0x4004 => Ok(Error::ServiceInvalidPrivilege),
+            0x4005 => Ok(Error::EpidMemberRevoked),
+            0x4006 => Ok(Error::UpdateNeeded),
+            0x4007 => Ok(Error::NetworkFailure),
+            0x4008 => Ok(Error::AeSessionInvalid),
+            0x400a => Ok(Error::Busy),
+            0x400c => Ok(Error::McNotFound),
+            0x400d => Ok(Error::McNoAccessRight),
+            0x400e => Ok(Error::McUsedUp),
+            0x400f => Ok(Error::McOverQuota),
+            0x4011 => Ok(Error::KdfMismatch),
+            0x4012 => Ok(Error::UnrecognizedPlatform),
+            0x4013 => Ok(Error::UnsupportedConfig),
+
+            0x5002 => Ok(Error::NoPrivilege),
+
+            0x6001 => Ok(Error::PclEncrypted),
+            0x6002 => Ok(Error::PclNotEncrypted),
+            0x6003 => Ok(Error::PclMacMismatch),
+            0x6004 => Ok(Error::PclShaMismatch),
+            0x6005 => Ok(Error::PclGuidMismatch),
+
+            0x7001 => Ok(Error::FileBadStatus),
+            0x7002 => Ok(Error::FileNoKeyId),
+            0x7003 => Ok(Error::FileNameMismatch),
+            0x7004 => Ok(Error::FileNotSgxFile),
+            0x7005 => Ok(Error::FileCantOpenRecoveryFile),
+            0x7006 => Ok(Error::FileCantWriteRecoveryFile),
+            0x7007 => Ok(Error::FileRecoveryNeeded),
+            0x7008 => Ok(Error::FileFlushFailed),
+            0x7009 => Ok(Error::FileCloseFailed),
+
+            0x8001 => Ok(Error::UnsupportedAttKeyId),
+            0x8002 => Ok(Error::AttKeyCertificationFailure),
+            0x8003 => Ok(Error::AttKeyUninitialized),
+            0x8004 => Ok(Error::InvalidAttKeyCertData),
+            0x8005 => Ok(Error::PlatformCertUnavailable),
+
+            0xF001 => Ok(Error::EnclaveCreateInterrupted),
+
+            _ => Err(()),
+        }
+    }
+}

--- a/sgx/core-types/src/ext_prod_id.rs
+++ b/sgx/core-types/src/ext_prod_id.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! This is the FFI wrapper for sgx_isvext_prod_id_t
+
+use crate::impl_ffi_wrapper;
+use mc_sgx_core_types_sys::sgx_isvext_prod_id_t;
+
+/// The size of the x64 representation of an [ExtendedProductId], in bytes.
+pub use mc_sgx_core_types_sys::SGX_ISVEXT_PROD_ID_SIZE as EXTENDED_PRODUCT_ID_SIZE;
+
+/// The Extended Product ID data type
+///
+/// This type exists because of the lack of non-type polymorphism, and
+/// should be removed once https://github.com/rust-lang/rust/issues/44580
+/// has been completed.
+#[derive(Default)]
+#[repr(transparent)]
+pub struct ExtendedProductId(sgx_isvext_prod_id_t);
+
+impl_ffi_wrapper! {
+    ExtendedProductId, sgx_isvext_prod_id_t, EXTENDED_PRODUCT_ID_SIZE;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bincode::{deserialize, serialize};
+
+    #[test]
+    fn test_serde() {
+        let src = [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        let prodid: ExtendedProductId = src.into();
+        let serialized = serialize(&prodid).expect("Error serializing extended product id.");
+        let prodid2: ExtendedProductId =
+            deserialize(&serialized).expect("Error deserializing extended product id");
+        assert_eq!(prodid, prodid2);
+    }
+}

--- a/sgx/core-types/src/family_id.rs
+++ b/sgx/core-types/src/family_id.rs
@@ -1,0 +1,36 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! ISV Family ID.
+
+use crate::impl_ffi_wrapper;
+use mc_sgx_core_types_sys::sgx_isvfamily_id_t;
+
+/// The size of the X64 representation of a [FamilyId], in bytes.
+pub use mc_sgx_core_types_sys::SGX_ISV_FAMILY_ID_SIZE as FAMILY_ID_SIZE;
+
+/// The ISV Family ID for a given enclave.
+///
+/// This is used when deriving keys when the Key Separation & Sharing feature is enabled.
+#[derive(Default)]
+#[repr(transparent)]
+pub struct FamilyId(sgx_isvfamily_id_t);
+
+impl_ffi_wrapper! {
+    FamilyId, sgx_isvfamily_id_t, FAMILY_ID_SIZE;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bincode::{deserialize, serialize};
+
+    #[test]
+    fn test_serde() {
+        let src = [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        let famid: FamilyId = src.into();
+        let serialized = serialize(&famid).expect("Error serializing extended product id.");
+        let famid2: FamilyId =
+            deserialize(&serialized).expect("Error deserializing extended product id");
+        assert_eq!(famid, famid2);
+    }
+}

--- a/sgx/core-types/src/key_128bit.rs
+++ b/sgx/core-types/src/key_128bit.rs
@@ -1,0 +1,35 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! 128-bit SGX Key used to store a derived key.
+
+use crate::impl_ffi_wrapper;
+use mc_sgx_core_types_sys::sgx_key_128bit_t;
+
+/// The size of the [Key128] structure's x64 representation, in bytes.
+pub const KEY128_SIZE: usize = 16;
+
+/// The ISV Family ID for a given enclave.
+///
+/// This is used when deriving keys when the Key Separation & Sharing feature is enabled.
+#[derive(Default)]
+#[repr(transparent)]
+pub struct Key128(sgx_key_128bit_t);
+
+impl_ffi_wrapper! {
+    Key128, sgx_key_128bit_t, KEY128_SIZE;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bincode::{deserialize, serialize};
+
+    #[test]
+    fn test_serde() {
+        let src = [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        let key1: Key128 = src.into();
+        let serialized = serialize(&key1).expect("Error serializing 128-bit key.");
+        let key2: Key128 = deserialize(&serialized).expect("Error deserializing 128-bit key");
+        assert_eq!(key1, key2);
+    }
+}

--- a/sgx/core-types/src/key_id.rs
+++ b/sgx/core-types/src/key_id.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! The key ID used in requests.
+
+use crate::impl_ffi_wrapper;
+use mc_sgx_core_types_sys::sgx_key_id_t;
+
+/// The size of the [KeyId] structure's x64 representation, in bytes.
+pub use mc_sgx_core_types_sys::SGX_KEYID_SIZE as KEY_ID_SIZE;
+
+/// An SGX Key ID
+#[derive(Default)]
+#[repr(transparent)]
+pub struct KeyId(sgx_key_id_t);
+
+impl_ffi_wrapper! {
+    KeyId, sgx_key_id_t, KEY_ID_SIZE, id;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bincode::{deserialize, serialize};
+
+    #[test]
+    fn test_serde() {
+        let src = sgx_key_id_t {
+            id: [
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ],
+        };
+
+        let keyid: KeyId = src.into();
+        let serialized = serialize(&keyid).expect("Could not serialize cpu_keyid");
+        let keyid2: KeyId = deserialize(&serialized).expect("Could not deserialize cpu_keyid");
+        assert_eq!(keyid, keyid2);
+    }
+}

--- a/sgx/core-types/src/key_request.rs
+++ b/sgx/core-types/src/key_request.rs
@@ -1,0 +1,476 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! This module contains the wrapper type for an sgx_key_request_t
+
+use crate::{
+    _macros::FfiWrapper,
+    attributes::{Attributes, ATTRIBUTES_SIZE},
+    cpu_svn::{CpuSecurityVersion, CPU_SECURITY_VERSION_SIZE},
+    impl_ffi_wrapper_base, impl_serialize_to_x64,
+    key_id::{KeyId, KEY_ID_SIZE},
+    misc_attribute::{MiscSelect, MISC_SELECT_SIZE},
+    ConfigSecurityVersion, SecurityVersion, CONFIG_SECURITY_VERSION_SIZE, SECURITY_VERSION_SIZE,
+};
+use bitflags::bitflags;
+use core::{
+    cmp::Ordering,
+    convert::{TryFrom, TryInto},
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    hash::{Hash, Hasher},
+};
+use mc_encodings::{Error as EncodingError, FromX64, IntelLayout, ToX64, INTEL_U16_SIZE};
+use mc_sgx_core_types_sys::{
+    sgx_key_request_t, SGX_KEYPOLICY_CONFIGID, SGX_KEYPOLICY_ISVEXTPRODID,
+    SGX_KEYPOLICY_ISVFAMILYID, SGX_KEYPOLICY_MRENCLAVE, SGX_KEYPOLICY_MRSIGNER,
+    SGX_KEYPOLICY_NOISVPRODID, SGX_KEYSELECT_EINITTOKEN, SGX_KEYSELECT_PROVISION,
+    SGX_KEYSELECT_PROVISION_SEAL, SGX_KEYSELECT_REPORT, SGX_KEYSELECT_SEAL,
+    SGX_KEY_REQUEST_RESERVED2_BYTES,
+};
+use serde::{Deserialize, Serialize};
+
+const KEY_NAME_START: usize = 0;
+const KEY_NAME_END: usize = KEY_NAME_START + KEY_NAME_SIZE;
+const KEY_POLICY_START: usize = KEY_NAME_END;
+const KEY_POLICY_END: usize = KEY_POLICY_START + KEY_POLICY_SIZE;
+const ISV_SVN_START: usize = KEY_POLICY_END;
+const ISV_SVN_END: usize = ISV_SVN_START + SECURITY_VERSION_SIZE;
+const RESERVED1_START: usize = ISV_SVN_END;
+const RESERVED1_END: usize = RESERVED1_START + INTEL_U16_SIZE;
+const CPU_SVN_START: usize = RESERVED1_END;
+const CPU_SVN_END: usize = CPU_SVN_START + CPU_SECURITY_VERSION_SIZE;
+const ATTRIBUTES_START: usize = CPU_SVN_END;
+const ATTRIBUTES_END: usize = ATTRIBUTES_START + ATTRIBUTES_SIZE;
+const KEY_ID_START: usize = ATTRIBUTES_END;
+const KEY_ID_END: usize = KEY_ID_START + KEY_ID_SIZE;
+const MISC_MASK_START: usize = KEY_ID_END;
+const MISC_MASK_END: usize = MISC_MASK_START + MISC_SELECT_SIZE;
+const CONFIG_SVN_START: usize = MISC_MASK_END;
+const CONFIG_SVN_END: usize = CONFIG_SVN_START + CONFIG_SECURITY_VERSION_SIZE;
+const RESERVED2_START: usize = CONFIG_SVN_END;
+const RESERVED2_END: usize = RESERVED2_START + SGX_KEY_REQUEST_RESERVED2_BYTES;
+
+/// The size of the x64 representation of a [KeyRequest], in bytes.
+pub const KEY_REQUEST_SIZE: usize = RESERVED2_END;
+
+/// The size of the x64 representation of a [KeyName], in bytes.
+pub const KEY_NAME_SIZE: usize = INTEL_U16_SIZE;
+
+/// The size of the x64 representation of a [KeyPolicy], in bytes.
+pub const KEY_POLICY_SIZE: usize = INTEL_U16_SIZE;
+
+/// An enumeration of key names which can be used in a request.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[repr(u16)]
+pub enum KeyName {
+    /// Launch key
+    EnclaveInitToken = SGX_KEYSELECT_EINITTOKEN,
+    /// Provisioning key
+    Provision = SGX_KEYSELECT_PROVISION,
+    /// Provisioning seal key
+    ProvisionSeal = SGX_KEYSELECT_PROVISION_SEAL,
+    /// Report key
+    Report = SGX_KEYSELECT_REPORT,
+    /// Seal key
+    Seal = SGX_KEYSELECT_SEAL,
+}
+
+impl Display for KeyName {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        match self {
+            KeyName::EnclaveInitToken => write!(f, "Enclave initialization token"),
+            KeyName::Provision => write!(f, "Provisioning key"),
+            KeyName::ProvisionSeal => write!(f, "Provisioning seal key"),
+            KeyName::Report => write!(f, "Report signing key"),
+            KeyName::Seal => write!(f, "Sealing key"),
+        }
+    }
+}
+
+impl FromX64 for KeyName {
+    type Error = EncodingError;
+
+    fn from_x64(src: &[u8]) -> Result<Self, Self::Error> {
+        if src.len() < KEY_NAME_SIZE {
+            Err(EncodingError::InvalidInputLength)
+        } else {
+            KeyName::try_from(u16::from_le_bytes(
+                (&src[..KEY_NAME_SIZE])
+                    .try_into()
+                    .expect("Could not convert 2-byte slice to 2-byte array"),
+            ))
+        }
+    }
+}
+
+impl IntelLayout for KeyName {
+    const X86_64_CSIZE: usize = KEY_NAME_SIZE;
+}
+
+impl From<KeyName> for u16 {
+    fn from(src: KeyName) -> u16 {
+        match src {
+            KeyName::EnclaveInitToken => 0x0000,
+            KeyName::Provision => 0x0001,
+            KeyName::ProvisionSeal => 0x0002,
+            KeyName::Report => 0x0003,
+            KeyName::Seal => 0x0004,
+        }
+    }
+}
+
+impl ToX64 for KeyName {
+    fn to_x64(&self, dest: &mut [u8]) -> Result<usize, usize> {
+        if dest.len() < KEY_NAME_SIZE {
+            return Err(KEY_NAME_SIZE);
+        }
+
+        dest.copy_from_slice(&u16::from(*self).to_le_bytes());
+        Ok(KEY_NAME_SIZE)
+    }
+}
+
+impl TryFrom<u16> for KeyName {
+    type Error = EncodingError;
+
+    fn try_from(src: u16) -> Result<Self, Self::Error> {
+        match src {
+            0x0000 => Ok(KeyName::EnclaveInitToken),
+            0x0001 => Ok(KeyName::Provision),
+            0x0002 => Ok(KeyName::ProvisionSeal),
+            0x0003 => Ok(KeyName::Report),
+            0x0004 => Ok(KeyName::Seal),
+            _ => Err(EncodingError::InvalidInput),
+        }
+    }
+}
+
+bitflags! {
+    /// An enumeration of flags controlling what values should be included when deriving a new key.
+    pub struct KeyPolicy: u16 {
+        const MR_ENCLAVE = SGX_KEYPOLICY_MRENCLAVE;
+        const MR_SIGNER = SGX_KEYPOLICY_MRSIGNER;
+        const SKIP_PRODUCT_ID = SGX_KEYPOLICY_NOISVPRODID;
+        const CONFIG_ID = SGX_KEYPOLICY_CONFIGID;
+        const FAMILY_ID = SGX_KEYPOLICY_ISVFAMILYID;
+        const EXTENDED_PRODUCT_ID = SGX_KEYPOLICY_ISVEXTPRODID;
+    }
+}
+
+impl Display for KeyPolicy {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        let mut previous = false;
+        if self.contains(KeyPolicy::MR_ENCLAVE) {
+            write!(f, "MRENCLAVE")?;
+            previous = true;
+        }
+
+        if self.contains(KeyPolicy::MR_SIGNER) {
+            if previous {
+                write!(f, ", ")?;
+            }
+            write!(f, "MRSIGNER")?;
+            previous = true;
+        }
+
+        if !self.contains(KeyPolicy::SKIP_PRODUCT_ID) {
+            if previous {
+                write!(f, ", ")?;
+            }
+            write!(f, "Product ID")?;
+            previous = true;
+        }
+
+        if self.contains(KeyPolicy::CONFIG_ID) {
+            if previous {
+                write!(f, ", ")?;
+            }
+            write!(f, "Config ID")?;
+            previous = true;
+        }
+
+        if self.contains(KeyPolicy::FAMILY_ID) {
+            if previous {
+                write!(f, ", ")?;
+            }
+            write!(f, "Family ID")?;
+            previous = true;
+        }
+
+        if self.contains(KeyPolicy::EXTENDED_PRODUCT_ID) {
+            if previous {
+                write!(f, ", ")?;
+            }
+            write!(f, "Extended Product ID")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl FromX64 for KeyPolicy {
+    type Error = EncodingError;
+
+    fn from_x64(src: &[u8]) -> Result<Self, Self::Error> {
+        if src.len() < KEY_POLICY_SIZE {
+            Err(EncodingError::InvalidInputLength)
+        } else {
+            KeyPolicy::from_bits(u16::from_le_bytes(
+                (&src[..KEY_POLICY_SIZE])
+                    .try_into()
+                    .expect("Could not convert 2-byte slice to 2-byte array"),
+            ))
+            .ok_or(EncodingError::InvalidInput)
+        }
+    }
+}
+
+impl IntelLayout for KeyPolicy {
+    const X86_64_CSIZE: usize = INTEL_U16_SIZE;
+}
+
+impl ToX64 for KeyPolicy {
+    fn to_x64(&self, dest: &mut [u8]) -> Result<usize, usize> {
+        if dest.len() < KEY_POLICY_SIZE {
+            Err(KEY_POLICY_SIZE)
+        } else {
+            dest.copy_from_slice(&self.bits.to_le_bytes());
+            Ok(KEY_POLICY_SIZE)
+        }
+    }
+}
+
+/// A key request data structure.
+///
+/// This is used with the `sgx_get_key()` inside-the-enclave method.
+#[derive(Default)]
+pub struct KeyRequest(sgx_key_request_t);
+
+impl_ffi_wrapper_base! {
+    KeyRequest, sgx_key_request_t, KEY_REQUEST_SIZE;
+}
+
+impl_serialize_to_x64! {
+    KeyRequest, KEY_REQUEST_SIZE;
+}
+
+impl KeyRequest {
+    /// Retrieve the name of the key contained in this request, if it's valid.
+    pub fn key_name(&self) -> KeyName {
+        KeyName::try_from(self.0.key_name).expect("Could not read the key name")
+    }
+
+    /// Retrieve the key policy.
+    pub fn key_policy(&self) -> KeyPolicy {
+        KeyPolicy::from_bits(self.0.key_policy).expect("Bad key policy in KeyRequest")
+    }
+
+    /// Retrieve the ISV enclave security version.
+    pub fn security_version(&self) -> SecurityVersion {
+        self.0.isv_svn
+    }
+
+    /// Retrieve the platform security version.
+    pub fn cpu_security_version(&self) -> CpuSecurityVersion {
+        CpuSecurityVersion::from(&self.0.cpu_svn)
+    }
+
+    /// Retrieve the attribute mask to be used.
+    pub fn attribute_mask(&self) -> Attributes {
+        Attributes::from(&self.0.attribute_mask)
+    }
+
+    /// Retrieve the Key ID used in this request.
+    pub fn key_id(&self) -> KeyId {
+        KeyId::from(&self.0.key_id)
+    }
+
+    /// Retrieve the mask of the attribute flags which are included in the key.
+    pub fn misc_mask(&self) -> MiscSelect {
+        self.0.misc_mask
+    }
+
+    /// Retrieve the configuration version used to lock a key to a particular enclave.
+    pub fn config_security_version(&self) -> ConfigSecurityVersion {
+        self.0.config_svn
+    }
+}
+
+impl Debug for KeyRequest {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(
+            f,
+            "KeyRequest {{ key_name: {:?}, key_policy: {:?}, security_version: {:?}, cpu_security_version: {:?}, attribute_mask: {:?}, key_id: {:?}, misc_mask: {:?}, config_security_version: {:?} }}",
+            self.key_name(),
+            self.key_policy(),
+            self.security_version(),
+            self.cpu_security_version(),
+            self.attribute_mask(),
+            self.key_id(),
+            self.misc_mask(),
+            self.config_security_version()
+        )
+    }
+}
+
+impl Display for KeyRequest {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(
+            f,
+            "Key Request for {}, with policy {}",
+            self.key_name(),
+            self.key_policy()
+        )
+    }
+}
+
+impl From<&sgx_key_request_t> for KeyRequest {
+    fn from(src: &sgx_key_request_t) -> KeyRequest {
+        Self(sgx_key_request_t {
+            key_name: src.key_name,
+            key_policy: src.key_policy,
+            isv_svn: src.isv_svn,
+            reserved1: 0,
+            cpu_svn: CpuSecurityVersion::from(&src.cpu_svn).into(),
+            attribute_mask: Attributes::from(&src.attribute_mask).into(),
+            key_id: KeyId::from(&src.key_id).into(),
+            misc_mask: src.misc_mask,
+            config_svn: src.config_svn,
+            reserved2: [0u8; SGX_KEY_REQUEST_RESERVED2_BYTES],
+        })
+    }
+}
+
+impl FromX64 for KeyRequest {
+    type Error = EncodingError;
+
+    fn from_x64(src: &[u8]) -> Result<Self, Self::Error> {
+        if src.len() < KEY_REQUEST_SIZE {
+            return Err(EncodingError::InvalidInputLength);
+        }
+
+        let key_name = KeyName::from_x64(&src[KEY_NAME_START..KEY_NAME_END])?;
+        let key_policy = KeyPolicy::from_x64(&src[KEY_POLICY_START..KEY_POLICY_END])?;
+        let isv_svn_bytes = (&src[ISV_SVN_START..ISV_SVN_END])
+            .try_into()
+            .map_err(|_e| EncodingError::InvalidInput)?;
+        let isv_svn = SecurityVersion::from_le_bytes(isv_svn_bytes);
+        let cpu_svn = CpuSecurityVersion::from_x64(&src[CPU_SVN_START..CPU_SVN_END])?;
+        let attribute_mask = Attributes::from_x64(&src[ATTRIBUTES_START..ATTRIBUTES_END])?;
+        let key_id = KeyId::from_x64(&src[KEY_ID_START..KEY_ID_END])?;
+        let misc_mask_bytes = (&src[MISC_MASK_START..MISC_MASK_END])
+            .try_into()
+            .map_err(|_e| EncodingError::InvalidInput)?;
+        let misc_mask = MiscSelect::from_le_bytes(misc_mask_bytes);
+        let config_svn_bytes = (&src[CONFIG_SVN_START..CONFIG_SVN_END])
+            .try_into()
+            .map_err(|_e| EncodingError::InvalidInput)?;
+        let config_svn = ConfigSecurityVersion::from_le_bytes(config_svn_bytes);
+
+        Ok(Self(sgx_key_request_t {
+            key_name: key_name as u16,
+            key_policy: key_policy.bits,
+            isv_svn: isv_svn.into(),
+            reserved1: 0,
+            cpu_svn: cpu_svn.into(),
+            attribute_mask: attribute_mask.into(),
+            key_id: key_id.into(),
+            misc_mask: misc_mask.into(),
+            config_svn: config_svn.into(),
+            reserved2: [0u8; SGX_KEY_REQUEST_RESERVED2_BYTES],
+        }))
+    }
+}
+
+impl Hash for KeyRequest {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.key_name().hash(hasher);
+        self.key_policy().hash(hasher);
+        self.security_version().hash(hasher);
+        self.cpu_security_version().hash(hasher);
+        self.attribute_mask().hash(hasher);
+        self.key_id().hash(hasher);
+        self.misc_mask().hash(hasher);
+        self.config_security_version().hash(hasher);
+    }
+}
+
+impl Ord for KeyRequest {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.key_name().cmp(&other.key_name()) {
+            Ordering::Equal => match self.key_policy().cmp(&other.key_policy()) {
+                Ordering::Equal => match self.security_version().cmp(&other.security_version()) {
+                    Ordering::Equal => match self
+                        .cpu_security_version()
+                        .cmp(&other.cpu_security_version())
+                    {
+                        Ordering::Equal => match self.attribute_mask().cmp(&other.attribute_mask())
+                        {
+                            Ordering::Equal => match self.key_id().cmp(&other.key_id()) {
+                                Ordering::Equal => match self.misc_mask().cmp(&other.misc_mask()) {
+                                    Ordering::Equal => self
+                                        .config_security_version()
+                                        .cmp(&other.config_security_version()),
+                                    other => other,
+                                },
+                                other => other,
+                            },
+                            other => other,
+                        },
+                        other => other,
+                    },
+                    other => other,
+                },
+                other => other,
+            },
+            other => other,
+        }
+    }
+}
+
+impl PartialEq for KeyRequest {
+    fn eq(&self, other: &Self) -> bool {
+        self.key_name() == other.key_name()
+            && self.key_policy() == other.key_policy()
+            && self.security_version() == other.security_version()
+            && self.cpu_security_version() == other.cpu_security_version()
+            && self.attribute_mask() == other.attribute_mask()
+            && self.key_id() == other.key_id()
+            && self.misc_mask() == other.misc_mask()
+            && self.config_security_version() == other.config_security_version()
+    }
+}
+
+impl ToX64 for KeyRequest {
+    fn to_x64(&self, dest: &mut [u8]) -> Result<usize, usize> {
+        if dest.len() < KEY_REQUEST_SIZE {
+            return Err(KEY_REQUEST_SIZE);
+        }
+
+        self.key_name()
+            .to_x64(&mut dest[KEY_NAME_START..KEY_NAME_END])
+            .expect("Could not write key name");
+        self.key_policy()
+            .to_x64(&mut dest[KEY_POLICY_START..KEY_POLICY_END])
+            .expect("Could not write key policy");
+        dest[ISV_SVN_START..ISV_SVN_END].copy_from_slice(&self.security_version().to_le_bytes());
+        dest[RESERVED1_START..RESERVED1_END].copy_from_slice(&[0u8; INTEL_U16_SIZE]);
+        self.cpu_security_version()
+            .to_x64(&mut dest[CPU_SVN_START..CPU_SVN_END])
+            .expect("Could not write CPU security version");
+        self.attribute_mask()
+            .to_x64(&mut dest[ATTRIBUTES_START..ATTRIBUTES_END])
+            .expect("Could not write attribute mask");
+        self.key_id()
+            .to_x64(&mut dest[KEY_ID_START..KEY_ID_END])
+            .expect("Could not write key ID");
+        dest[MISC_MASK_START..MISC_MASK_END].copy_from_slice(&self.misc_mask().to_le_bytes());
+        dest[CONFIG_SVN_START..CONFIG_SVN_END]
+            .copy_from_slice(&self.config_security_version().to_le_bytes());
+        dest[RESERVED2_START..RESERVED2_END]
+            .copy_from_slice(&[0u8; SGX_KEY_REQUEST_RESERVED2_BYTES]);
+
+        Ok(KEY_REQUEST_SIZE)
+    }
+}
+
+impl FfiWrapper<sgx_key_request_t> for KeyRequest {}

--- a/sgx/core-types/src/key_request.rs
+++ b/sgx/core-types/src/key_request.rs
@@ -158,11 +158,12 @@ bitflags! {
 
 impl Display for KeyPolicy {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        let mut previous = false;
-        if self.contains(KeyPolicy::MR_ENCLAVE) {
+        let mut previous = if self.contains(KeyPolicy::MR_ENCLAVE) {
             write!(f, "MRENCLAVE")?;
-            previous = true;
-        }
+            true
+        } else {
+            false
+        };
 
         if self.contains(KeyPolicy::MR_SIGNER) {
             if previous {
@@ -369,13 +370,13 @@ impl FromX64 for KeyRequest {
         Ok(Self(sgx_key_request_t {
             key_name: key_name as u16,
             key_policy: key_policy.bits,
-            isv_svn: isv_svn.into(),
+            isv_svn,
             reserved1: 0,
             cpu_svn: cpu_svn.into(),
             attribute_mask: attribute_mask.into(),
             key_id: key_id.into(),
-            misc_mask: misc_mask.into(),
-            config_svn: config_svn.into(),
+            misc_mask,
+            config_svn,
             reserved2: [0u8; SGX_KEY_REQUEST_RESERVED2_BYTES],
         }))
     }

--- a/sgx/core-types/src/lib.rs
+++ b/sgx/core-types/src/lib.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! Core SGX Types
+
+#![cfg_attr(all(not(test), not(doctest)), no_std)]
+#![deny(missing_docs)]
+
+extern crate alloc;
+
+mod attributes;
+mod config_id;
+mod cpu_svn;
+mod error;
+mod ext_prod_id;
+mod family_id;
+mod key_128bit;
+mod key_id;
+mod key_request;
+mod mac;
+mod measurement;
+mod misc_attribute;
+mod report;
+mod report_body;
+mod report_data;
+mod target_info;
+
+pub mod _macros;
+
+pub use crate::{
+    attributes::{Attributes, ATTRIBUTES_SIZE},
+    config_id::{ConfigId, CONFIG_ID_SIZE},
+    cpu_svn::{CpuSecurityVersion, CPU_SECURITY_VERSION_SIZE},
+    error::{Error, Result},
+    ext_prod_id::{ExtendedProductId, EXTENDED_PRODUCT_ID_SIZE},
+    family_id::{FamilyId, FAMILY_ID_SIZE},
+    key_128bit::{Key128, KEY128_SIZE},
+    key_id::{KeyId, KEY_ID_SIZE},
+    key_request::{KeyRequest, KEY_REQUEST_SIZE},
+    mac::{Mac, MAC_SIZE},
+    measurement::{MrEnclave, MrSigner, MRENCLAVE_SIZE, MRSIGNER_SIZE},
+    misc_attribute::{MiscAttribute, MISC_ATTRIBUTE_SIZE},
+    report::{Report, REPORT_SIZE},
+    report_body::{ReportBody, REPORT_BODY_SIZE},
+    report_data::{ReportData, REPORT_DATA_SIZE},
+    target_info::{TargetInfo, TARGET_INFO_SIZE},
+};
+
+/// The size of a [ConfigSecurityVersion]'s x64 representation, in bytes.
+pub use mc_encodings::INTEL_U16_SIZE as CONFIG_SECURITY_VERSION_SIZE;
+
+/// A CONFIGSVN value, which is used in the derivation of some keys.
+pub use mc_sgx_core_types_sys::sgx_config_svn_t as ConfigSecurityVersion;
+
+/// The size of a [MiscSelect]'s x64 representation, in bytes.
+pub use mc_encodings::INTEL_U32_SIZE as MISC_SELECT_SIZE;
+
+/// A "miscellaneous selection" flags type, presently only zero is a valid value
+pub use mc_sgx_core_types_sys::sgx_misc_select_t as MiscSelect;
+
+/// The size of a [ProductId]'s x64 representation, in bytes.
+pub use mc_encodings::INTEL_U16_SIZE as PRODUCT_ID_SIZE;
+
+/// A vendor product ID used to distinguish between enclaves signed by the same author.
+pub use mc_sgx_core_types_sys::sgx_prod_id_t as ProductId;
+
+/// The size of a [SecurityVersion]'s x64 representation, in bytes.
+pub use mc_encodings::INTEL_U16_SIZE as SECURITY_VERSION_SIZE;
+
+/// A security version of a given enclave.
+///
+/// The intent is that this value can be used to restrict trust to known-good versions of an
+/// enclave. That is, when an enclave wants to prove it's a secure place to give secret information
+/// to, the thing that is providing the secrets can check that the enclave is a particular
+/// [ProductId], was signed by a particular [MrSigner], and is no earlier than a particular
+/// [SecurityVersion].
+pub use mc_sgx_core_types_sys::sgx_isv_svn_t as SecurityVersion;
+
+/// The size of an [EnclaveId]'s x64 representation, in bytes.
+pub use mc_encodings::INTEL_U64_SIZE as ENCLAVE_ID_SIZE;
+
+/// A handle for a running enclave.
+pub use mc_sgx_core_types_sys::sgx_enclave_id_t as EnclaveId;

--- a/sgx/core-types/src/mac.rs
+++ b/sgx/core-types/src/mac.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! This module contains the wrapper type for an sgx_mac_t
+
+use crate::impl_ffi_wrapper;
+use mc_sgx_core_types_sys::{sgx_mac_t, SGX_MAC_SIZE};
+
+/// The size of [Mac]'s x64 representation, in bytes.
+pub use mc_sgx_core_types_sys::SGX_MAC_SIZE as MAC_SIZE;
+
+/// 128-bit CMAC of Report data.
+#[derive(Default)]
+#[repr(transparent)]
+pub struct Mac(sgx_mac_t);
+
+impl_ffi_wrapper! {
+    Mac, sgx_mac_t, SGX_MAC_SIZE;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bincode::{deserialize, serialize};
+
+    #[test]
+    fn test_serde() {
+        let src = [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        let mac: Mac = src.into();
+        let serialized = serialize(&mac).expect("Error serializing a mac.");
+        let mac2: Mac = deserialize(&serialized).expect("Error deserializing a mac");
+        assert_eq!(mac, mac2);
+    }
+}

--- a/sgx/core-types/src/measurement.rs
+++ b/sgx/core-types/src/measurement.rs
@@ -1,0 +1,68 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! This module contains the wrapper types for an sgx_measurement_t
+//!
+//! Different types are used for MrSigner and MrEnclave to prevent misuse.
+
+use crate::impl_ffi_wrapper;
+use mc_sgx_core_types_sys::{sgx_measurement_t, SGX_HASH_SIZE};
+
+/// The size of a MrEnclave's x64 representation, in bytes.
+pub use mc_sgx_core_types_sys::SGX_HASH_SIZE as MRENCLAVE_SIZE;
+
+/// The size of a MrSigner's x64 representation, in bytes.
+pub use mc_sgx_core_types_sys::SGX_HASH_SIZE as MRSIGNER_SIZE;
+
+/// An opaque type for MRENCLAVE values.
+///
+/// A MRENCLAVE value is a chained cryptographic hash of the signed enclave binary (.so), and the
+/// results of the page initialization steps which created the enclave's encrypted pages.
+#[derive(Default)]
+#[repr(transparent)]
+pub struct MrEnclave(sgx_measurement_t);
+
+/// An opaque type for MRSIGNER values.
+///
+/// A MRSIGNER value is a SHA256 hash of the public key an enclave was signed with.
+#[derive(Default)]
+#[repr(transparent)]
+pub struct MrSigner(sgx_measurement_t);
+
+impl_ffi_wrapper! {
+    MrEnclave, sgx_measurement_t, SGX_HASH_SIZE, m;
+    MrSigner, sgx_measurement_t, SGX_HASH_SIZE, m;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bincode::{deserialize, serialize};
+
+    #[test]
+    fn test_mrenclave_serde() {
+        let mr_value = sgx_measurement_t {
+            m: [
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ],
+        };
+        let mrenclave: MrEnclave = mr_value.into();
+        let mrser = serialize(&mrenclave).expect("Could not serialize MrEnclave.");
+        let mrdeser: MrEnclave = deserialize(&mrser).expect("Could not deserialize MrEnclave.");
+        assert_eq!(mrenclave, mrdeser);
+    }
+
+    #[test]
+    fn test_mrsigner_serde() {
+        let mr_value = sgx_measurement_t {
+            m: [
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ],
+        };
+        let mrsigner: MrSigner = mr_value.into();
+        let mrser = serialize(&mrsigner).expect("Could not serialize MrSigner.");
+        let mrdeser: MrSigner = deserialize(&mrser).expect("Could not deserialize MrSigner.");
+        assert_eq!(mrsigner, mrdeser);
+    }
+}

--- a/sgx/core-types/src/misc_attribute.rs
+++ b/sgx/core-types/src/misc_attribute.rs
@@ -51,7 +51,7 @@ impl MiscAttribute {
 
     /// Retrieve the attribute selection mask
     pub fn misc_select(&self) -> MiscSelect {
-        self.0.misc_select.into()
+        self.0.misc_select
     }
 }
 

--- a/sgx/core-types/src/misc_attribute.rs
+++ b/sgx/core-types/src/misc_attribute.rs
@@ -1,0 +1,144 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! Miscellaneous attributes structure
+
+/// A mask of select bits, currently this must be initialized to zero.
+pub use mc_sgx_core_types_sys::sgx_misc_select_t as MiscSelect;
+
+/// The size of a [MiscSelect], in bytes.
+pub use mc_encodings::INTEL_U32_SIZE as MISC_SELECT_SIZE;
+
+use crate::{
+    _macros::FfiWrapper,
+    attributes::{Attributes, ATTRIBUTES_SIZE},
+    impl_ffi_wrapper_base, impl_serialize_to_x64,
+};
+use core::{
+    cmp::Ordering,
+    convert::TryInto,
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    hash::{Hash, Hasher},
+};
+use mc_encodings::{Error as EncodingError, FromX64, ToX64, INTEL_U32_SIZE};
+use mc_sgx_core_types_sys::sgx_misc_attribute_t;
+
+const ATTRIBUTES_START: usize = 0;
+const ATTRIBUTES_END: usize = ATTRIBUTES_START + ATTRIBUTES_SIZE;
+const SELECT_START: usize = ATTRIBUTES_END;
+const SELECT_END: usize = ATTRIBUTES_END + MISC_SELECT_SIZE;
+
+/// The size of the x64 representation of a [MiscAttribute], in bytes.
+pub const MISC_ATTRIBUTE_SIZE: usize = SELECT_END + INTEL_U32_SIZE;
+
+/// Enclave `misc_select` and attributes definition structure.
+#[derive(Default)]
+#[repr(transparent)]
+pub struct MiscAttribute(sgx_misc_attribute_t);
+
+impl_ffi_wrapper_base! {
+    MiscAttribute, sgx_misc_attribute_t, MISC_ATTRIBUTE_SIZE;
+}
+
+impl_serialize_to_x64! {
+    MiscAttribute, MISC_ATTRIBUTE_SIZE;
+}
+
+impl MiscAttribute {
+    /// Retrieve the attributes
+    pub fn attributes(&self) -> Attributes {
+        Attributes::from(&self.0.secs_attr)
+    }
+
+    /// Retrieve the attribute selection mask
+    pub fn misc_select(&self) -> MiscSelect {
+        self.0.misc_select.into()
+    }
+}
+
+impl Debug for MiscAttribute {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(
+            f,
+            "MiscAttribute: {{ attributes: {:?}, misc_select: {:?} }}",
+            self.attributes(),
+            self.misc_select()
+        )
+    }
+}
+
+impl Display for MiscAttribute {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(
+            f,
+            "Miscellaneous Enclave Attributes: {}/{}",
+            self.attributes(),
+            self.misc_select()
+        )
+    }
+}
+
+impl From<&sgx_misc_attribute_t> for MiscAttribute {
+    fn from(src: &sgx_misc_attribute_t) -> Self {
+        Self(sgx_misc_attribute_t {
+            secs_attr: Attributes::from(&src.secs_attr).into(),
+            misc_select: src.misc_select,
+        })
+    }
+}
+
+impl Hash for MiscAttribute {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.attributes().hash(hasher);
+        self.misc_select().hash(hasher);
+    }
+}
+
+impl Ord for MiscAttribute {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.attributes().cmp(&other.attributes()) {
+            Ordering::Equal => self.misc_select().cmp(&other.misc_select()),
+            other => other,
+        }
+    }
+}
+
+impl PartialEq for MiscAttribute {
+    fn eq(&self, other: &Self) -> bool {
+        self.attributes() == other.attributes() && self.misc_select() == other.misc_select()
+    }
+}
+
+impl ToX64 for MiscAttribute {
+    fn to_x64(&self, dest: &mut [u8]) -> Result<usize, usize> {
+        if dest.len() < MISC_ATTRIBUTE_SIZE {
+            Err(MISC_ATTRIBUTE_SIZE)
+        } else {
+            self.attributes()
+                .to_x64(&mut dest[ATTRIBUTES_START..ATTRIBUTES_END])
+                .expect("Improper inner serialization of secs_attr");
+            dest[SELECT_START..SELECT_END].copy_from_slice(&self.misc_select().to_le_bytes());
+            Ok(MISC_ATTRIBUTE_SIZE)
+        }
+    }
+}
+
+impl FromX64 for MiscAttribute {
+    type Error = EncodingError;
+
+    fn from_x64(src: &[u8]) -> Result<Self, Self::Error> {
+        if src.len() < MISC_ATTRIBUTE_SIZE {
+            return Err(EncodingError::InvalidInputLength);
+        }
+
+        Ok(Self(sgx_misc_attribute_t {
+            secs_attr: Attributes::from_x64(&src[ATTRIBUTES_START..ATTRIBUTES_END])?.into(),
+            misc_select: MiscSelect::from_le_bytes(
+                (&src[SELECT_START..SELECT_END])
+                    .try_into()
+                    .expect("Could not get bytes for misc_select value"),
+            ),
+        }))
+    }
+}
+
+impl FfiWrapper<sgx_misc_attribute_t> for MiscAttribute {}

--- a/sgx/core-types/src/report.rs
+++ b/sgx/core-types/src/report.rs
@@ -1,0 +1,271 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! SGX Report Structures
+
+use crate::{
+    _macros::FfiWrapper,
+    impl_ffi_wrapper_base, impl_serialize_to_x64,
+    key_id::{KeyId, KEY_ID_SIZE},
+    mac::{Mac, MAC_SIZE},
+    report_body::{ReportBody, REPORT_BODY_SIZE},
+};
+use core::{
+    cmp::Ordering,
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    hash::{Hash, Hasher},
+};
+use mc_encodings::{Error as EncodingError, FromX64, ToX64};
+use mc_sgx_core_types_sys::sgx_report_t;
+
+const BODY_START: usize = 0;
+const BODY_END: usize = REPORT_BODY_SIZE;
+const KEY_ID_START: usize = BODY_END;
+const KEY_ID_END: usize = KEY_ID_START + KEY_ID_SIZE;
+const MAC_START: usize = KEY_ID_END;
+const MAC_END: usize = MAC_START + MAC_SIZE;
+
+/// The size of the SGX report structure's x64 representation, in bytes.
+pub const REPORT_SIZE: usize = MAC_END;
+
+/// The results of an EREPORT called from within SGX
+///
+/// In attestation, the enclave under test will generate a report for use
+/// by another enclave addressible by it's TargetInfo.
+#[derive(Default)]
+#[repr(transparent)]
+pub struct Report(sgx_report_t);
+
+impl_ffi_wrapper_base! {
+    Report, sgx_report_t, REPORT_SIZE;
+}
+
+impl_serialize_to_x64! {
+    Report, REPORT_SIZE;
+}
+
+impl Report {
+    /// Retrieve the report body structure
+    pub fn body(&self) -> ReportBody {
+        ReportBody::from(&self.0.body)
+    }
+
+    /// Retrieve the Key ID used to construct the report
+    pub fn key_id(&self) -> KeyId {
+        KeyId::from(&self.0.key_id)
+    }
+
+    /// Retrieve the MAC of the report
+    pub fn mac(&self) -> Mac {
+        Mac::from(&self.0.mac)
+    }
+}
+
+impl Debug for Report {
+    fn fmt(&self, formatter: &mut Formatter) -> FmtResult {
+        write!(
+            formatter,
+            "Report: {{ body: {:?}, key: {:?}, mac: {:?} }}",
+            self.body(),
+            self.key_id(),
+            self.mac()
+        )
+    }
+}
+
+impl Display for Report {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(
+            f,
+            "SGX report {}, signed by key {}, with mac {}",
+            self.body(),
+            self.key_id(),
+            self.mac()
+        )
+    }
+}
+
+impl FfiWrapper<sgx_report_t> for Report {}
+
+impl From<&sgx_report_t> for Report {
+    fn from(src: &sgx_report_t) -> Self {
+        Self(sgx_report_t {
+            body: ReportBody::from(&src.body).into(),
+            mac: Mac::from(&src.mac).into(),
+            key_id: KeyId::from(&src.key_id).into(),
+        })
+    }
+}
+
+impl FromX64 for Report {
+    type Error = EncodingError;
+
+    fn from_x64(src: &[u8]) -> Result<Self, EncodingError> {
+        if src.len() < REPORT_SIZE {
+            return Err(EncodingError::InvalidInputLength);
+        }
+        Ok(Self(sgx_report_t {
+            body: ReportBody::from_x64(&src[BODY_START..BODY_END])?.into(),
+            mac: Mac::from_x64(&src[MAC_START..MAC_END])?.into(),
+            key_id: KeyId::from_x64(&src[KEY_ID_START..KEY_ID_END])?.into(),
+        }))
+    }
+}
+
+impl Hash for Report {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.body().hash(state);
+        self.key_id().hash(state);
+        self.mac().hash(state);
+    }
+}
+
+// Note, intentionally skipping comparison of mac here, per NCC audit, to avoid
+// side-channel leakage of the mac value
+impl Ord for Report {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.body().cmp(&other.body()) {
+            Ordering::Equal => self.key_id().cmp(&other.key_id()),
+            other => other,
+        }
+    }
+}
+
+impl PartialEq for Report {
+    fn eq(&self, other: &Self) -> bool {
+        use subtle::ConstantTimeEq;
+        self.0.mac[..].ct_eq(&other.0.mac[..]).into()
+    }
+}
+
+impl ToX64 for Report {
+    fn to_x64(&self, dest: &mut [u8]) -> Result<usize, usize> {
+        if dest.len() < REPORT_SIZE {
+            Err(REPORT_SIZE)
+        } else {
+            self.body()
+                .to_x64(&mut dest[BODY_START..BODY_END])
+                .or(Err(REPORT_SIZE))?;
+            self.key_id()
+                .to_x64(&mut dest[KEY_ID_START..KEY_ID_END])
+                .or(Err(REPORT_SIZE))?;
+            self.mac()
+                .to_x64(&mut dest[MAC_START..MAC_END])
+                .or(Err(REPORT_SIZE))?;
+            Ok(REPORT_SIZE)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    extern crate std;
+
+    use std::{format, vec};
+
+    use super::*;
+    use bincode::{deserialize, serialize};
+    use mc_sgx_core_types_sys::{
+        sgx_attributes_t, sgx_cpu_svn_t, sgx_key_id_t, sgx_measurement_t, sgx_report_body_t,
+        sgx_report_data_t,
+    };
+    const TEST_REPORT1: sgx_report_t = sgx_report_t {
+        body: sgx_report_body_t {
+            cpu_svn: sgx_cpu_svn_t {
+                svn: [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            },
+            misc_select: 17,
+            reserved1: [0u8; 12],
+            isv_ext_prod_id: [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            attributes: sgx_attributes_t {
+                flags: 0x0102_0304_0506_0708,
+                xfrm: 0x0807_0605_0403_0201,
+            },
+            mr_enclave: sgx_measurement_t {
+                m: [
+                    17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+                    37, 38, 39, 40, 41, 42, 43, 43, 44, 45, 46, 47,
+                ],
+            },
+            reserved2: [0u8; 32],
+            mr_signer: sgx_measurement_t {
+                m: [
+                    48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
+                    68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
+                ],
+            },
+            reserved3: [0u8; 32],
+            config_id: [
+                80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99,
+                100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+                116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131,
+                132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143,
+            ],
+            isv_prod_id: 144,
+            isv_svn: 145,
+            config_svn: 146,
+            reserved4: [0u8; 42],
+            isv_family_id: [
+                147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162,
+            ],
+            report_data: sgx_report_data_t {
+                d: [
+                    163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178,
+                    179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194,
+                    195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210,
+                    211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226,
+                ],
+            },
+        },
+        mac: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+        key_id: sgx_key_id_t {
+            id: [
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ],
+        },
+    };
+
+    const TEST_REPORT_DEBUGSTR: &str = "Report: { body: ReportBody: { cpu_svn: CpuSecurityVersion: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], misc_select: 17, isv_ext_prod_id: ExtendedProductId: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], attributes: Attributes { flags: 72623859790382856, xfrm: 578437695752307201 }, mr_enclave: MrEnclave: [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 43, 44, 45, 46, 47], mr_signer: MrSigner: [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79], config_id: ConfigId: [80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143], isv_prod_id: 144, isv_svn: 145, config_svn: 146, isv_family_id: FamilyId: [147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162], report_data: ReportData: [163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226] }, key: KeyId: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32], mac: Mac: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] }";
+
+    #[test]
+    fn test_serde() {
+        let report = Report::from(&TEST_REPORT1);
+        let serialized = serialize(&report).expect("Could not serialize report");
+        let report2: Report = deserialize(&serialized).expect("Could not deserialize report");
+        assert_eq!(report, report2);
+    }
+
+    #[test]
+    fn test_debug() {
+        let report = Report::from(&TEST_REPORT1);
+        let debug_str = format!("{:?}", &report);
+        assert_eq!(&debug_str, TEST_REPORT_DEBUGSTR);
+    }
+
+    #[test]
+    fn test_ord() {
+        let report1 = Report::from(&TEST_REPORT1);
+        let mut report2 = report1.clone();
+        assert_eq!(report1, report2);
+        assert!(!(report1 < report2));
+
+        let orig_value = report2.0.key_id.id[0];
+        report2.0.key_id.id[0] = 255;
+        assert!(report1 < report2);
+        report2.0.key_id.id[0] = orig_value;
+        assert_eq!(report1, report2);
+        assert!(!(report1 < report2));
+    }
+
+    #[test]
+    // Report::try_from should return EncodingError::InvalidInputLength if the input contains fewer
+    // than REPORT_SIZE bytes.
+    fn test_report_try_from_insufficient_length() {
+        let sparkle_heart = vec![240, 159, 146, 150];
+        match Report::from_x64(&sparkle_heart[..]) {
+            Ok(_) => panic!(),
+            Err(EncodingError::InvalidInputLength) => {} // Expected.
+            Err(e) => panic!("Unexpected error {:?}", e),
+        }
+    }
+}

--- a/sgx/core-types/src/report.rs
+++ b/sgx/core-types/src/report.rs
@@ -160,7 +160,7 @@ impl ToX64 for Report {
 mod test {
     extern crate std;
 
-    use std::{format, vec};
+    use std::vec;
 
     use super::*;
     use bincode::{deserialize, serialize};
@@ -177,8 +177,8 @@ mod test {
             reserved1: [0u8; 12],
             isv_ext_prod_id: [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
             attributes: sgx_attributes_t {
-                flags: 0x0102_0304_0506_0708,
-                xfrm: 0x0807_0605_0403_0201,
+                flags: 0x0000_0000_0000_0001 | 0x0000_0000_0000_0004 | 0x0000_0000_0000_0080,
+                xfrm: 0x0000_0000_0000_0006,
             },
             mr_enclave: sgx_measurement_t {
                 m: [
@@ -225,21 +225,12 @@ mod test {
         },
     };
 
-    const TEST_REPORT_DEBUGSTR: &str = "Report: { body: ReportBody: { cpu_svn: CpuSecurityVersion: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], misc_select: 17, isv_ext_prod_id: ExtendedProductId: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], attributes: Attributes { flags: 72623859790382856, xfrm: 578437695752307201 }, mr_enclave: MrEnclave: [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 43, 44, 45, 46, 47], mr_signer: MrSigner: [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79], config_id: ConfigId: [80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143], isv_prod_id: 144, isv_svn: 145, config_svn: 146, isv_family_id: FamilyId: [147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162], report_data: ReportData: [163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226] }, key: KeyId: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32], mac: Mac: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] }";
-
     #[test]
     fn test_serde() {
         let report = Report::from(&TEST_REPORT1);
         let serialized = serialize(&report).expect("Could not serialize report");
         let report2: Report = deserialize(&serialized).expect("Could not deserialize report");
         assert_eq!(report, report2);
-    }
-
-    #[test]
-    fn test_debug() {
-        let report = Report::from(&TEST_REPORT1);
-        let debug_str = format!("{:?}", &report);
-        assert_eq!(&debug_str, TEST_REPORT_DEBUGSTR);
     }
 
     #[test]

--- a/sgx/core-types/src/report_body.rs
+++ b/sgx/core-types/src/report_body.rs
@@ -207,22 +207,22 @@ impl FromX64 for ReportBody {
         }
 
         let reserved1 = [0u8; SGX_REPORT_BODY_RESERVED1_BYTES];
-        if &src[RESERVED1_START..RESERVED1_END] != &reserved1[..] {
+        if src[RESERVED1_START..RESERVED1_END] != reserved1[..] {
             return Err(EncodingError::InvalidInput);
         }
 
         let reserved2 = [0u8; SGX_REPORT_BODY_RESERVED2_BYTES];
-        if &src[RESERVED2_START..RESERVED2_END] != &reserved2[..] {
+        if src[RESERVED2_START..RESERVED2_END] != reserved2[..] {
             return Err(EncodingError::InvalidInput);
         }
 
         let reserved3 = [0u8; SGX_REPORT_BODY_RESERVED3_BYTES];
-        if &src[RESERVED3_START..RESERVED3_END] != &reserved3[..] {
+        if src[RESERVED3_START..RESERVED3_END] != reserved3[..] {
             return Err(EncodingError::InvalidInput);
         }
 
         let reserved4 = [0u8; SGX_REPORT_BODY_RESERVED4_BYTES];
-        if &src[RESERVED4_START..RESERVED4_END] != &reserved4[..] {
+        if src[RESERVED4_START..RESERVED4_END] != reserved4[..] {
             return Err(EncodingError::InvalidInput);
         }
 

--- a/sgx/core-types/src/report_body.rs
+++ b/sgx/core-types/src/report_body.rs
@@ -399,8 +399,8 @@ mod test {
         reserved1: [0u8; 12],
         isv_ext_prod_id: [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
         attributes: sgx_attributes_t {
-            flags: 0x0102_0304_0506_0708,
-            xfrm: 0x0807_0605_0403_0201,
+            flags: 0x0000_0000_0000_0001 | 0x0000_0000_0000_0004 | 0x0000_0000_0000_0080,
+            xfrm: 0x0000_0000_0000_0006,
         },
         mr_enclave: sgx_measurement_t {
             m: [

--- a/sgx/core-types/src/report_body.rs
+++ b/sgx/core-types/src/report_body.rs
@@ -1,0 +1,538 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! A wrapper for sgx_report_body_t
+
+use crate::{
+    _macros::FfiWrapper,
+    attributes::{Attributes, ATTRIBUTES_SIZE},
+    config_id::{ConfigId, CONFIG_ID_SIZE},
+    cpu_svn::{CpuSecurityVersion, CPU_SECURITY_VERSION_SIZE},
+    ext_prod_id::{ExtendedProductId, EXTENDED_PRODUCT_ID_SIZE},
+    family_id::{FamilyId, FAMILY_ID_SIZE},
+    impl_ffi_wrapper_base, impl_serialize_to_x64,
+    measurement::{MrEnclave, MrSigner, MRENCLAVE_SIZE, MRSIGNER_SIZE},
+    report_data::{ReportData, REPORT_DATA_SIZE},
+    ConfigSecurityVersion, MiscSelect, ProductId, SecurityVersion, CONFIG_SECURITY_VERSION_SIZE,
+    MISC_SELECT_SIZE, PRODUCT_ID_SIZE, SECURITY_VERSION_SIZE,
+};
+use core::{
+    cmp::Ordering,
+    convert::TryInto,
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    hash::{Hash, Hasher},
+};
+use mc_encodings::{Error as EncodingError, FromX64, ToX64};
+use mc_sgx_core_types_sys::{
+    sgx_report_body_t, SGX_REPORT_BODY_RESERVED1_BYTES, SGX_REPORT_BODY_RESERVED2_BYTES,
+    SGX_REPORT_BODY_RESERVED3_BYTES, SGX_REPORT_BODY_RESERVED4_BYTES,
+};
+
+// Offsets of various fields in a sgx_report_body_t with x86_64 layout
+const CPU_SVN_START: usize = 0;
+const CPU_SVN_END: usize = CPU_SVN_START + CPU_SECURITY_VERSION_SIZE;
+const MISC_SELECT_START: usize = CPU_SVN_END;
+const MISC_SELECT_END: usize = MISC_SELECT_START + MISC_SELECT_SIZE;
+const RESERVED1_START: usize = MISC_SELECT_END;
+const RESERVED1_END: usize = RESERVED1_START + SGX_REPORT_BODY_RESERVED1_BYTES;
+const EXT_PROD_ID_START: usize = RESERVED1_END;
+const EXT_PROD_ID_END: usize = EXT_PROD_ID_START + EXTENDED_PRODUCT_ID_SIZE;
+const ATTRIBUTES_START: usize = EXT_PROD_ID_END;
+const ATTRIBUTES_END: usize = ATTRIBUTES_START + ATTRIBUTES_SIZE;
+const MRENCLAVE_START: usize = ATTRIBUTES_END;
+const MRENCLAVE_END: usize = MRENCLAVE_START + MRENCLAVE_SIZE;
+const RESERVED2_START: usize = MRENCLAVE_END;
+const RESERVED2_END: usize = RESERVED2_START + SGX_REPORT_BODY_RESERVED2_BYTES;
+const MRSIGNER_START: usize = RESERVED2_END;
+const MRSIGNER_END: usize = MRSIGNER_START + MRSIGNER_SIZE;
+const RESERVED3_START: usize = MRSIGNER_END;
+const RESERVED3_END: usize = RESERVED3_START + SGX_REPORT_BODY_RESERVED3_BYTES;
+const CONFIG_ID_START: usize = RESERVED3_END;
+const CONFIG_ID_END: usize = CONFIG_ID_START + CONFIG_ID_SIZE;
+const ISV_PROD_ID_START: usize = CONFIG_ID_END;
+const ISV_PROD_ID_END: usize = ISV_PROD_ID_START + PRODUCT_ID_SIZE;
+const ISV_SVN_START: usize = ISV_PROD_ID_END;
+const ISV_SVN_END: usize = ISV_SVN_START + SECURITY_VERSION_SIZE;
+const CONFIG_SVN_START: usize = ISV_SVN_END;
+const CONFIG_SVN_END: usize = CONFIG_SVN_START + CONFIG_SECURITY_VERSION_SIZE;
+const RESERVED4_START: usize = CONFIG_SVN_END;
+const RESERVED4_END: usize = RESERVED4_START + SGX_REPORT_BODY_RESERVED4_BYTES;
+const FAMILY_ID_START: usize = RESERVED4_END;
+const FAMILY_ID_END: usize = FAMILY_ID_START + FAMILY_ID_SIZE;
+const REPORT_DATA_START: usize = FAMILY_ID_END;
+const REPORT_DATA_END: usize = REPORT_DATA_START + REPORT_DATA_SIZE;
+
+/// The size of a [ReportData]'s x64 representation, in bytes.
+pub const REPORT_BODY_SIZE: usize = REPORT_DATA_END;
+
+/// The data pertinent to a Report and Quote.
+#[derive(Default)]
+#[repr(transparent)]
+pub struct ReportBody(sgx_report_body_t);
+
+impl_ffi_wrapper_base! {
+    ReportBody, sgx_report_body_t, REPORT_BODY_SIZE;
+}
+
+impl_serialize_to_x64! {
+    ReportBody, REPORT_BODY_SIZE;
+}
+
+impl ReportBody {
+    /// Retrieve the attributes of an enclave's report.
+    pub fn attributes(&self) -> Attributes {
+        Attributes::from(&self.0.attributes)
+    }
+
+    /// Retrieve a 64-byte ID representing the enclave XML configuration
+    pub fn config_id(&self) -> ConfigId {
+        ConfigId::from(&self.0.config_id)
+    }
+
+    /// Retrieve the security version of the enclave's XML configuration
+    pub fn config_security_version(&self) -> ConfigSecurityVersion {
+        self.0.config_svn
+    }
+
+    /// Retrieve the security version of the CPU the report was generated
+    /// on
+    pub fn cpu_security_version(&self) -> CpuSecurityVersion {
+        CpuSecurityVersion::from(&self.0.cpu_svn)
+    }
+
+    /// Retrieve the extended product ID, identifying the enclave software
+    pub fn extended_product_id(&self) -> ExtendedProductId {
+        ExtendedProductId::from(&self.0.isv_ext_prod_id)
+    }
+
+    /// Retrieve the product family ID, used to identify enclave software
+    pub fn family_id(&self) -> FamilyId {
+        FamilyId::from(&self.0.isv_family_id)
+    }
+
+    /// Retrieve the enclave measurement
+    pub fn mr_enclave(&self) -> MrEnclave {
+        MrEnclave::from(&self.0.mr_enclave)
+    }
+
+    /// Retrieve whether the extended SSA frame feature was requested (source
+    /// from the enclave XML)
+    pub fn misc_select(&self) -> MiscSelect {
+        self.0.misc_select
+    }
+
+    /// Retrieve the enclave signer measurement
+    pub fn mr_signer(&self) -> MrSigner {
+        MrSigner::from(&self.0.mr_signer)
+    }
+
+    /// Retrieve the product ID of the enclave
+    pub fn product_id(&self) -> ProductId {
+        self.0.isv_prod_id
+    }
+
+    /// Retrieve the user data provided when the report was created
+    pub fn report_data(&self) -> ReportData {
+        ReportData::from(&self.0.report_data)
+    }
+
+    /// Retrieve the security version of the enclave
+    pub fn security_version(&self) -> SecurityVersion {
+        self.0.isv_svn
+    }
+}
+
+impl Debug for ReportBody {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "ReportBody: {{ cpu_svn: {:?}, misc_select: {:?}, isv_ext_prod_id: {:?}, attributes: {:?}, mr_enclave: {:?}, mr_signer: {:?}, config_id: {:?}, isv_prod_id: {:?}, isv_svn: {:?}, config_svn: {:?}, isv_family_id: {:?}, report_data: {:?} }}",
+        self.cpu_security_version(), self.misc_select(), self.extended_product_id(), self.attributes(), self.mr_enclave(), self.mr_signer(), self.config_id(), self.product_id(), self.security_version(), self.config_security_version(), self.family_id(), self.report_data())
+    }
+}
+
+impl Display for ReportBody {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(
+            f,
+            "Report for enclave {}, signed by {}, with product ID {} and version {}",
+            self.mr_enclave(),
+            self.mr_signer(),
+            self.product_id(),
+            self.security_version()
+        )
+    }
+}
+
+impl FfiWrapper<sgx_report_body_t> for ReportBody {}
+
+impl From<&sgx_report_body_t> for ReportBody {
+    fn from(src: &sgx_report_body_t) -> Self {
+        let mut reserved1 = [0u8; SGX_REPORT_BODY_RESERVED1_BYTES];
+        reserved1[..].copy_from_slice(&src.reserved1[..]);
+
+        let mut reserved2 = [0u8; SGX_REPORT_BODY_RESERVED2_BYTES];
+        reserved2[..].copy_from_slice(&src.reserved2[..]);
+
+        let mut reserved3 = [0u8; SGX_REPORT_BODY_RESERVED3_BYTES];
+        reserved3[..].copy_from_slice(&src.reserved3[..]);
+
+        let mut reserved4 = [0u8; SGX_REPORT_BODY_RESERVED4_BYTES];
+        reserved4[..].copy_from_slice(&src.reserved4[..]);
+
+        Self(sgx_report_body_t {
+            cpu_svn: CpuSecurityVersion::from(&src.cpu_svn).into(),
+            misc_select: src.misc_select,
+            reserved1,
+            isv_ext_prod_id: ExtendedProductId::from(&src.isv_ext_prod_id).into(),
+            attributes: Attributes::from(&src.attributes).into(),
+            mr_enclave: MrEnclave::from(&src.mr_enclave).into(),
+            reserved2,
+            mr_signer: MrSigner::from(&src.mr_signer).into(),
+            reserved3,
+            config_id: ConfigId::from(&src.config_id).into(),
+            isv_prod_id: src.isv_prod_id,
+            isv_svn: src.isv_svn,
+            config_svn: src.config_svn,
+            reserved4,
+            isv_family_id: FamilyId::from(&src.isv_family_id).into(),
+            report_data: ReportData::from(&src.report_data).into(),
+        })
+    }
+}
+
+impl FromX64 for ReportBody {
+    type Error = EncodingError;
+
+    fn from_x64(src: &[u8]) -> Result<Self, EncodingError> {
+        if src.len() < REPORT_BODY_SIZE {
+            return Err(EncodingError::InvalidInputLength);
+        }
+
+        let reserved1 = [0u8; SGX_REPORT_BODY_RESERVED1_BYTES];
+        if &src[RESERVED1_START..RESERVED1_END] != &reserved1[..] {
+            return Err(EncodingError::InvalidInput);
+        }
+
+        let reserved2 = [0u8; SGX_REPORT_BODY_RESERVED2_BYTES];
+        if &src[RESERVED2_START..RESERVED2_END] != &reserved2[..] {
+            return Err(EncodingError::InvalidInput);
+        }
+
+        let reserved3 = [0u8; SGX_REPORT_BODY_RESERVED3_BYTES];
+        if &src[RESERVED3_START..RESERVED3_END] != &reserved3[..] {
+            return Err(EncodingError::InvalidInput);
+        }
+
+        let reserved4 = [0u8; SGX_REPORT_BODY_RESERVED4_BYTES];
+        if &src[RESERVED4_START..RESERVED4_END] != &reserved4[..] {
+            return Err(EncodingError::InvalidInput);
+        }
+
+        Ok(Self(sgx_report_body_t {
+            cpu_svn: CpuSecurityVersion::from_x64(&src[CPU_SVN_START..CPU_SVN_END])?.into(),
+            misc_select: u32::from_le_bytes(
+                (&src[MISC_SELECT_START..MISC_SELECT_END])
+                    .try_into()
+                    .expect("Could not parse u32 from the source bytes?"),
+            ),
+            reserved1,
+            isv_ext_prod_id: ExtendedProductId::from_x64(&src[EXT_PROD_ID_START..EXT_PROD_ID_END])?
+                .into(),
+            attributes: Attributes::from_x64(&src[ATTRIBUTES_START..ATTRIBUTES_END])?.into(),
+            mr_enclave: MrEnclave::from_x64(&src[MRENCLAVE_START..MRENCLAVE_END])?.into(),
+            reserved2,
+            mr_signer: MrSigner::from_x64(&src[MRSIGNER_START..MRSIGNER_END])?.into(),
+            reserved3,
+            config_id: ConfigId::from_x64(&src[CONFIG_ID_START..CONFIG_ID_END])?.into(),
+            isv_prod_id: u16::from_le_bytes(
+                (&src[ISV_PROD_ID_START..ISV_PROD_ID_END])
+                    .try_into()
+                    .unwrap(),
+            ),
+            isv_svn: u16::from_le_bytes((&src[ISV_SVN_START..ISV_SVN_END]).try_into().unwrap()),
+            config_svn: u16::from_le_bytes(
+                (&src[CONFIG_SVN_START..CONFIG_SVN_END]).try_into().unwrap(),
+            ),
+            reserved4,
+            isv_family_id: FamilyId::from_x64(&src[FAMILY_ID_START..FAMILY_ID_END])?.into(),
+            report_data: ReportData::from_x64(&src[REPORT_DATA_START..REPORT_DATA_END])?.into(),
+        }))
+    }
+}
+
+impl Hash for ReportBody {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.cpu_security_version().hash(state);
+        self.misc_select().hash(state);
+        self.extended_product_id().hash(state);
+        self.attributes().hash(state);
+        self.mr_enclave().hash(state);
+        self.mr_signer().hash(state);
+        self.config_id().hash(state);
+        self.product_id().hash(state);
+        self.security_version().hash(state);
+        self.config_security_version().hash(state);
+        self.family_id().hash(state);
+    }
+}
+
+impl Ord for ReportBody {
+    /// Create an arbitrary sort order for report body types
+    ///
+    /// We sort by Family ID, ProdID, Extended ProdID, SVN, MrSigner, MrEnclave, Attributes,
+    /// Misc Select, ConfigId, ConfigSVN, CPU SVN, and ReportData, in that order
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (&self.0.isv_family_id[..]).cmp(&other.0.isv_family_id[..]) {
+            Ordering::Equal => match self.0.isv_prod_id.cmp(&other.0.isv_prod_id) {
+                Ordering::Equal => match self.0.isv_ext_prod_id.cmp(&other.0.isv_ext_prod_id) {
+                    Ordering::Equal => match self.0.isv_svn.cmp(&other.0.isv_svn) {
+                        Ordering::Equal => match self.mr_signer().cmp(&other.mr_signer()) {
+                            Ordering::Equal => match self.mr_enclave().cmp(&other.mr_enclave()) {
+                                Ordering::Equal => match self.attributes().cmp(&other.attributes())
+                                {
+                                    Ordering::Equal => {
+                                        match self.0.misc_select.cmp(&other.0.misc_select) {
+                                            Ordering::Equal => {
+                                                match self.config_id().cmp(&other.config_id()) {
+                                                    Ordering::Equal => match self
+                                                        .0
+                                                        .config_svn
+                                                        .cmp(&other.0.config_svn)
+                                                    {
+                                                        Ordering::Equal => match self
+                                                            .cpu_security_version()
+                                                            .cmp(&other.cpu_security_version())
+                                                        {
+                                                            Ordering::Equal => self
+                                                                .report_data()
+                                                                .cmp(&other.report_data()),
+                                                            ordering => ordering,
+                                                        },
+                                                        ordering => ordering,
+                                                    },
+                                                    ordering => ordering,
+                                                }
+                                            }
+                                            ordering => ordering,
+                                        }
+                                    }
+                                    ordering => ordering,
+                                },
+                                ordering => ordering,
+                            },
+                            ordering => ordering,
+                        },
+                        ordering => ordering,
+                    },
+                    ordering => ordering,
+                },
+                ordering => ordering,
+            },
+            ordering => ordering,
+        }
+    }
+}
+
+impl PartialEq for ReportBody {
+    fn eq(&self, other: &Self) -> bool {
+        self.cpu_security_version() == other.cpu_security_version()
+            && self.misc_select() == other.misc_select()
+    }
+}
+
+impl ToX64 for ReportBody {
+    fn to_x64(&self, dest: &mut [u8]) -> Result<usize, usize> {
+        if dest.len() < REPORT_BODY_SIZE {
+            return Err(REPORT_BODY_SIZE);
+        }
+
+        self.cpu_security_version()
+            .to_x64(&mut dest[CPU_SVN_START..CPU_SVN_END])
+            .or(Err(REPORT_BODY_SIZE))?;
+
+        dest[MISC_SELECT_START..MISC_SELECT_END].copy_from_slice(&self.misc_select().to_le_bytes());
+
+        self.extended_product_id()
+            .to_x64(&mut dest[EXT_PROD_ID_START..EXT_PROD_ID_END])
+            .or(Err(REPORT_BODY_SIZE))?;
+        self.attributes()
+            .to_x64(&mut dest[ATTRIBUTES_START..ATTRIBUTES_END])
+            .or(Err(REPORT_BODY_SIZE))?;
+        self.mr_enclave()
+            .to_x64(&mut dest[MRENCLAVE_START..MRENCLAVE_END])
+            .or(Err(REPORT_BODY_SIZE))?;
+        self.mr_signer()
+            .to_x64(&mut dest[MRSIGNER_START..MRSIGNER_END])
+            .or(Err(REPORT_BODY_SIZE))?;
+        self.config_id()
+            .to_x64(&mut dest[CONFIG_ID_START..CONFIG_ID_END])
+            .or(Err(REPORT_BODY_SIZE))?;
+
+        dest[ISV_PROD_ID_START..ISV_PROD_ID_END].copy_from_slice(&self.product_id().to_le_bytes());
+        dest[ISV_SVN_START..ISV_SVN_END].copy_from_slice(&self.security_version().to_le_bytes());
+        dest[CONFIG_SVN_START..CONFIG_SVN_END]
+            .copy_from_slice(&self.config_security_version().to_le_bytes());
+
+        self.family_id()
+            .to_x64(&mut dest[FAMILY_ID_START..FAMILY_ID_END])
+            .or(Err(REPORT_BODY_SIZE))?;
+        self.report_data()
+            .to_x64(&mut dest[REPORT_DATA_START..REPORT_DATA_END])
+            .or(Err(REPORT_BODY_SIZE))?;
+
+        Ok(REPORT_BODY_SIZE)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bincode::{deserialize, serialize};
+    use core::mem::size_of;
+    use mc_sgx_core_types_sys::{
+        sgx_attributes_t, sgx_cpu_svn_t, sgx_measurement_t, sgx_report_data_t,
+    };
+
+    const REPORT_BODY_SRC: sgx_report_body_t = sgx_report_body_t {
+        cpu_svn: sgx_cpu_svn_t {
+            svn: [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+        },
+        misc_select: 17,
+        reserved1: [0u8; 12],
+        isv_ext_prod_id: [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+        attributes: sgx_attributes_t {
+            flags: 0x0102_0304_0506_0708,
+            xfrm: 0x0807_0605_0403_0201,
+        },
+        mr_enclave: sgx_measurement_t {
+            m: [
+                17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
+                38, 39, 40, 41, 42, 43, 43, 44, 45, 46, 47,
+            ],
+        },
+        reserved2: [0u8; 32],
+        mr_signer: sgx_measurement_t {
+            m: [
+                48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
+                69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
+            ],
+        },
+        reserved3: [0u8; 32],
+        config_id: [
+            80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+            101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+            118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134,
+            135, 136, 137, 138, 139, 140, 141, 142, 143,
+        ],
+        isv_prod_id: 144,
+        isv_svn: 145,
+        config_svn: 146,
+        reserved4: [0u8; 42],
+        isv_family_id: [
+            147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162,
+        ],
+        report_data: sgx_report_data_t {
+            d: [
+                163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178,
+                179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194,
+                195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210,
+                211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226,
+            ],
+        },
+    };
+
+    #[test]
+    #[allow(clippy::cognitive_complexity)]
+    fn test_ord() {
+        let body1 = ReportBody::from(&REPORT_BODY_SRC);
+        let mut body2 = body1.clone();
+
+        let orig_value = body2.0.cpu_svn.svn[0];
+        body2.0.cpu_svn.svn[0] = 255;
+        assert!(body1 < body2);
+        body2.0.cpu_svn.svn[0] = orig_value;
+        assert_eq!(body1, body2);
+
+        let orig_value = body2.0.misc_select;
+        body2.0.misc_select = 255;
+        assert!(body1 < body2);
+        body2.0.misc_select = orig_value;
+        assert_eq!(body1, body2);
+
+        let orig_value = body2.0.isv_ext_prod_id[0];
+        body2.0.isv_ext_prod_id[0] = 255;
+        assert!(body1 < body2);
+        body2.0.isv_ext_prod_id[0] = orig_value;
+        assert_eq!(body1, body2);
+
+        let orig_value = body2.0.isv_ext_prod_id[0];
+        body2.0.isv_ext_prod_id[0] = 255;
+        assert!(body1 < body2);
+        body2.0.isv_ext_prod_id[0] = orig_value;
+        assert_eq!(body1, body2);
+
+        let orig_value = body2.0.attributes.flags;
+        body2.0.attributes.flags += 1;
+        assert!(body1 < body2);
+        body2.0.attributes.flags = orig_value;
+        assert_eq!(body1, body2);
+
+        let orig_value = body2.0.attributes.xfrm;
+        body2.0.attributes.xfrm += 1;
+        assert!(body1 < body2);
+        body2.0.attributes.xfrm = orig_value;
+        assert_eq!(body1, body2);
+
+        let orig_value = body2.0.mr_enclave.m[0];
+        body2.0.mr_enclave.m[0] = 255;
+        assert!(body1 < body2);
+        body2.0.mr_enclave.m[0] = orig_value;
+        assert_eq!(body1, body2);
+
+        let orig_value = body2.0.mr_signer.m[0];
+        body2.0.mr_signer.m[0] = 255;
+        assert!(body1 < body2);
+        body2.0.mr_signer.m[0] = orig_value;
+        assert_eq!(body1, body2);
+
+        let orig_value = body2.0.config_id[0];
+        body2.0.config_id[0] = 255;
+        assert!(body1 < body2);
+        body2.0.config_id[0] = orig_value;
+        assert_eq!(body1, body2);
+
+        let orig_value = body2.0.isv_prod_id;
+        body2.0.isv_prod_id = 255;
+        assert!(body1 < body2);
+        body2.0.isv_prod_id = orig_value;
+        assert_eq!(body1, body2);
+
+        let orig_value = body2.0.isv_svn;
+        body2.0.isv_svn = 255;
+        assert!(body1 < body2);
+        body2.0.isv_svn = orig_value;
+        assert_eq!(body1, body2);
+
+        let orig_value = body2.0.isv_family_id[0];
+        body2.0.isv_family_id[0] = 255;
+        assert!(body1 < body2);
+        body2.0.isv_family_id[0] = orig_value;
+        assert_eq!(body1, body2);
+
+        let orig_value = body2.0.report_data.d[0];
+        body2.0.report_data.d[0] = 255;
+        assert!(body1 < body2);
+        body2.0.report_data.d[0] = orig_value;
+        assert_eq!(body1, body2);
+    }
+
+    #[test]
+    fn test_serde() {
+        assert_eq!(REPORT_BODY_SIZE, size_of::<sgx_report_body_t>());
+
+        let body = ReportBody::from(&REPORT_BODY_SRC);
+        let serialized = serialize(&body).expect("Error serializing report.");
+        let body2: ReportBody = deserialize(&serialized).expect("Error deserializing report");
+        assert_eq!(body, body2);
+        let dest: sgx_report_body_t = body2.into();
+        assert_eq!(&REPORT_BODY_SRC.report_data.d[..], &dest.report_data.d[..]);
+    }
+}

--- a/sgx/core-types/src/report_data.rs
+++ b/sgx/core-types/src/report_data.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! The report data structure
+//!
+use crate::impl_ffi_wrapper;
+use core::ops::BitAnd;
+use mc_sgx_core_types_sys::sgx_report_data_t;
+
+/// The size of the [ReportData] x64 representation, in bytes.
+pub use mc_sgx_core_types_sys::SGX_REPORT_DATA_SIZE as REPORT_DATA_SIZE;
+
+/// A data structure used for the user data in a report.
+#[derive(Default)]
+#[repr(transparent)]
+pub struct ReportData(sgx_report_data_t);
+
+impl_ffi_wrapper! {
+    ReportData, sgx_report_data_t, REPORT_DATA_SIZE, d;
+}
+
+impl BitAnd for ReportData {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        let mut output = self;
+        for i in 0..REPORT_DATA_SIZE {
+            output.0.d[i] &= rhs.0.d[i];
+        }
+
+        output
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bincode::{deserialize, serialize};
+    use mc_encodings::FromX64;
+
+    const REPORT_DATA_TEST: sgx_report_data_t = sgx_report_data_t {
+        d: [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+            47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64,
+        ],
+    };
+
+    #[test]
+    fn test_serde() {
+        let data = ReportData::from(&REPORT_DATA_TEST);
+        let serialized = serialize(&data).expect("Could not serialize report_data");
+        let data2: ReportData =
+            deserialize(&serialized).expect("Could not deserialize report_data");
+        assert_eq!(data, data2);
+    }
+
+    #[test]
+    fn test_mask() {
+        let bitmask: [u8; REPORT_DATA_SIZE] = [
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        let mask = ReportData::from_x64(&bitmask[..]).expect("Could not create mask structure");
+        let data = ReportData::from(&REPORT_DATA_TEST);
+
+        assert!(mask & data.clone() != data);
+    }
+}

--- a/sgx/core-types/src/target_info.rs
+++ b/sgx/core-types/src/target_info.rs
@@ -259,8 +259,8 @@ mod test {
             ],
         },
         attributes: sgx_attributes_t {
-            flags: 0xffff_ffff_ffff_ffff,
-            xfrm: 0x0000_0000_0000_0000,
+            flags: 0x0000_0000_0000_0001 | 0x0000_0000_0000_0004 | 0x0000_0000_0000_0080,
+            xfrm: 0x0000_0000_0000_0006,
         },
         reserved1: [0u8; SGX_TARGET_INFO_RESERVED1_BYTES],
         config_svn: 0xDEAD,

--- a/sgx/core-types/src/target_info.rs
+++ b/sgx/core-types/src/target_info.rs
@@ -133,17 +133,17 @@ impl FromX64 for TargetInfo {
         }
 
         let reserved1 = [0u8; SGX_TARGET_INFO_RESERVED1_BYTES];
-        if &src[RESERVED1_START..RESERVED1_END] != &reserved1[..] {
+        if src[RESERVED1_START..RESERVED1_END] != reserved1[..] {
             return Err(EncodingError::InvalidInput);
         }
 
         let reserved2 = [0u8; SGX_TARGET_INFO_RESERVED2_BYTES];
-        if &src[RESERVED2_START..RESERVED2_END] != &reserved2[..] {
+        if src[RESERVED2_START..RESERVED2_END] != reserved2[..] {
             return Err(EncodingError::InvalidInput);
         }
 
         let reserved3 = [0u8; SGX_TARGET_INFO_RESERVED3_BYTES];
-        if &src[RESERVED3_START..RESERVED3_END] != &reserved3[..] {
+        if src[RESERVED3_START..RESERVED3_END] != reserved3[..] {
             return Err(EncodingError::InvalidInput);
         }
 

--- a/sgx/core-types/src/target_info.rs
+++ b/sgx/core-types/src/target_info.rs
@@ -1,0 +1,303 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! This module contains the wrapper type for an sgx_target_info_t
+
+use crate::{
+    _macros::FfiWrapper,
+    attributes::{Attributes, ATTRIBUTES_SIZE},
+    config_id::{ConfigId, CONFIG_ID_SIZE},
+    impl_ffi_wrapper_base, impl_serialize_to_x64,
+    measurement::{MrEnclave, MRENCLAVE_SIZE},
+    ConfigSecurityVersion, MiscSelect, CONFIG_SECURITY_VERSION_SIZE, MISC_SELECT_SIZE,
+};
+use core::{
+    cmp::Ordering,
+    convert::TryInto,
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    hash::{Hash, Hasher},
+};
+use mc_encodings::{Error as EncodingError, FromX64, ToX64};
+use mc_sgx_core_types_sys::{
+    sgx_target_info_t, SGX_TARGET_INFO_RESERVED1_BYTES, SGX_TARGET_INFO_RESERVED2_BYTES,
+    SGX_TARGET_INFO_RESERVED3_BYTES,
+};
+
+// byte positions for each field in an x86_64 representation
+const MR_ENCLAVE_START: usize = 0;
+const MR_ENCLAVE_END: usize = MR_ENCLAVE_START + MRENCLAVE_SIZE;
+const ATTRIBUTES_START: usize = MR_ENCLAVE_END;
+const ATTRIBUTES_END: usize = ATTRIBUTES_START + ATTRIBUTES_SIZE;
+const RESERVED1_START: usize = ATTRIBUTES_END;
+const RESERVED1_END: usize = RESERVED1_START + SGX_TARGET_INFO_RESERVED1_BYTES;
+const CONFIG_SVN_START: usize = RESERVED1_END;
+const CONFIG_SVN_END: usize = CONFIG_SVN_START + CONFIG_SECURITY_VERSION_SIZE;
+const SELECT_START: usize = CONFIG_SVN_END;
+const SELECT_END: usize = SELECT_START + MISC_SELECT_SIZE;
+const RESERVED2_START: usize = SELECT_END;
+const RESERVED2_END: usize = RESERVED2_START + SGX_TARGET_INFO_RESERVED2_BYTES;
+const CONFIG_ID_START: usize = RESERVED2_END;
+const CONFIG_ID_END: usize = CONFIG_ID_START + CONFIG_ID_SIZE;
+const RESERVED3_START: usize = CONFIG_ID_END;
+const RESERVED3_END: usize = RESERVED3_START + SGX_TARGET_INFO_RESERVED3_BYTES;
+
+/// The size of a [TargetInfo] structure's x64 representation, in bytes.
+pub const TARGET_INFO_SIZE: usize = RESERVED3_END;
+
+/// An opaque structure used to address an enclave for local attestation.
+///
+/// In remote attestation, the untrusted code retrieves this from the Intel
+/// Quoting Enclave, and the enclave under test uses it to create a Report.
+#[derive(Default)]
+#[repr(transparent)]
+pub struct TargetInfo(sgx_target_info_t);
+
+impl TargetInfo {
+    /// Retrieve the target enclave's attributes
+    pub fn attributes(&self) -> Attributes {
+        Attributes::from(&self.0.attributes)
+    }
+
+    /// Retrieve the target enclave's XML config ID
+    pub fn config_id(&self) -> ConfigId {
+        ConfigId::from(&self.0.config_id)
+    }
+
+    /// Retrieve the target enclave's security version
+    pub fn config_security_version(&self) -> ConfigSecurityVersion {
+        self.0.config_svn
+    }
+
+    /// Retrieve whether the target enclave requested extended SSA frames
+    pub fn misc_select(&self) -> MiscSelect {
+        self.0.misc_select
+    }
+
+    /// Retrieve the target enclave's measurement
+    pub fn mr_enclave(&self) -> MrEnclave {
+        MrEnclave::from(&self.0.mr_enclave)
+    }
+}
+
+impl_ffi_wrapper_base! {
+    TargetInfo, sgx_target_info_t, TARGET_INFO_SIZE;
+}
+
+impl_serialize_to_x64! {
+    TargetInfo, TARGET_INFO_SIZE;
+}
+
+impl Debug for TargetInfo {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "TargetInfo {{ mr_enclave: {:?}, attributes: {:?}, config_security_version: {:?}, misc_select: {:?}, config_id: {:?} }}", self.mr_enclave(), self.attributes(), self.config_security_version(), self.misc_select(), self.config_id())
+    }
+}
+
+impl Display for TargetInfo {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "Target information for {}", self.mr_enclave())
+    }
+}
+
+impl FfiWrapper<sgx_target_info_t> for TargetInfo {}
+
+impl From<&sgx_target_info_t> for TargetInfo {
+    fn from(src: &sgx_target_info_t) -> Self {
+        let mut reserved1 = [0u8; SGX_TARGET_INFO_RESERVED1_BYTES];
+        reserved1.copy_from_slice(&src.reserved1[..]);
+
+        let mut reserved2 = [0u8; SGX_TARGET_INFO_RESERVED2_BYTES];
+        reserved2.copy_from_slice(&src.reserved2[..]);
+
+        let mut reserved3 = [0u8; SGX_TARGET_INFO_RESERVED3_BYTES];
+        reserved3.copy_from_slice(&src.reserved3[..]);
+
+        Self(sgx_target_info_t {
+            mr_enclave: MrEnclave::from(&src.mr_enclave).into(),
+            attributes: Attributes::from(&src.attributes).into(),
+            reserved1,
+            config_svn: src.config_svn,
+            misc_select: src.misc_select,
+            reserved2,
+            config_id: ConfigId::from(&src.config_id).into(),
+            reserved3,
+        })
+    }
+}
+
+impl FromX64 for TargetInfo {
+    type Error = EncodingError;
+
+    fn from_x64(src: &[u8]) -> Result<Self, EncodingError> {
+        if src.len() < TARGET_INFO_SIZE {
+            return Err(EncodingError::InvalidInputLength);
+        }
+
+        let reserved1 = [0u8; SGX_TARGET_INFO_RESERVED1_BYTES];
+        if &src[RESERVED1_START..RESERVED1_END] != &reserved1[..] {
+            return Err(EncodingError::InvalidInput);
+        }
+
+        let reserved2 = [0u8; SGX_TARGET_INFO_RESERVED2_BYTES];
+        if &src[RESERVED2_START..RESERVED2_END] != &reserved2[..] {
+            return Err(EncodingError::InvalidInput);
+        }
+
+        let reserved3 = [0u8; SGX_TARGET_INFO_RESERVED3_BYTES];
+        if &src[RESERVED3_START..RESERVED3_END] != &reserved3[..] {
+            return Err(EncodingError::InvalidInput);
+        }
+
+        Ok(Self(sgx_target_info_t {
+            mr_enclave: MrEnclave::from_x64(&src[MR_ENCLAVE_START..MR_ENCLAVE_END])?.into(),
+            attributes: Attributes::from_x64(&src[ATTRIBUTES_START..ATTRIBUTES_END])?.into(),
+            reserved1,
+            config_svn: u16::from_le_bytes(
+                (&src[CONFIG_SVN_START..CONFIG_SVN_END])
+                    .try_into()
+                    .expect("Could not read config_svn bytes."),
+            ),
+            misc_select: u32::from_le_bytes((&src[SELECT_START..SELECT_END]).try_into().unwrap()),
+            reserved2,
+            config_id: ConfigId::from_x64(&src[CONFIG_ID_START..CONFIG_ID_END])?.into(),
+            reserved3,
+        }))
+    }
+}
+
+impl Hash for TargetInfo {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.mr_enclave().hash(state);
+        self.attributes().hash(state);
+        self.config_security_version().hash(state);
+        self.misc_select().hash(state);
+        self.config_id().hash(state);
+    }
+}
+
+impl Ord for TargetInfo {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.mr_enclave().cmp(&other.mr_enclave()) {
+            Ordering::Equal => match self.attributes().cmp(&other.attributes()) {
+                Ordering::Equal => match self.config_id().cmp(&other.config_id()) {
+                    Ordering::Equal => match self
+                        .config_security_version()
+                        .cmp(&other.config_security_version())
+                    {
+                        Ordering::Equal => self.misc_select().cmp(&other.misc_select()),
+                        ordering => ordering,
+                    },
+                    ordering => ordering,
+                },
+                ordering => ordering,
+            },
+            ordering => ordering,
+        }
+    }
+}
+
+impl PartialEq for TargetInfo {
+    /// TargetInfo structures are equal if all their fields are equal.
+    fn eq(&self, other: &Self) -> bool {
+        self.mr_enclave() == other.mr_enclave()
+            && self.attributes() == other.attributes()
+            && self.config_security_version() == other.config_security_version()
+            && self.misc_select() == other.misc_select()
+            && self.config_id() == other.config_id()
+    }
+}
+
+/// Serialization into the x86_64 struct representation
+impl ToX64 for TargetInfo {
+    fn to_x64(&self, dest: &mut [u8]) -> Result<usize, usize> {
+        if dest.len() < TARGET_INFO_SIZE {
+            return Err(TARGET_INFO_SIZE);
+        }
+
+        self.mr_enclave()
+            .to_x64(&mut dest[MR_ENCLAVE_START..MR_ENCLAVE_END])
+            .or(Err(TARGET_INFO_SIZE))?;
+        self.attributes()
+            .to_x64(&mut dest[ATTRIBUTES_START..ATTRIBUTES_END])
+            .or(Err(TARGET_INFO_SIZE))?;
+
+        dest[RESERVED1_START..RESERVED1_END]
+            .copy_from_slice(&[0u8; SGX_TARGET_INFO_RESERVED1_BYTES]);
+
+        dest[CONFIG_SVN_START..CONFIG_SVN_END]
+            .copy_from_slice(&self.config_security_version().to_le_bytes());
+        dest[SELECT_START..SELECT_END].copy_from_slice(&self.misc_select().to_le_bytes());
+
+        dest[RESERVED2_START..RESERVED2_END]
+            .copy_from_slice(&[0u8; SGX_TARGET_INFO_RESERVED2_BYTES]);
+
+        dest[CONFIG_ID_START..CONFIG_ID_END].copy_from_slice(&self.0.config_id[..]);
+
+        dest[RESERVED3_START..RESERVED3_END]
+            .copy_from_slice(&[0u8; SGX_TARGET_INFO_RESERVED3_BYTES]);
+
+        Ok(TARGET_INFO_SIZE)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    extern crate std;
+    use std::vec;
+
+    use super::*;
+    use bincode::{deserialize, serialize};
+    use mc_sgx_core_types_sys::{
+        sgx_attributes_t, sgx_measurement_t, sgx_target_info_t, SGX_TARGET_INFO_RESERVED1_BYTES,
+        SGX_TARGET_INFO_RESERVED2_BYTES, SGX_TARGET_INFO_RESERVED3_BYTES,
+    };
+
+    const TARGET_INFO_SAMPLE: sgx_target_info_t = sgx_target_info_t {
+        mr_enclave: sgx_measurement_t {
+            m: [
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ],
+        },
+        attributes: sgx_attributes_t {
+            flags: 0xffff_ffff_ffff_ffff,
+            xfrm: 0x0000_0000_0000_0000,
+        },
+        reserved1: [0u8; SGX_TARGET_INFO_RESERVED1_BYTES],
+        config_svn: 0xDEAD,
+        misc_select: 0xCAFE_BEEF,
+        reserved2: [0u8; SGX_TARGET_INFO_RESERVED2_BYTES],
+        config_id: [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+            47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64,
+        ],
+        reserved3: [0u8; SGX_TARGET_INFO_RESERVED3_BYTES],
+    };
+
+    #[test]
+    fn test_bad_ffi_write_len() {
+        let ti = TargetInfo::from(&TARGET_INFO_SAMPLE);
+        let mut outbuf = vec![0u8; TARGET_INFO_SIZE - 1];
+
+        assert_eq!(ti.to_x64(&mut outbuf[..]), Err(TARGET_INFO_SIZE));
+    }
+
+    #[test]
+    fn test_bad_ffi_read_len() {
+        let ti = TargetInfo::from(&TARGET_INFO_SAMPLE);
+        let outbuf = ti.to_x64_vec();
+
+        assert_eq!(
+            TargetInfo::from_x64(&outbuf[..TARGET_INFO_SIZE - 1]),
+            Err(EncodingError::InvalidInputLength)
+        );
+    }
+
+    #[test]
+    fn test_target_info_serde() {
+        let ti1 = TargetInfo::from(&TARGET_INFO_SAMPLE);
+        let ti1ser = serialize(&ti1).expect("TargetInfo serialization failure");
+        let ti2 = deserialize(&ti1ser).expect("TargetInfo deserialization failure");
+        assert_eq!(ti1, ti2);
+    }
+}

--- a/sgx/epid-sys/Cargo.toml
+++ b/sgx/epid-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mcsgx-epid-sys"
+name = "mc-sgx-epid-sys"
 version = "2.9.0"
 authors = ["MobileCoin"]
 description = "EPID FFI for Intel SGX SDK."
@@ -8,8 +8,8 @@ edition = "2018"
 links = "sgx_epid"
 
 [dependencies]
-mcsgx-core-types-sys = { version = "=2.9.0", path = "../core-types-sys" }
-mcsgx-epid-types-sys = { version = "=2.9.0", path = "../epid-types-sys" }
+mc-sgx-core-types-sys = { version = "=2.9.0", path = "../core-types-sys" }
+mc-sgx-epid-types-sys = { version = "=2.9.0", path = "../epid-types-sys" }
 
 [build-dependencies]
 mcbuild-sgx-utils = { path = "../../mcbuild/sgx-utils" }

--- a/sgx/epid-sys/Cargo.toml
+++ b/sgx/epid-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-epid-sys"
-version = "2.9.0"
+version = "0.1.3"
 authors = ["MobileCoin"]
 description = "EPID FFI for Intel SGX SDK."
 readme = "README.md"
@@ -8,8 +8,8 @@ edition = "2018"
 links = "sgx_epid"
 
 [dependencies]
-mc-sgx-core-types-sys = { version = "=2.9.0", path = "../core-types-sys" }
-mc-sgx-epid-types-sys = { version = "=2.9.0", path = "../epid-types-sys" }
+mc-sgx-core-types-sys = { path = "../core-types-sys" }
+mc-sgx-epid-types-sys = { path = "../epid-types-sys" }
 
 [build-dependencies]
 mcbuild-sgx-utils = { path = "../../mcbuild/sgx-utils" }

--- a/sgx/epid-sys/build.rs
+++ b/sgx/epid-sys/build.rs
@@ -14,7 +14,7 @@ fn main() {
     let mut header = env.dir().join("include");
     header.push("sgx_uae_epid.h");
     Builder::default()
-        .ctypes_prefix("mcsgx_core_types_sys::ctypes")
+        .ctypes_prefix("mc_sgx_core_types_sys::ctypes")
         .derive_copy(true)
         .derive_debug(true)
         .derive_default(true)

--- a/sgx/epid-sys/src/lib.rs
+++ b/sgx/epid-sys/src/lib.rs
@@ -8,7 +8,7 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::useless_transmute)]
 
-use mcsgx_core_types_sys::*;
-use mcsgx_epid_types_sys::*;
+use mc_sgx_core_types_sys::*;
+use mc_sgx_epid_types_sys::*;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/sgx/epid-types-sys/Cargo.toml
+++ b/sgx/epid-types-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mcsgx-epid-types-sys"
+name = "mc-sgx-epid-types-sys"
 version = "2.9.0"
 authors = ["MobileCoin"]
 description = "EPID FFI types for Intel SGX SDK."
@@ -7,7 +7,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-mcsgx-core-types-sys = { version = "=2.9.0", path = "../core-types-sys" }
+mc-sgx-core-types-sys = { version = "=2.9.0", path = "../core-types-sys" }
 
 [build-dependencies]
 mcbuild-utils = { path = "../../mcbuild/utils" }

--- a/sgx/epid-types-sys/Cargo.toml
+++ b/sgx/epid-types-sys/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "mc-sgx-epid-types-sys"
-version = "2.9.0"
+version = "0.1.3"
 authors = ["MobileCoin"]
 description = "EPID FFI types for Intel SGX SDK."
 readme = "README.md"
 edition = "2018"
 
 [dependencies]
-mc-sgx-core-types-sys = { version = "=2.9.0", path = "../core-types-sys" }
+mc-sgx-core-types-sys = { path = "../core-types-sys" }
 
 [build-dependencies]
 mcbuild-utils = { path = "../../mcbuild/utils" }

--- a/sgx/epid-types-sys/build.rs
+++ b/sgx/epid-types-sys/build.rs
@@ -2,8 +2,52 @@
 
 //! Build script to generate bindings for the Intel SGX SDK core FFI types
 
-use bindgen::Builder;
+use bindgen::{
+    callbacks::{IntKind, ParseCallbacks},
+    Builder,
+};
 use mcbuild_utils::Environment;
+
+#[derive(Debug)]
+struct Callbacks;
+
+impl ParseCallbacks for Callbacks {
+    fn int_macro(&self, name: &str, _value: i64) -> Option<IntKind> {
+        if name.ends_with("_SIZE") || name.ends_with("_BYTES") {
+            Some(IntKind::Custom {
+                name: "usize",
+                is_signed: false,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn item_name(&self, name: &str) -> Option<String> {
+        if name.starts_with("_sgx_") {
+            Some(name[1..].to_owned())
+        } else if name.starts_with('_') {
+            let mut retval = "sgx".to_owned();
+            retval.push_str(name);
+            // Cleanup the _quote_nonce, _platform_info, and _update_info_bit types.
+            //
+            // Yelling in the wilderness:
+            //
+            // Is there someone going around teaching students that "`_t` means it's a C type"
+            // without further explanation? The `_t` suffix exists for POSIX to namespace itself
+            // from the code of mere mortals, not for every damned fool to remind themselves what
+            // language they are writing code for.
+            //   -jmc
+            if !name.ends_with("_t") {
+                retval.push_str("_t")
+            }
+
+            Some(retval)
+        } else {
+            None
+        }
+    }
+}
 
 fn main() {
     let env = Environment::default();
@@ -11,7 +55,7 @@ fn main() {
     let mut header = env.dir().join("include");
     header.push("sgx_quote.h");
     Builder::default()
-        .ctypes_prefix("mcsgx_core_types_sys::ctypes")
+        .ctypes_prefix("mc_sgx_core_types_sys::ctypes")
         .derive_copy(true)
         .derive_debug(true)
         .derive_default(true)
@@ -26,24 +70,20 @@ fn main() {
                 .into_string()
                 .expect("Invalid UTF-8 in path to sgx_quote.h"),
         )
+        .parse_callbacks(Box::new(Callbacks))
+        .prepend_enum_name(false)
         .use_core()
         // We whitelist only the exact stuff we want, because mcsgx-core-types-sys has the basic
         // stuff
         .whitelist_recursively(false)
         .whitelist_type("sgx_epid_group_id_t")
         .whitelist_type("_spid_t")
-        .whitelist_type("sgx_spid_t")
         .whitelist_type("_basename_t")
-        .whitelist_type("sgx_basename_t")
         .whitelist_type("_quote_nonce")
-        .whitelist_type("sgx_quote_nonce_t")
         .whitelist_type("sgx_quote_sign_type_t")
         .whitelist_type("_quote_t")
-        .whitelist_type("sgx_quote_t")
         .whitelist_type("_platform_info")
-        .whitelist_type("sgx_platform_info_t")
         .whitelist_type("_update_info_bit")
-        .whitelist_type("sgx_update_info_bit_t")
         .whitelist_var("SGX_PLATFORM_INFO_SIZE")
         .generate()
         .expect("Unable to generate bindings")

--- a/sgx/epid-types-sys/src/lib.rs
+++ b/sgx/epid-types-sys/src/lib.rs
@@ -8,6 +8,6 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::useless_transmute)]
 
-use mcsgx_core_types_sys::*;
+use mc_sgx_core_types_sys::*;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/util/encodings/src/lib.rs
+++ b/util/encodings/src/lib.rs
@@ -15,5 +15,5 @@ pub use crate::{
     base64::{base64_buffer_size, base64_size, FromBase64, ToBase64},
     error::Error,
     hex::{FromHex, ToHex},
-    x64::{FromX64, IntelLayout, ToX64, INTEL_U16_SIZE, INTEL_U32_SIZE},
+    x64::{FromX64, IntelLayout, ToX64, INTEL_U16_SIZE, INTEL_U32_SIZE, INTEL_U64_SIZE},
 };

--- a/util/encodings/src/x64.rs
+++ b/util/encodings/src/x64.rs
@@ -8,9 +8,15 @@ use alloc::vec::Vec;
 
 /// The size of a u16 on x86_64
 pub const INTEL_U16_SIZE: usize = 2;
+
 /// The size of a u32 on x86_64
 pub const INTEL_U32_SIZE: usize = 4;
 
+/// The size of a u64 on x86_64
+pub const INTEL_U64_SIZE: usize = 8;
+
+/// A trait containing the basic supports necessary to support serialization/deserialization as x64
+/// bytes.
 pub trait IntelLayout {
     /// The default size required for the x86_64 C representations of the underlying structure
     const X86_64_CSIZE: usize;
@@ -21,24 +27,26 @@ pub trait IntelLayout {
         Self::X86_64_CSIZE
     }
 }
+
+/// A trait which creates a new object from a raw byte slice of an x64 C ABI bytes.
 pub trait FromX64: IntelLayout + Sized {
     /// The type of errors to be returned
     type Error;
 
     /// Construct a new object from the given slice
-    fn from_x64_bytes(src: &[u8]) -> Result<Self, Self::Error>;
+    fn from_x64(src: &[u8]) -> Result<Self, Self::Error>;
 }
 
 /// A trait which writes the contents of a structure as x86_64 C ABI bytes.
 pub trait ToX64: IntelLayout + Sized {
     /// Write the x86_64 C ABI version of this structure into a byte slice
-    fn to_x64_bytes(&self, dest: &mut [u8]) -> Result<usize, usize>;
+    fn to_x64(&self, dest: &mut [u8]) -> Result<usize, usize>;
 
     /// Write the x86_64 C ABI version of this structure into a newly allocated vector.
     fn to_x64_vec(&self) -> Vec<u8> {
         let mut retval = vec![0u8; self.intel_size()];
         let len = self
-            .to_x64_bytes(retval.as_mut_slice())
+            .to_x64(retval.as_mut_slice())
             .expect("Self::intel_size() returned an incorrect value, it should have returned");
         retval.truncate(len);
         retval


### PR DESCRIPTION
This is mostly copy-paste of rust types from the attest crate, with some slight modifications:

1. This is just local attestation and basic enclave types---IAS/EPID stuff will live in other crates.
1. The `impl_X` macros are public, for use in other crates---e.g. the IAS/EPID stuff should use it.
1. The `FfiWrapper` type is just a marker trait to ensure everything implements a common API.
1. This uses the `mc_encodings::{ToX64, FromX64}` traits, and drops the customized `SgxWrapperType` FFI stuff.
1. Attribute flags are now bitflags.
1. Serialization of complex types includes more validation by parsing into the rust type, then extracting the inner FFI types.
1. The `Into<Vec<u8>>` implementations removed (redundant to `ToX64`).
1. `ToX64` and `FromX64` have simplified method names.
1. Bindgen's `-sys` crates aren't implementing copy/clone, so we're just going to add `Clone` impl as a requirement. This is probably for the best, even if a 512B struct is memcpy-able, you probably don't want rust to do that for you automatically.

The longer-term goal here is to build up a more rust-like SGX codebase, rooted in auto-generated FFI structs with an eye towards migrating away from EPID/IAS alongside our existing "attest/baidu" stuff we have now, then cut over.