### PR TITLE
MC-1344 Merkle proofs omit nil hashes

### DIFF
--- a/transaction/core/src/membership_proofs/mod.rs
+++ b/transaction/core/src/membership_proofs/mod.rs
@@ -141,8 +141,6 @@ pub fn is_membership_proof_valid(
                     // Missing hashes are assumed to be the Nil hash, indicating that the range of
                     // TxOuts do not exist yet.
                     &NIL_HASH
-                    // // Proof does not contain a required hash.
-                    // return Ok(false);
                 }
             };
 


### PR DESCRIPTION
Allows Merkle proofs in transactions to omit hash values that can be inferred by the consensus enclave.

Many of the hashes in each Merkle proof are likely to be "Nil" hashes, which correspond to "missing" leaves compared to a complete binary tree. These Nils can be inferred server-side. Omitting them may be a significant savings in transaction size.