### PR TITLE
MC-539 Transaction domain separator tags

### DIFF
--- a/transaction/core/src/amount.rs
+++ b/transaction/core/src/amount.rs
@@ -7,7 +7,10 @@
 
 #![cfg_attr(test, allow(clippy::unnecessary_operation))]
 
-use crate::{ring_signature::CurveScalar, CompressedCommitment};
+use crate::{
+    domain_separators::AMOUNT_BLINDING_DOMAIN_TAG, ring_signature::CurveScalar,
+    CompressedCommitment,
+};
 use blake2::{Blake2b, Digest};
 use curve25519_dalek::scalar::Scalar;
 use digestible::Digestible;
@@ -24,12 +27,6 @@ pub enum AmountError {
     #[fail(display = "Inconsistent Commitment")]
     InconsistentCommitment,
 }
-
-/// Value mask hash function domain separator.
-const VALUE_MASK: &str = "amount_value_mask";
-
-/// Blinding mask hash function domain separator.
-const BLINDING_MASK: &str = "amount_blinding";
 
 // The "blinding factor" in a Pedersen commitment.
 pub type Blinding = CurveScalar;
@@ -116,7 +113,7 @@ impl Amount {
 /// * `shared_secret` - The shared secret, e.g. `rB`.
 fn get_value_mask(shared_secret: &RistrettoPublic) -> Scalar {
     let mut hasher = Blake2b::new();
-    hasher.input(&VALUE_MASK);
+    hasher.input(&AMOUNT_VALUE_DOMAIN_TAG);
     hasher.input(&shared_secret.to_bytes());
     Scalar::from_hash(hasher)
 }
@@ -127,7 +124,7 @@ fn get_value_mask(shared_secret: &RistrettoPublic) -> Scalar {
 /// * `shared_secret` - The shared secret, e.g. `rB`.
 fn get_blinding(shared_secret: &RistrettoPublic) -> Scalar {
     let mut hasher = Blake2b::new();
-    hasher.input(&BLINDING_MASK);
+    hasher.input(&AMOUNT_BLINDING_DOMAIN_TAG);
     hasher.input(&shared_secret.to_bytes());
     Scalar::from_hash(hasher)
 }

--- a/transaction/core/src/amount.rs
+++ b/transaction/core/src/amount.rs
@@ -8,7 +8,8 @@
 #![cfg_attr(test, allow(clippy::unnecessary_operation))]
 
 use crate::{
-    domain_separators::AMOUNT_BLINDING_DOMAIN_TAG, ring_signature::CurveScalar,
+    domain_separators::{AMOUNT_BLINDING_DOMAIN_TAG, AMOUNT_VALUE_DOMAIN_TAG},
+    ring_signature::CurveScalar,
     CompressedCommitment,
 };
 use blake2::{Blake2b, Digest};

--- a/transaction/core/src/domain_separators.rs
+++ b/transaction/core/src/domain_separators.rs
@@ -2,7 +2,7 @@
 
 //! Domain separation tags for hash functions used in the MobileCoin transaction protocol.
 //!
-//! Domain separation allows multiple distinct hash functions to be derived a single base function:
+//! Domain separation allows multiple distinct hash functions to be derived from a single base function:
 //!   Hash_1(X) = Hash("Hash_1" || X),
 //!   Hash_2(X) = Hash("Hash_2" || X),
 //!   etc.

--- a/transaction/core/src/domain_separators.rs
+++ b/transaction/core/src/domain_separators.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! Domain separation tags for hash functions used in the MobileCoin transaction protocol.
+//!
+//! Domain separation allows multiple distinct hash functions to be derived a single base function:
+//!   Hash_1(X) = Hash("Hash_1" || X),
+//!   Hash_2(X) = Hash("Hash_2" || X),
+//!   etc.
+//!
+//! Here, "Hash_1" and "Hash_2" are called domain separation tags. Tags should uniquely identify
+//! the hash function within the protocol and should include the protocol's version so that each
+//! derived hash function is independent of others within the protocol and independent of hash
+//! functions in other versions of the protocol.
+
+/// Domain separator for Amount's value mask hash function.
+pub const AMOUNT_VALUE_DOMAIN_TAG: &str = "mc_amount_value_v0";
+
+/// Domain separator for Amount's blinding mask hash function.
+pub const AMOUNT_BLINDING_DOMAIN_TAG: &str = "mc_amount_blinding_v0";
+
+// TODO:
+// pub const HASH_TO_POINT_DOMAIN_TAG: &str = "mc_hash_to_point_v0";
+
+// TODO:
+// pub const TXOUT_MERKLE_LEAF_DOMAIN_TAG: &str = "mc_tx_out_merkle_leaf_v0";
+// pub const TXOUT_MERKLE_NODE_DOMAIN_TAG: &str = "mc_tx_out_merkle_node_v0";
+// pub const TXOUT_MERKLE_NIL_DOMAIN_TAG: &str = "mc_tx_out_merkle_nil_v0";
+
+/// Domain separator for RingMLSAG's challenges.
+pub const RING_MLSAG_CHALLENGE_DOMAIN_TAG: &str = "mc_ring_mlsag_challenge_v0";

--- a/transaction/core/src/domain_separators.rs
+++ b/transaction/core/src/domain_separators.rs
@@ -8,23 +8,27 @@
 //!   etc.
 //!
 //! Here, "Hash_1" and "Hash_2" are called domain separation tags. Tags should uniquely identify
-//! the hash function within the protocol and should include the protocol's version so that each
+//! the hash function within the protocol and may include the protocol's version so that each
 //! derived hash function is independent of others within the protocol and independent of hash
 //! functions in other versions of the protocol.
 
 /// Domain separator for Amount's value mask hash function.
-pub const AMOUNT_VALUE_DOMAIN_TAG: &str = "mc_amount_value_v0";
+pub const AMOUNT_VALUE_DOMAIN_TAG: &str = "mc_amount_value";
 
 /// Domain separator for Amount's blinding mask hash function.
-pub const AMOUNT_BLINDING_DOMAIN_TAG: &str = "mc_amount_blinding_v0";
+pub const AMOUNT_BLINDING_DOMAIN_TAG: &str = "mc_amount_blinding";
 
 // TODO:
-// pub const HASH_TO_POINT_DOMAIN_TAG: &str = "mc_hash_to_point_v0";
+// pub const HASH_TO_POINT_DOMAIN_TAG: &str = "mc_hash_to_point";
 
-// TODO:
-// pub const TXOUT_MERKLE_LEAF_DOMAIN_TAG: &str = "mc_tx_out_merkle_leaf_v0";
-// pub const TXOUT_MERKLE_NODE_DOMAIN_TAG: &str = "mc_tx_out_merkle_node_v0";
-// pub const TXOUT_MERKLE_NIL_DOMAIN_TAG: &str = "mc_tx_out_merkle_nil_v0";
+/// Domain separator for hashing a TxOut leaf node in a Merkle tree.
+pub const TXOUT_MERKLE_LEAF_DOMAIN_TAG: &str = "mc_tx_out_merkle_leaf";
+
+/// Domain separator for hashing internal hash values in a Merkle tree.
+pub const TXOUT_MERKLE_NODE_DOMAIN_TAG: &str = "mc_tx_out_merkle_node";
+
+/// Domain separator for hashing the "nil" value in a Merkle tree.
+pub const TXOUT_MERKLE_NIL_DOMAIN_TAG: &str = "mc_tx_out_merkle_nil";
 
 /// Domain separator for RingMLSAG's challenges.
-pub const RING_MLSAG_CHALLENGE_DOMAIN_TAG: &str = "mc_ring_mlsag_challenge_v0";
+pub const RING_MLSAG_CHALLENGE_DOMAIN_TAG: &str = "mc_ring_mlsag_challenge";

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -22,6 +22,7 @@ mod blockchain;
 mod commitment;
 mod compressed_commitment;
 pub mod constants;
+mod domain_separators;
 pub mod encrypted_fog_hint;
 pub mod fog_hint;
 pub mod membership_proofs;

--- a/transaction/core/src/membership_proofs/mod.rs
+++ b/transaction/core/src/membership_proofs/mod.rs
@@ -15,14 +15,17 @@ use crate::{
 use alloc::vec::Vec;
 use blake2::digest::Input;
 use common::HashMap;
+use mcserial::serialize;
+mod errors;
+use crate::{
+    blake2b_256::Blake2b256,
+    domain_separators::{
+        TXOUT_MERKLE_LEAF_DOMAIN_TAG, TXOUT_MERKLE_NIL_DOMAIN_TAG, TXOUT_MERKLE_NODE_DOMAIN_TAG,
+    },
+};
 use core::convert::TryInto;
 use digestible::Digestible;
 pub use errors::Error as MembershipProofError;
-
-// Hash function Ddomain separators.
-const TXOUT_MERKLE_LEAF: &str = "mc_txout_merkle_leaf";
-const TXOUT_MERKLE_NODE: &str = "mc_txout_merkle_node";
-const TXOUT_MERKLE_NIL: &str = "mc_txout_merkle_nil";
 
 lazy_static! {
     pub static ref NIL_HASH: [u8; 32] = hash_nil();
@@ -31,7 +34,7 @@ lazy_static! {
 /// Merkle tree hash function for a leaf node.
 pub fn hash_leaf(tx_out: &TxOut) -> [u8; 32] {
     let mut hasher = Blake2b256::new();
-    hasher.input(&TXOUT_MERKLE_LEAF);
+    hasher.input(&TXOUT_MERKLE_LEAF_DOMAIN_TAG);
     tx_out.digest(&mut hasher);
     hasher.result().try_into().unwrap()
 }
@@ -39,7 +42,7 @@ pub fn hash_leaf(tx_out: &TxOut) -> [u8; 32] {
 /// Merkle tree hash function for an internal node.
 pub fn hash_nodes(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
     let mut hasher = Blake2b256::new();
-    hasher.input(&TXOUT_MERKLE_NODE);
+    hasher.input(&TXOUT_MERKLE_NODE_DOMAIN_TAG);
     hasher.input(left);
     hasher.input(right);
     hasher.result().try_into().unwrap()
@@ -48,7 +51,7 @@ pub fn hash_nodes(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
 /// Merkle tree Hash function for hashing a "nil" value.
 fn hash_nil() -> [u8; 32] {
     let mut hasher = Blake2b256::new();
-    hasher.input(&TXOUT_MERKLE_NIL);
+    hasher.input(&TXOUT_MERKLE_NIL_DOMAIN_TAG);
     hasher.result().try_into().unwrap()
 }
 

--- a/transaction/core/src/membership_proofs/mod.rs
+++ b/transaction/core/src/membership_proofs/mod.rs
@@ -4,10 +4,11 @@
 
 extern crate alloc;
 
-mod errors;
-
 use crate::{
     blake2b_256::Blake2b256,
+    domain_separators::{
+        TXOUT_MERKLE_LEAF_DOMAIN_TAG, TXOUT_MERKLE_NIL_DOMAIN_TAG, TXOUT_MERKLE_NODE_DOMAIN_TAG,
+    },
     membership_proofs::errors::Error,
     range::Range,
     tx::{TxOut, TxOutMembershipHash, TxOutMembershipProof},
@@ -15,17 +16,11 @@ use crate::{
 use alloc::vec::Vec;
 use blake2::digest::Input;
 use common::HashMap;
-use mcserial::serialize;
-mod errors;
-use crate::{
-    blake2b_256::Blake2b256,
-    domain_separators::{
-        TXOUT_MERKLE_LEAF_DOMAIN_TAG, TXOUT_MERKLE_NIL_DOMAIN_TAG, TXOUT_MERKLE_NODE_DOMAIN_TAG,
-    },
-};
 use core::convert::TryInto;
 use digestible::Digestible;
 pub use errors::Error as MembershipProofError;
+
+mod errors;
 
 lazy_static! {
     pub static ref NIL_HASH: [u8; 32] = hash_nil();


### PR DESCRIPTION
Collects domain separator tags into a central place so that they can be standardized, documented, etc.

This PR moves the existing domain separators. Other PRs will add more where needed.