### PR TITLE
LedgerDB: Store `BlockSignature` as proto-encoded instead of cbor-encoded 

### DIFF
--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -219,7 +219,7 @@ impl ReprBytes32 for Ed25519Public {
     type Error = SignatureError;
 
     fn to_bytes(&self) -> [u8; 32] {
-        <Self as AsRef<[u8; PUBLIC_KEY_LENGTH]>>::as_ref(self).clone()
+        *<Self as AsRef<[u8; PUBLIC_KEY_LENGTH]>>::as_ref(self)
     }
 
     fn from_bytes(src: &[u8; 32]) -> Result<Self, <Self as ReprBytes32>::Error> {

--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -431,6 +431,14 @@ impl AsRef<[u8]> for Ed25519Signature {
     }
 }
 
+impl<'a> TryFrom<&'a [u8]> for Ed25519Signature {
+    type Error = Ed25519SignatureError;
+
+    fn try_from(bytes: &'a [u8]) -> Result<Self, Error> {
+        Ok(Self(Signature::try_from(bytes)?))
+    }
+}
+
 impl Message for Ed25519Signature {
     fn encode_raw<B>(&self, buf: &mut B)
     where

--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -24,7 +24,7 @@ use ed25519_dalek::{
 };
 use mc_crypto_digestible::Digestible;
 use mc_util_from_random::FromRandom;
-use mc_util_serial::deduce_core_traits_from_public_bytes;
+use mc_util_serial::{deduce_core_traits_from_public_bytes, prost_message_helper32, ReprBytes32};
 use prost::{
     bytes::{Buf, BufMut},
     encoding::{bytes, skip_field, DecodeContext, WireType},
@@ -214,6 +214,20 @@ impl TryFrom<&[u8]> for Ed25519Public {
         ))
     }
 }
+
+impl ReprBytes32 for Ed25519Public {
+    type Error = SignatureError;
+
+    fn to_bytes(&self) -> [u8; 32] {
+        <Self as AsRef<[u8; PUBLIC_KEY_LENGTH]>>::as_ref(self).clone()
+    }
+
+    fn from_bytes(src: &[u8; 32]) -> Result<Self, <Self as ReprBytes32>::Error> {
+        Self::try_from(&src[..])
+    }
+}
+
+prost_message_helper32! { Ed25519Public }
 
 /// An Ed25519 private key
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -177,7 +177,7 @@ impl Ledger for LedgerDB {
         let db_transaction = self.env.begin_ro_txn()?;
         let key = u64_to_key_bytes(block_number);
         let signature_bytes = db_transaction.get(self.block_signatures, &key)?;
-        let signature = mcserial::decode(&signature_bytes)?;
+        let signature = mc_util_serial::decode(&signature_bytes)?;
         Ok(signature)
     }
 
@@ -330,7 +330,7 @@ impl LedgerDB {
             db_transaction.put(
                 self.block_signatures,
                 &u64_to_key_bytes(block.index),
-                &mcserial::encode(signature),
+                &mc_util_serial::encode(signature),
                 WriteFlags::empty(),
             )?;
         }

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -177,7 +177,7 @@ impl Ledger for LedgerDB {
         let db_transaction = self.env.begin_ro_txn()?;
         let key = u64_to_key_bytes(block_number);
         let signature_bytes = db_transaction.get(self.block_signatures, &key)?;
-        let signature = deserialize(&signature_bytes)?;
+        let signature = mcserial::decode(&signature_bytes)?;
         Ok(signature)
     }
 
@@ -330,9 +330,7 @@ impl LedgerDB {
             db_transaction.put(
                 self.block_signatures,
                 &u64_to_key_bytes(block.index),
-                &serialize(signature).unwrap_or_else(|_| {
-                    panic!("Could not serialize block signature {:?}", signature)
-                }),
+                &mcserial::encode(signature),
                 WriteFlags::empty(),
             )?;
         }

--- a/transaction/core/src/blockchain/block_signature.rs
+++ b/transaction/core/src/blockchain/block_signature.rs
@@ -1,22 +1,25 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use crate::Block;
-use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
+use core::fmt::{Display, Formatter, Result as FmtResult};
 use mc_crypto_digestible::Digestible;
 use mc_crypto_keys::{
     DigestSigner, DigestVerifier, Ed25519Pair, Ed25519Public, Ed25519Signature,
     Ed25519SignatureError,
 };
+use prost::Message;
 use serde::{Deserialize, Serialize};
 use sha2::Sha512;
 
 /// A block signature.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Message)]
 pub struct BlockSignature {
     /// The actual signature of the block.
+    #[prost(message, required, tag = "1")]
     signature: Ed25519Signature,
 
     /// The public key of the keypair used to generate the signature.
+    #[prost(message, required, tag = "2")]
     signer: Ed25519Public,
 }
 
@@ -69,17 +72,6 @@ impl Display for BlockSignature {
         write!(
             f,
             "{}:{}",
-            hex_fmt::HexFmt(&self.signature),
-            hex_fmt::HexFmt(&self.signer)
-        )
-    }
-}
-
-impl Debug for BlockSignature {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        write!(
-            f,
-            "BlockSignature({}:{})",
             hex_fmt::HexFmt(&self.signature),
             hex_fmt::HexFmt(&self.signer)
         )


### PR DESCRIPTION
Another incremental step at making the ledger db contents be backed by protos.

Sadly this involves ugly wrappers.

**This is a breaking change as it changes the ledger format.**