### PR TITLE
Add rpc response type to allow unknown peers without error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,6 +2434,7 @@ dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-common 0.1.5-alpha-1",
  "mc-connection 0.1.5-alpha-1",
+ "mc-consensus-api 0.1.5-alpha-1",
  "mc-consensus-enclave-api 0.1.5-alpha-1",
  "mc-consensus-scp 0.1.5-alpha-1",
  "mc-crypto-keys 0.1.5-alpha-1",

--- a/consensus/api/proto/consensus_peer.proto
+++ b/consensus/api/proto/consensus_peer.proto
@@ -16,7 +16,7 @@ service ConsensusPeerAPI {
     rpc PeerTxPropose(attest.Message) returns (consensus_common.ProposeTxResponse);
 
     /// Feed a consensus message into the node.
-    rpc SendConsensusMsg (ConsensusMsg) returns (google.protobuf.Empty) {}
+    rpc SendConsensusMsg (ConsensusMsg) returns (ConsensusMsgResponse) {}
 
     /// Fetch the latest SCP message a node has issued.
     rpc FetchLatestMsg (google.protobuf.Empty) returns (FetchLatestMsgResponse) {}
@@ -33,6 +33,17 @@ message ConsensusMsg {
 
     // Serialized peers::ConsensusMsg.
     bytes payload = 2;
+}
+
+enum ConsensusMsgResult {
+    Ok = 0;
+    UnknownPeer = 10;
+}
+
+/// Response from a ConsensusMsg RPC call.
+message ConsensusMsgResponse {
+    /// Result.
+    ConsensusMsgResult result = 1;
 }
 
 message FetchLatestMsgResponse {

--- a/peers/src/connection.rs
+++ b/peers/src/connection.rs
@@ -22,7 +22,10 @@ use mc_connection::{
 use mc_consensus_api::{
     blockchain::BlocksRequest,
     blockchain_grpc::BlockchainApiClient,
-    consensus_peer::{ConsensusMsg as GrpcConsensusMsg, FetchTxsRequest as GrpcFetchTxsRequest},
+    consensus_peer::{
+        ConsensusMsg as GrpcConsensusMsg, ConsensusMsgResponse,
+        FetchTxsRequest as GrpcFetchTxsRequest,
+    },
     consensus_peer_grpc::ConsensusPeerApiClient,
     empty::Empty,
 };
@@ -231,13 +234,14 @@ impl<Enclave: ConsensusEnclaveProxy> ConsensusConnection for PeerConnection<Encl
         self.local_node_id.clone()
     }
 
-    fn send_consensus_msg(&mut self, msg: &ConsensusMsg) -> Result<()> {
+    fn send_consensus_msg(&mut self, msg: &ConsensusMsg) -> Result<ConsensusMsgResponse> {
         let mut grpc_msg = GrpcConsensusMsg::default();
         grpc_msg.set_from_responder_id(serialize(&self.local_node_id.responder_id)?);
         grpc_msg.set_payload(serialize(&msg)?);
 
-        self.attested_call(|this| this.consensus_api_client.send_consensus_msg(&grpc_msg))?;
-        Ok(())
+        let response =
+            self.attested_call(|this| this.consensus_api_client.send_consensus_msg(&grpc_msg))?;
+        Ok(response)
     }
 
     fn send_propose_tx(

--- a/peers/src/sync.rs
+++ b/peers/src/sync.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use mc_common::{NodeID, ResponderId};
 use mc_connection::{impl_sync_connection_retry, SyncConnection};
+use mc_consensus_api::consensus_peer::ConsensusMsgResponse;
 use mc_consensus_enclave_api::{TxContext, WellFormedEncryptedTx};
 use mc_transaction_core::tx::TxHash;
 use std::time::Duration;
@@ -24,7 +25,7 @@ impl<CC: ConsensusConnection> RetryableConsensusConnection for SyncConnection<CC
         &self,
         msg: &ConsensusMsg,
         retry_iterator: impl IntoIterator<Item = Duration>,
-    ) -> RetryResult<()> {
+    ) -> RetryResult<ConsensusMsgResponse> {
         impl_sync_connection_retry!(
             self.write(),
             self.logger(),

--- a/peers/src/traits.rs
+++ b/peers/src/traits.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use mc_common::{NodeID, ResponderId};
 use mc_connection::Connection;
+use mc_consensus_api::consensus_peer::ConsensusMsgResponse;
 use mc_consensus_enclave_api::{TxContext, WellFormedEncryptedTx};
 use mc_transaction_core::tx::TxHash;
 use std::time::Duration;
@@ -21,7 +22,7 @@ pub trait ConsensusConnection: Connection {
     fn local_node_id(&self) -> NodeID;
 
     /// Send the given consensus message to the remote peer.
-    fn send_consensus_msg(&mut self, msg: &ConsensusMsg) -> Result<()>;
+    fn send_consensus_msg(&mut self, msg: &ConsensusMsg) -> Result<ConsensusMsgResponse>;
 
     /// Send the given propose tx message to the remote peer.
     fn send_propose_tx(
@@ -47,7 +48,7 @@ pub trait RetryableConsensusConnection {
         &self,
         msg: &ConsensusMsg,
         retry_iterator: impl IntoIterator<Item = Duration>,
-    ) -> RetryResult<()>;
+    ) -> RetryResult<ConsensusMsgResponse>;
 
     /// Retryable version of the propose tx message transmitter
     fn send_propose_tx(

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 mc-common = { path = "../../common" }
 mc-connection = { path = "../../connection" }
+mc-consensus-api = { path = "../../consensus/api" }
 mc-consensus-enclave-api = { path = "../../consensus/enclave/api" }
 mc-consensus-scp = { path = "../../consensus/scp" }
 mc-crypto-keys = { path = "../../crypto/keys" }

--- a/peers/test-utils/src/lib.rs
+++ b/peers/test-utils/src/lib.rs
@@ -360,7 +360,7 @@ mod peer_manager_tests {
             .send_consensus_msg(&msg, Fibonacci::from_millis(10).take(7));
 
         match ret {
-            Ok(()) => panic!("should've failed"),
+            Ok(_) => panic!("should've failed"),
             Err(retry::Error::Operation { .. }) => {
                 // This is expected
             }


### PR DESCRIPTION
Fixes MC-1356.

Currently, peers receive an invalid argument gRPC error when sending consensus messages to a peer who does not know of them. However, it is expected that when a node is first joining the network, no other peers have added them to the `known_peers` section of the network.toml.

This change introduces a response type that allows for specifying the non-error case that the node is not yet known.