### PR TITLE
Switch from TempDir::into_path to TempDir::path

### DIFF
--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -465,8 +465,9 @@ mod ed25519_tests {
     #[test]
     #[ignore]
     fn validate_ed25519_priv_der_prefix() {
-        let tempdir = TempDir::new("keys").unwrap().into_path();
+        let tempdir = TempDir::new("keys").unwrap();
         let privder = tempdir
+            .path()
             .join("openssl-ed25519-private.der")
             .to_str()
             .unwrap()
@@ -501,13 +502,15 @@ mod ed25519_tests {
     #[test]
     #[ignore]
     fn validate_ed25519_pub_der_prefix() {
-        let tempdir = TempDir::new("keys").unwrap().into_path();
+        let tempdir = TempDir::new("keys").unwrap();
         let privkey = tempdir
+            .path()
             .join("openssl-ed25519-private.pem")
             .to_str()
             .unwrap()
             .to_string();
         let pubder = tempdir
+            .path()
             .join("openssl-ed25519-pubkey.der")
             .to_str()
             .unwrap()

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -68,16 +68,15 @@ pub fn get_test_databases(
 
     // Note that TempDir manages uniqueness by constructing paths
     // like: /tmp/ledger_db.tvF0XHTKsilx
-    let ledger_db_tmp = TempDir::new("ledger_db")
-        .expect("Could not make tempdir for ledger db")
-        .into_path();
+    let ledger_db_tmp = TempDir::new("ledger_db").expect("Could not make tempdir for ledger db");
     let ledger_db_path = ledger_db_tmp
+        .path()
         .to_str()
         .expect("Could not get path as string");
-    let mobilecoind_db_tmp = TempDir::new("mobilecoind_db")
-        .expect("Could not make tempdir for mobilecoind db")
-        .into_path();
+    let mobilecoind_db_tmp =
+        TempDir::new("mobilecoind_db").expect("Could not make tempdir for mobilecoind db");
     let mobilecoind_db_path = mobilecoind_db_tmp
+        .path()
         .to_str()
         .expect("Could not get path as string");
 

--- a/mobilecoind/src/utxo_store.rs
+++ b/mobilecoind/src/utxo_store.rs
@@ -435,10 +435,12 @@ mod test {
             .collect();
 
         // The instance to test.
-        let db_tmp = TempDir::new("utxo_store_db")
-            .expect("Could not make tempdir for utxo store db")
-            .into_path();
-        let db_path = db_tmp.to_str().expect("Could not get path as string");
+        let db_tmp =
+            TempDir::new("utxo_store_db").expect("Could not make tempdir for utxo store db");
+        let db_path = db_tmp
+            .path()
+            .to_str()
+            .expect("Could not get path as string");
 
         let env = Arc::new(
             Environment::new()

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -95,8 +95,8 @@ mod testing {
 
     #[test]
     fn test_default_generation() {
-        let dir1 = TempDir::new("test").unwrap().into_path();
-        let dir2 = TempDir::new("test").unwrap().into_path();
+        let dir1 = TempDir::new("test").unwrap();
+        let dir2 = TempDir::new("test").unwrap();
 
         let fqdn = "example.com".to_string();
         write_default_keyfiles(&dir1, 10, Some(&fqdn), DEFAULT_SEED).unwrap();
@@ -122,8 +122,8 @@ mod testing {
 
     #[test]
     fn test_default_generation_no_acct() {
-        let dir1 = TempDir::new("test").unwrap().into_path();
-        let dir2 = TempDir::new("test").unwrap().into_path();
+        let dir1 = TempDir::new("test").unwrap();
+        let dir2 = TempDir::new("test").unwrap();
 
         write_default_keyfiles(&dir1, 10, None, DEFAULT_SEED).unwrap();
         write_default_keyfiles(&dir2, 10, None, DEFAULT_SEED).unwrap();
@@ -148,7 +148,7 @@ mod testing {
 
     #[test]
     fn test_hard_coded_root_entropy() {
-        let dir1 = TempDir::new("test").unwrap().into_path();
+        let dir1 = TempDir::new("test").unwrap();
 
         write_default_keyfiles(&dir1, 10, None, DEFAULT_SEED).unwrap();
 

--- a/util/keyfile/src/lib.rs
+++ b/util/keyfile/src/lib.rs
@@ -101,11 +101,11 @@ mod testing {
     #[test]
     fn test_keyfile() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-        let dir = TempDir::new("test").unwrap().into_path();
+        let dir = TempDir::new("test").unwrap();
 
         {
             let entropy = RootIdentity::random(&mut rng, None);
-            let f1 = dir.join("f1");
+            let f1 = dir.path().join("f1");
             write_keyfile(&f1, &entropy).unwrap();
             let result = read_keyfile(&f1).unwrap();
             assert_eq!(entropy, result);
@@ -115,12 +115,12 @@ mod testing {
     #[test]
     fn test_pubfile() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-        let dir = TempDir::new("test").unwrap().into_path();
+        let dir = TempDir::new("test").unwrap();
 
         {
             let acct_key = AccountKey::random(&mut rng);
             let pubaddr = acct_key.default_subaddress();
-            let f2 = dir.join("f2");
+            let f2 = dir.path().join("f2");
             write_pubfile(&f2, &pubaddr).unwrap();
             let result = read_pubfile(&f2).unwrap();
             assert_eq!(pubaddr, result);
@@ -129,7 +129,7 @@ mod testing {
         {
             let acct_key = AccountKey::random_with_fog(&mut rng);
             let pubaddr = acct_key.default_subaddress();
-            let f3 = dir.join("f3");
+            let f3 = dir.path().join("f3");
             write_pubfile(&f3, &pubaddr).unwrap();
             let result = read_pubfile(&f3).unwrap();
             assert_eq!(pubaddr, result);

--- a/util/keyfile/tests/bin-determinism.rs
+++ b/util/keyfile/tests/bin-determinism.rs
@@ -22,7 +22,7 @@ fn sample_keys_determinism() {
         sample_keys_bin.display()
     );
 
-    let tempdir = TempDir::new("keys").unwrap().into_path();
+    let tempdir = TempDir::new("keys").unwrap();
     env::set_current_dir(&tempdir).unwrap();
     assert!(Command::new(sample_keys_bin.clone())
         .args(&["--num", "10", "--acct", "discovery.example.mobilecoin.com"])
@@ -30,7 +30,7 @@ fn sample_keys_determinism() {
         .expect("sample_keys failed")
         .success());
 
-    let tempdir2 = TempDir::new("keys").unwrap().into_path();
+    let tempdir2 = TempDir::new("keys").unwrap();
     env::set_current_dir(&tempdir2).unwrap();
     assert!(Command::new(sample_keys_bin)
         .args(&["--num", "10", "--acct", "discovery.example.mobilecoin.com"])
@@ -39,7 +39,11 @@ fn sample_keys_determinism() {
         .success());
 
     assert!(Command::new("diff")
-        .args(&["-rq", tempdir.to_str().unwrap(), tempdir2.to_str().unwrap()])
+        .args(&[
+            "-rq",
+            tempdir.path().to_str().unwrap(),
+            tempdir2.path().to_str().unwrap()
+        ])
         .status()
         .expect("Diff reported unexpected differences, this indicates nondeterminism")
         .success());
@@ -56,7 +60,7 @@ fn sample_keys_determinism2() {
         sample_keys_bin.display()
     );
 
-    let tempdir = TempDir::new("keys").unwrap().into_path();
+    let tempdir = TempDir::new("keys").unwrap();
     env::set_current_dir(&tempdir).unwrap();
     assert!(Command::new(sample_keys_bin.clone())
         .args(&["--num", "10", "--acct", "discovery.example.mobilecoin.com"])
@@ -64,7 +68,7 @@ fn sample_keys_determinism2() {
         .expect("sample_keys failed")
         .success());
 
-    let tempdir2 = TempDir::new("keys").unwrap().into_path();
+    let tempdir2 = TempDir::new("keys").unwrap();
     env::set_current_dir(&tempdir2).unwrap();
     assert!(Command::new(sample_keys_bin)
         .args(&["--num", "20", "--acct", "discovery.example.mobilecoin.com"])
@@ -77,8 +81,8 @@ fn sample_keys_determinism2() {
         .args(&[
             "-rq",
             "--exclude=*1[0123456789].*",
-            tempdir.to_str().unwrap(),
-            tempdir2.to_str().unwrap()
+            tempdir.path().to_str().unwrap(),
+            tempdir2.path().to_str().unwrap()
         ])
         .status()
         .expect("Diff reported unexpected differences, this indicates nondeterminism")


### PR DESCRIPTION
…  to prevent leaking the temporary directory (or more accurately, to prevent it from being cleaned up when it goes out of scope).