### PR TITLE
Fix usage of tombstone parameter in mob_client.py

### DIFF
--- a/mobilecoind/clients/python/mob_client.py
+++ b/mobilecoind/clients/python/mob_client.py
@@ -181,7 +181,8 @@ class mob_client:
                                         change_subaddress=change_subaddress,
                                         input_list=input_list,
                                         outlay_list=outlay_list,
-                                        fee=fee)
+                                        fee=fee,
+                                        tombstone=tombstone)
         return self.stub.GenerateTx(request).tx_proposal
 
     def generate_optimization_tx(self, monitor_id, subaddress):


### PR DESCRIPTION
The `mob_client.generate_tx()` function in `mob_client.py` isn't passing the `tombstone` parameter through to the grpc call. This PR fixes that.