### PR TITLE
More efficient BlockContents storage in LedgerDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,6 +2052,7 @@ dependencies = [
  "mc-util-from-random 0.1.0",
  "mcrand 1.0.0",
  "mcserial 0.1.0",
+ "prost 0.6.1 (git+https://github.com/mobilecoinofficial/prost?rev=4e1905329369ca7a1cac3eda978ee9379167ee95)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -16,6 +16,7 @@ failure = "0.1.5"
 keys = { path = "../../crypto/keys", optional = true }
 lmdb = "0.8.0"
 mc-util-from-random = { path = "../../util/from-random" }
+mcserial = { path = "../../util/mcserial", features = ["std"] }
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand = { version = "0.7", optional = true }
 rand_core = "0.5"

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -13,14 +13,14 @@ test_utils = ["rand", "keys"]
 [dependencies]
 common = { path = "../../common", features = ["log"] }
 failure = "0.1.5"
+keys = { path = "../../crypto/keys", optional = true }
 lmdb = "0.8.0"
 mc-util-from-random = { path = "../../util/from-random" }
-mcserial = { path = "../../util/mcserial" }
+prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+rand = { version = "0.7", optional = true }
 rand_core = "0.5"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 transaction = { path = "../../transaction/core" }
-keys = { path = "../../crypto/keys", optional = true }
-rand = { version = "0.7", optional = true }
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
 curve25519-dalek = { version = "2.0", default-features = false, features = ["simd_backend", "nightly"] }

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -30,6 +30,9 @@ pub enum Error {
     #[fail(display = "InvalidBlockID")]
     InvalidBlockID,
 
+    #[fail(display = "NoOutputs")]
+    NoOutputs,
+
     /// LMDB error, may mean database is opened multiple times in a process.
     #[fail(display = "BadRslot")]
     BadRslot,

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -72,6 +72,18 @@ impl From<mcserial::encode::Error> for Error {
     }
 }
 
+impl From<mcserial::DecodeError> for Error {
+    fn from(_: mcserial::DecodeError) -> Self {
+        Error::Deserialization
+    }
+}
+
+impl From<mcserial::EncodeError> for Error {
+    fn from(_: mcserial::EncodeError) -> Self {
+        Error::Serialization
+    }
+}
+
 impl From<transaction::range::RangeError> for Error {
     fn from(_: transaction::range::RangeError) -> Self {
         Error::RangeError

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -412,8 +412,7 @@ impl LedgerDB {
 
         // A block must have outputs.
         if block_contents.outputs.is_empty() {
-            // TODO: better error type.
-            return Err(Error::InvalidBlock);
+            return Err(Error::NoOutputs);
         }
 
         // TODO: enable this.
@@ -873,7 +872,7 @@ mod ledger_db_test {
 
         assert_eq!(
             ledger_db.append_block(&block, &block_contents, None),
-            Err(Error::InvalidBlock)
+            Err(Error::NoOutputs)
         );
     }
 


### PR DESCRIPTION
Prior to this PR, `LedgerDB` would store a serialized `BlockContents` object for each block. This contains redundant data, as key images and TxOuts are already stored separately. The change proposed here removes this redundancy, effectively achieving almost x2 size reduction in stored ledger size.

**This is a breaking change as it changes the ledger LMDB format**.