### PR TITLE
Increases BulletproofGens party_size to allow large transactions

### DIFF
--- a/transaction/core/src/constants.rs
+++ b/transaction/core/src/constants.rs
@@ -9,10 +9,10 @@ pub const MAX_TRANSACTIONS_PER_BLOCK: usize = 5000;
 pub const RING_SIZE: usize = 11;
 
 /// Each transaction must contain no more than this many inputs (rings).
-pub const MAX_INPUTS: u16 = 16;
+pub const MAX_INPUTS: u64 = 16;
 
 /// Each transaction must contain no more than this many outputs.
-pub const MAX_OUTPUTS: u16 = 16;
+pub const MAX_OUTPUTS: u64 = 16;
 
 /// Maximum number of blocks in the future a transaction's tombstone block can be set to.
 pub const MAX_TOMBSTONE_BLOCKS: u64 = 100;

--- a/transaction/core/src/ring_signature/mod.rs
+++ b/transaction/core/src/ring_signature/mod.rs
@@ -12,8 +12,6 @@ pub use key_image::*;
 pub use mlsag::*;
 pub use rct_bulletproofs::*;
 
-use crate::constants::{MAX_INPUTS, MAX_OUTPUTS};
-
 mod curve_scalar;
 mod error;
 mod key_image;
@@ -25,6 +23,8 @@ lazy_static! {
     pub static ref GENERATORS: PedersenGens = PedersenGens::default();
 
     /// Generators (base points) for Bulletproofs.
+    /// The `party_capacity` is the maximum number of values in one proof. It should
+    /// be at least 2 * num_inputs + num_outputs + 1, which allows for inputs, pseudo outputs, outputs, and the fee.
     pub static ref BP_GENERATORS: BulletproofGens =
-        BulletproofGens::new(64, MAX_INPUTS as usize + MAX_OUTPUTS as usize);
+        BulletproofGens::new(64, 64);
 }

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -57,7 +57,7 @@ pub fn validate<R: RngCore + CryptoRng>(
 /// The transaction must have at least one input, and no more than the maximum allowed number of inputs.
 fn validate_number_of_inputs(
     tx_prefix: &TxPrefix,
-    maximum_allowed_inputs: u16,
+    maximum_allowed_inputs: u64,
 ) -> TransactionValidationResult<()> {
     let num_inputs = tx_prefix.inputs.len();
 
@@ -77,7 +77,7 @@ fn validate_number_of_inputs(
 /// The transaction must have at least one output.
 fn validate_number_of_outputs(
     tx_prefix: &TxPrefix,
-    maximum_allowed_outputs: u16,
+    maximum_allowed_outputs: u64,
 ) -> TransactionValidationResult<()> {
     let num_outputs = tx_prefix.outputs.len();
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -302,8 +302,6 @@ pub mod transaction_builder_tests {
                 &sender.subaddress_spend_key(DEFAULT_SUBADDRESS_INDEX),
             );
 
-            let key_image = KeyImage::from(&onetime_private_key);
-
             let membership_proofs: Vec<TxOutMembershipProof> = ring
                 .iter()
                 .map(|_tx_out| {

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -71,12 +71,6 @@ impl TransactionBuilder {
 
         self.outputs.push(tx_out.clone());
         self.output_shared_secrets.push(shared_secret);
-
-        // TODO: sort outputs and their corresponding secrets.
-        // Sort outputs by public_key. This removes ordering information that could be used to
-        // infer things like the identity of a "change" output.
-        // outputs.sort_by(|a, b| a.public_key.cmp(&b.public_key));
-
         Ok(tx_out)
     }
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -280,7 +280,6 @@ pub mod transaction_builder_tests {
     }
 
     // Uses TransactionBuilder to build a transaction.
-    #[allow(unused)]
     fn get_transaction<RNG: RngCore + CryptoRng>(
         num_inputs: usize,
         num_outputs: usize,


### PR DESCRIPTION
Previously, signing a transaction with 16 inputs and 16 outputs (the max currently allowed) would fail.