### PR TITLE
KeyImage cleanup

### DIFF
--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -417,7 +417,6 @@ pub fn key_bytes_to_u64(bytes: &[u8]) -> u64 {
 mod ledger_db_test {
     use super::*;
     use core::convert::TryFrom;
-    use curve25519_dalek::ristretto::RistrettoPoint;
     use keys::RistrettoPrivate;
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
@@ -567,9 +566,7 @@ mod ledger_db_test {
             })
             .collect();
 
-        let key_images: Vec<KeyImage> = (0..5)
-            .map(|_i| KeyImage::from(RistrettoPoint::random(&mut rng)))
-            .collect();
+        let key_images: Vec<KeyImage> = (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
 
         let block_contents = BlockContents::new(key_images.clone(), outputs);
         let block = Block::new(
@@ -682,7 +679,7 @@ mod ledger_db_test {
         let account_key = AccountKey::random(&mut rng);
         let num_key_images = 3;
         let key_images: Vec<KeyImage> = (0..num_key_images)
-            .map(|_i| KeyImage::from(RistrettoPoint::random(&mut rng)))
+            .map(|_i| KeyImage::from(rng.next_u64()))
             .collect();
 
         let tx_out = TxOut::new(
@@ -728,7 +725,7 @@ mod ledger_db_test {
         let account_key = AccountKey::random(&mut rng);
         let num_key_images = 3;
         let key_images: Vec<KeyImage> = (0..num_key_images)
-            .map(|_i| KeyImage::from(RistrettoPoint::random(&mut rng)))
+            .map(|_i| KeyImage::from(rng.next_u64()))
             .collect();
 
         let tx_out = TxOut::new(
@@ -776,7 +773,7 @@ mod ledger_db_test {
         // Write the next block, containing several key images but no outputs.
         let num_key_images = 3;
         let key_images: Vec<KeyImage> = (0..num_key_images)
-            .map(|_i| KeyImage::from(RistrettoPoint::random(&mut rng)))
+            .map(|_i| KeyImage::from(rng.next_u64()))
             .collect();
 
         let outputs = Vec::new();
@@ -833,7 +830,7 @@ mod ledger_db_test {
         let blocks = populate_db(&mut ledger_db, n_blocks, 2);
         assert_eq!(ledger_db.num_blocks().unwrap(), n_blocks);
 
-        let key_images = vec![KeyImage::from(RistrettoPoint::random(&mut rng))];
+        let key_images = vec![KeyImage::from(rng.next_u64())];
 
         let tx_out = TxOut::new(
             100,
@@ -887,7 +884,7 @@ mod ledger_db_test {
         let account_key = AccountKey::random(&mut rng);
         let num_key_images = 3;
         let block_one_key_images: Vec<KeyImage> = (0..num_key_images)
-            .map(|_i| KeyImage::from(RistrettoPoint::random(&mut rng)))
+            .map(|_i| KeyImage::from(rng.next_u64()))
             .collect();
 
         let block_one_contents = {
@@ -988,7 +985,7 @@ mod ledger_db_test {
             )
             .unwrap();
 
-            let key_images = vec![KeyImage::from(RistrettoPoint::random(&mut rng))];
+            let key_images = vec![KeyImage::from(rng.next_u64())];
             let block_contents = BlockContents::new(key_images, vec![tx_out]);
 
             let bytes = [14u8; 32];

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -2,10 +2,10 @@
 
 use crate::{Error, Ledger};
 use common::{HashMap, HashSet};
-use curve25519_dalek::ristretto::RistrettoPoint;
 use keys::RistrettoPrivate;
 use mc_util_from_random::FromRandom;
 use rand::{rngs::StdRng, SeedableRng};
+use rand_core::RngCore;
 use std::{
     iter::FromIterator,
     sync::{Arc, Mutex, MutexGuard},
@@ -217,7 +217,7 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
             .unwrap();
 
             let outputs = vec![tx_out];
-            let key_images = vec![KeyImage::from(RistrettoPoint::random(&mut rng))];
+            let key_images = vec![KeyImage::from(rng.next_u64())];
             let block_contents = BlockContents::new(key_images, outputs);
 
             let block = Block::new(

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -25,7 +25,8 @@ use std::{
 use transaction::{
     account_keys::{AccountKey, PublicAddress},
     constants::{BASE_FEE, MAX_INPUTS, RING_SIZE},
-    onetime_keys::{compute_key_image, recover_onetime_private_key},
+    onetime_keys::recover_onetime_private_key,
+    ring_signature::KeyImage,
     tx::{Tx, TxOut, TxOutMembershipProof},
     BlockIndex,
 };
@@ -627,7 +628,7 @@ impl<T: UserTxConnection + 'static> TransactionsManager<T> {
                 &from_account_key.subaddress_spend_key(utxo.subaddress_index),
             );
 
-            let key_image = compute_key_image(&onetime_private_key);
+            let key_image = KeyImage::from(&onetime_private_key);
             log::debug!(
                 logger,
                 "Adding input: ring {:?}, utxo index {:?}, key image {:?}, pubkey {:?}",

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1059,7 +1059,7 @@ mod test {
         account_keys::{AccountKey, PublicAddress, DEFAULT_SUBADDRESS_INDEX},
         constants::{BASE_FEE, MAX_INPUTS, RING_SIZE},
         get_tx_out_shared_secret,
-        onetime_keys::{compute_key_image, recover_onetime_private_key},
+        onetime_keys::recover_onetime_private_key,
         tx::{Tx, TxOut},
         Block, BlockContents, BlockIndex, BLOCK_VERSION,
     };
@@ -1331,7 +1331,7 @@ mod test {
                     account_key.view_private_key(),
                     &account_key.subaddress_spend_key(0),
                 );
-                let key_image = compute_key_image(&onetime_private_key);
+                let key_image = KeyImage::from(&onetime_private_key);
 
                 // Craft the expected UnspentTxOut
                 UnspentTxOut {

--- a/mobilecoind/src/sync.rs
+++ b/mobilecoind/src/sync.rs
@@ -40,7 +40,8 @@ use std::{
 };
 use transaction::{
     get_tx_out_shared_secret,
-    onetime_keys::{compute_key_image, recover_onetime_private_key, subaddress_for_key},
+    onetime_keys::{recover_onetime_private_key, subaddress_for_key},
+    ring_signature::KeyImage,
     tx::TxOut,
 };
 
@@ -388,7 +389,7 @@ fn match_tx_outs_into_utxos(
             &account_key.subaddress_spend_key(subaddress_id.index),
         );
 
-        let key_image = compute_key_image(&onetime_private_key);
+        let key_image = KeyImage::from(&onetime_private_key);
 
         results.push(UnspentTxOut {
             tx_out: tx_out.clone(),

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -121,27 +121,6 @@ pub fn recover_onetime_private_key(
     RistrettoPrivate::from(x)
 }
 
-/// Computes the (compressed) Key Image `I = x*Hp(x*G)` for a private key `x`.
-///
-/// # Arguments
-/// * `private_key` - A private key `x`.
-pub fn compute_key_image(private_key: &RistrettoPrivate) -> KeyImage {
-    let uncompressed_key_image = compute_key_image_uncompressed(private_key);
-    KeyImage::from(uncompressed_key_image)
-}
-
-/// Computes the (uncompressed) Key Image `I = x*Hp(x*G)` for a private key `x`.
-///
-/// # Arguments
-/// * `private_key` - A private key `x`.
-pub fn compute_key_image_uncompressed(private_key: &RistrettoPrivate) -> RistrettoPoint {
-    let x = private_key.as_ref();
-    // The compressed encoding is canonical.
-    let P: CompressedRistretto = RistrettoPublic::from(private_key).as_ref().compress();
-    let Hp = RistrettoPoint::hash_from_bytes::<Blake2b>(P.as_bytes());
-    x * Hp
-}
-
 /// Computes the shared secret `aB` from a private key `a` and a public key `B`.
 ///
 /// # Arguments

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -23,7 +23,6 @@ use serde::{Deserialize, Serialize};
 use crate::{
     commitment::Commitment,
     compressed_commitment::CompressedCommitment,
-    onetime_keys::compute_key_image,
     ring_signature::{CurveScalar, Error, KeyImage, Scalar, GENERATORS},
 };
 
@@ -121,7 +120,7 @@ impl RingMLSAG {
         let G = GENERATORS.B;
         let H = GENERATORS.B_blinding;
 
-        let key_image = compute_key_image(onetime_private_key);
+        let key_image = KeyImage::from(onetime_private_key);
 
         // The uncompressed key_image.
         let I: RistrettoPoint = key_image.try_into().expect("key_image should decompress");
@@ -330,9 +329,8 @@ fn decompress_ring(
 #[cfg(test)]
 mod mlsag_tests {
     use crate::{
-        onetime_keys::compute_key_image,
         proptest_fixtures::*,
-        ring_signature::{mlsag::RingMLSAG, CurveScalar, Error, Scalar, GENERATORS},
+        ring_signature::{mlsag::RingMLSAG, CurveScalar, Error, KeyImage, Scalar, GENERATORS},
         CompressedCommitment,
     };
     use alloc::vec::Vec;
@@ -458,7 +456,7 @@ mod mlsag_tests {
             )
             .unwrap();
 
-            let expected_key_image = compute_key_image(&params.onetime_private_key);
+            let expected_key_image = KeyImage::from(&params.onetime_private_key);
             assert_eq!(signature.key_image, expected_key_image);
         }
 
@@ -670,7 +668,7 @@ mod mlsag_tests {
             .unwrap();
 
             // Modify the key image.
-            let wrong_key_image = compute_key_image(&RistrettoPrivate::from_random(&mut rng));
+            let wrong_key_image = KeyImage::from(rng.next_u64());
             signature.key_image = wrong_key_image;
 
             let output_commitment = CompressedCommitment::new(params.value, params.pseudo_output_blinding);

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -123,7 +123,7 @@ impl RingMLSAG {
         let key_image = KeyImage::from(onetime_private_key);
 
         // The uncompressed key_image.
-        let I: RistrettoPoint = key_image.try_into().expect("key_image should decompress");
+        let I: RistrettoPoint = key_image.point.decompress().ok_or(Error::InvalidKeyImage)?;
 
         // Uncompressed output commitment.
         // This ensures that each address and commitment encodes a valid Ristretto point.
@@ -243,8 +243,9 @@ impl RingMLSAG {
         // This ensures that the key image encodes a valid Ristretto point.
         let I: RistrettoPoint = self
             .key_image
-            .try_into()
-            .map_err(|_e| Error::InvalidKeyImage)?;
+            .point
+            .decompress()
+            .ok_or(Error::InvalidKeyImage)?;
 
         let r: Vec<Scalar> = self
             .responses

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -592,7 +592,7 @@ mod rct_bulletproofs_tests {
 
             // Modify an MLSAG ring signature
             let index = rng.next_u64() as usize % (num_inputs);
-            signature.ring_signatures[index].key_image = KeyImage::from(RistrettoPoint::random(&mut rng));
+            signature.ring_signatures[index].key_image = KeyImage::from(rng.next_u64());
 
             let result = signature.verify(
                 &params.message,

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -32,7 +32,6 @@ use serde::{Deserialize, Serialize};
 use crate::{
     commitment::Commitment,
     compressed_commitment::CompressedCommitment,
-    onetime_keys::compute_key_image,
     range_proofs::{check_range_proofs, generate_range_proofs},
     ring_signature::{mlsag::RingMLSAG, CurveScalar, Error, KeyImage, Scalar, GENERATORS},
 };

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -243,6 +243,7 @@ pub mod transaction_builder_tests {
         account_keys::{AccountKey, DEFAULT_SUBADDRESS_INDEX},
         get_tx_out_shared_secret,
         onetime_keys::*,
+        ring_signature::KeyImage,
         tx::TxOutMembershipProof,
         validation::validate_transaction_signature,
     };
@@ -298,7 +299,7 @@ pub mod transaction_builder_tests {
             &alice.subaddress_spend_key(DEFAULT_SUBADDRESS_INDEX),
         );
 
-        let key_image = compute_key_image(&onetime_private_key);
+        let key_image = KeyImage::from(&onetime_private_key);
 
         let membership_proofs: Vec<TxOutMembershipProof> = ring
             .iter()

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -1,10 +1,9 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
-use curve25519_dalek::ristretto::RistrettoPoint;
 use keys::RistrettoPrivate;
 use ledger_db::{Ledger, LedgerDB};
 use mc_util_from_random::FromRandom;
-use rand::SeedableRng;
+use rand::{RngCore, SeedableRng};
 use rand_hc::Hc128Rng as FixedRng;
 use std::{path::PathBuf, vec::Vec};
 use transaction::{
@@ -61,7 +60,7 @@ pub fn bootstrap_ledger(
         }
 
         let key_images: Vec<KeyImage> = (0..key_images_per_block)
-            .map(|_i| KeyImage::from(RistrettoPoint::random(&mut rng)))
+            .map(|_i| KeyImage::from(rng.next_u64()))
             .collect();
 
         let block_contents = BlockContents::new(key_images, outputs.clone());


### PR DESCRIPTION
Replaces some "compute_key_image" functions with KeyImage::from. I think this makes it easier to figure out how to use KeyImage by reading key_image.rs .