### PR TITLE
MC-1340 Removes fee output from range proof, finer-grained errors

### DIFF
--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -16,6 +16,7 @@ use mc_transaction_core::{
     amount::Amount,
     encrypted_fog_hint::EncryptedFogHint,
     range::Range,
+    ring_signature,
     ring_signature::{
         CurveScalar, Error as RingSigError, KeyImage, RingMLSAG, SignatureRctBulletproofs,
     },
@@ -663,7 +664,7 @@ impl TryInto<TransactionValidationError> for ProposeTxResult {
             Self::InvalidInputSignature => Ok(TransactionValidationError::InvalidInputSignature),
             Self::InvalidTransactionSignature => {
                 Ok(TransactionValidationError::InvalidTransactionSignature(
-                    transaction::ring_signature::Error::InvalidSignature,
+                    ring_signature::Error::InvalidSignature,
                 ))
             }
             Self::InvalidRangeProof => Ok(TransactionValidationError::InvalidRangeProof),

--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -609,7 +609,7 @@ impl From<TransactionValidationError> for ProposeTxResult {
                 Self::InsufficientInputSignatures
             }
             TransactionValidationError::InvalidInputSignature => Self::InvalidInputSignature,
-            TransactionValidationError::InvalidTransactionSignature => {
+            TransactionValidationError::InvalidTransactionSignature(_e) => {
                 Self::InvalidTransactionSignature
             }
             TransactionValidationError::InvalidRangeProof => Self::InvalidRangeProof,
@@ -662,7 +662,9 @@ impl TryInto<TransactionValidationError> for ProposeTxResult {
             }
             Self::InvalidInputSignature => Ok(TransactionValidationError::InvalidInputSignature),
             Self::InvalidTransactionSignature => {
-                Ok(TransactionValidationError::InvalidTransactionSignature)
+                Ok(TransactionValidationError::InvalidTransactionSignature(
+                    transaction::ring_signature::Error::InvalidSignature,
+                ))
             }
             Self::InvalidRangeProof => Ok(TransactionValidationError::InvalidRangeProof),
             Self::InsufficientRingSize => Ok(TransactionValidationError::InsufficientRingSize),

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -235,10 +235,14 @@ pub mod well_formed_tests {
 
         // Corrupt the signature.
         tx.signature.ring_signatures[0].key_image = KeyImage::from(77);
-        assert_eq!(
-            Err(TransactionValidationError::InvalidTransactionSignature),
-            is_well_formed(&tx, &ledger)
-        );
+
+        match is_well_formed(&tx, &ledger) {
+            Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
+            Err(e) => {
+                panic!(format!("Unexpected error {}", e));
+            }
+            Ok(()) => panic!(),
+        }
     }
 
     #[test_with_logger]

--- a/transaction/core/src/constants.rs
+++ b/transaction/core/src/constants.rs
@@ -2,6 +2,8 @@
 
 //! MobileCoin Transaction Constants.
 
+use crate::ring_signature::Scalar;
+
 /// Maximum number of transactions that may be included in a Block.
 pub const MAX_TRANSACTIONS_PER_BLOCK: usize = 5000;
 
@@ -22,6 +24,11 @@ pub const TOTAL_MOB: u64 = 250_000_000;
 
 /// Minimum allowed fee, denominated in picoMOB.
 pub const BASE_FEE: u64 = 10;
+
+lazy_static! {
+    // Blinding for the implicit fee outputs.
+    pub static ref FEE_BLINDING: Scalar = Scalar::zero();
+}
 
 cfg_if::cfg_if! {
     if #[cfg(any(test, feature="test-net-fee-keys"))] {

--- a/transaction/core/src/ring_signature/error.rs
+++ b/transaction/core/src/ring_signature/error.rs
@@ -2,8 +2,9 @@
 
 use failure::Fail;
 use mc_crypto_keys::KeyError;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Fail, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Fail, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum Error {
     #[fail(
         display = "Incorrect length for array copy, provided {}, required {}",
@@ -34,6 +35,9 @@ pub enum Error {
 
     #[fail(display = "Failed to compress/decompress a KeyImage")]
     InvalidKeyImage,
+
+    #[fail(display = "Duplicate key image")]
+    DuplicateKeyImage,
 
     #[fail(display = "There was an opaque error returned by another crate or library")]
     InternalError,

--- a/transaction/core/src/ring_signature/mod.rs
+++ b/transaction/core/src/ring_signature/mod.rs
@@ -24,7 +24,7 @@ lazy_static! {
 
     /// Generators (base points) for Bulletproofs.
     /// The `party_capacity` is the maximum number of values in one proof. It should
-    /// be at least 2 * num_inputs + num_outputs + 1, which allows for inputs, pseudo outputs, outputs, and the fee.
+    /// be at least 2 * MAX_INPUTS + MAX_OUTPUTS, which allows for inputs, pseudo outputs, and outputs.
     pub static ref BP_GENERATORS: BulletproofGens =
         BulletproofGens::new(64, 64);
 }

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -818,7 +818,10 @@ mod rct_bulletproofs_tests {
                 wrong_fee,
                 &mut rng,
             ) {
-                Err(_e) => {} // Expected
+                Err(Error::ValueNotConserved) => {} // Expected
+                Err(e) => {
+                    panic!(alloc::format!("Unexpected error {}", e));
+                }
                 _ => panic!()
             }
 

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     commitment::Commitment,
     compressed_commitment::CompressedCommitment,
+    constants::FEE_BLINDING,
     range_proofs::{check_range_proofs, generate_range_proofs},
     ring_signature::{mlsag::RingMLSAG, Error, KeyImage, Scalar, GENERATORS},
 };
@@ -53,12 +54,14 @@ impl SignatureRctBulletproofs {
     /// * `real_input_indices` - The index of the real input in each ring.
     /// * `input_secrets` - One-time private key, amount value, and amount blinding for each real input.
     /// * `output_values_and_blindings` - Value and blinding for each output amount commitment.
+    /// * `fee` - Value of the implicit fee output.
     pub fn sign<CSPRNG: RngCore + CryptoRng>(
         message: &[u8; 32],
         rings: &[Vec<(CompressedRistrettoPublic, CompressedCommitment)>],
         real_input_indices: &[usize],
         input_secrets: &[(RistrettoPrivate, u64, Scalar)],
         output_values_and_blindings: &[(u64, Scalar)],
+        fee: u64,
         rng: &mut CSPRNG,
     ) -> Result<Self, Error> {
         sign_with_balance_check(
@@ -67,6 +70,7 @@ impl SignatureRctBulletproofs {
             real_input_indices,
             input_secrets,
             output_values_and_blindings,
+            fee,
             true,
             rng,
         )
@@ -78,12 +82,14 @@ impl SignatureRctBulletproofs {
     /// * `message` - The signed message.
     /// * `rings` - One or more rings of one-time addresses and amount commitments.
     /// * `output_commitments` - Output amount commitments.
+    /// * `fee` - Value of the implicit fee output.
     /// * `rng` -
     pub fn verify<CSPRNG: RngCore + CryptoRng>(
         &self,
         message: &[u8; 32],
         rings: &[Vec<(CompressedRistrettoPublic, CompressedCommitment)>],
         output_commitments: &[CompressedCommitment],
+        fee: u64,
         rng: &mut CSPRNG,
     ) -> Result<(), Error> {
         // Signature must contain one ring signature for each ring.
@@ -109,7 +115,7 @@ impl SignatureRctBulletproofs {
                 self.key_images().into_iter().all(move |x| uniq.insert(x))
             };
             if !key_images_are_unique {
-                return Err(Error::InvalidSignature);
+                return Err(Error::DuplicateKeyImage);
             }
         }
 
@@ -142,7 +148,7 @@ impl SignatureRctBulletproofs {
                 .map_err(|_e| Error::RangeProofError)?;
 
             check_range_proofs(&range_proof, &commitments, rng)
-                .map_err(|_e| Error::InvalidSignature)?;
+                .map_err(|_e| Error::RangeProofError)?;
         }
 
         // Output commitments - pseudo_outputs must be zero.
@@ -158,7 +164,10 @@ impl SignatureRctBulletproofs {
                     .map(|commitment| commitment.point)
                     .sum();
 
-            let difference = sum_of_output_commitments - sum_of_pseudo_output_commitments;
+            // The implicit fee output.
+            let fee_commitment = GENERATORS.commit(Scalar::from(fee), *FEE_BLINDING);
+            let difference =
+                sum_of_output_commitments + fee_commitment - sum_of_pseudo_output_commitments;
             if difference != GENERATORS.commit(Scalar::zero(), Scalar::zero()) {
                 return Err(Error::ValueNotConserved);
             }
@@ -199,6 +208,7 @@ impl SignatureRctBulletproofs {
 /// * `real_input_indices` - The index of the real input in each ring.
 /// * `input_secrets` - One-time private key, amount value, and amount blinding for each real input.
 /// * `output_values_and_blindings` - Value and blinding for each output amount commitment.
+/// * `fee` - Value of the implicit fee output.
 /// * `check_value_is_preserved` - If true, check that the value of inputs equals value of outputs.
 fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
     message: &[u8; 32],
@@ -206,6 +216,7 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
     real_input_indices: &[usize],
     input_secrets: &[(RistrettoPrivate, u64, Scalar)],
     output_values_and_blindings: &[(u64, Scalar)],
+    fee: u64,
     check_value_is_preserved: bool,
     rng: &mut CSPRNG,
 ) -> Result<SignatureRctBulletproofs, Error> {
@@ -244,6 +255,7 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
     for _i in 0..num_inputs - 1 {
         pseudo_output_blindings.push(Scalar::random(rng));
     }
+    // The implicit fee output is ommitted because its blinding is zero.
     let sum_of_output_blindings: Scalar = output_values_and_blindings
         .iter()
         .map(|(_, blinding)| blinding)
@@ -267,6 +279,8 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
             .map(|(value, blinding)| (*value, *blinding))
             .collect();
 
+        // The implicit fee output is omitted from the range proof because it is known.
+
         let (values, blindings): (Vec<_>, Vec<_>) = values_and_blindings.into_iter().unzip();
         generate_range_proofs(&values, &blindings, rng).map_err(|_e| Error::RangeProofError)?
     };
@@ -282,7 +296,11 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
             .map(|(value, blinding)| GENERATORS.commit(Scalar::from(*value), *blinding))
             .sum();
 
-        let difference = sum_of_output_commitments - sum_of_pseudo_output_commitments;
+        // The implicit fee output.
+        let fee_commitment = GENERATORS.commit(Scalar::from(fee), *FEE_BLINDING);
+
+        let difference =
+            sum_of_output_commitments + fee_commitment - sum_of_pseudo_output_commitments;
         if difference != GENERATORS.commit(Scalar::zero(), Scalar::zero()) {
             return Err(Error::ValueNotConserved);
         }
@@ -464,6 +482,7 @@ mod rct_bulletproofs_tests {
                 &params.real_input_indices,
                 &params.input_secrets,
                 &params.output_values_and_blindings,
+                0,
                 &mut rng,
             );
 
@@ -491,6 +510,7 @@ mod rct_bulletproofs_tests {
                 &params.real_input_indices,
                 &params.input_secrets,
                 &params.output_values_and_blindings,
+                0,
                 &mut rng,
             );
 
@@ -515,6 +535,7 @@ mod rct_bulletproofs_tests {
                 &params.real_input_indices,
                 &params.input_secrets,
                 &params.output_values_and_blindings,
+                0,
                 &mut rng,
             )
             .unwrap();
@@ -540,12 +561,14 @@ mod rct_bulletproofs_tests {
         ) {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
             let params = SignatureParams::random(num_inputs, num_mixins, &mut rng);
+            let fee = 0;
             let signature = SignatureRctBulletproofs::sign(
                 &params.message,
                 &params.rings,
                 &params.real_input_indices,
                 &params.input_secrets,
                 &params.output_values_and_blindings,
+                fee,
                 &mut rng,
             )
             .unwrap();
@@ -554,6 +577,7 @@ mod rct_bulletproofs_tests {
                 &params.message,
                 &params.rings,
                 &params.get_output_commitments(),
+                fee,
                 &mut rng,
             );
             assert!(result.is_ok());
@@ -568,12 +592,14 @@ mod rct_bulletproofs_tests {
         ) {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
             let params = SignatureParams::random(num_inputs, num_mixins, &mut rng);
+            let fee = 0;
             let mut signature = SignatureRctBulletproofs::sign(
                 &params.message,
                 &params.rings,
                 &params.real_input_indices,
                 &params.input_secrets,
                 &params.output_values_and_blindings,
+                fee,
                 &mut rng,
             )
             .unwrap();
@@ -586,6 +612,7 @@ mod rct_bulletproofs_tests {
                 &params.message,
                 &params.rings,
                 &params.get_output_commitments(),
+                fee,
                 &mut rng,
             );
 
@@ -601,7 +628,7 @@ mod rct_bulletproofs_tests {
         ) {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
             let mut params = SignatureParams::random(num_inputs, num_mixins, &mut rng);
-
+            let fee = 0;
             // Modify an output value
             {
                 let index = rng.next_u64() as usize % (num_inputs);
@@ -616,6 +643,7 @@ mod rct_bulletproofs_tests {
                 &params.real_input_indices,
                 &params.input_secrets,
                 &params.output_values_and_blindings,
+                fee,
                 false,
                 &mut rng,
             )
@@ -625,6 +653,7 @@ mod rct_bulletproofs_tests {
                 &params.message,
                 &params.rings,
                 &params.get_output_commitments(),
+                fee,
                 &mut rng,
             );
 
@@ -640,13 +669,14 @@ mod rct_bulletproofs_tests {
         ) {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
             let params = SignatureParams::random(num_inputs, num_mixins, &mut rng);
-
+            let fee = 0;
             let mut signature = SignatureRctBulletproofs::sign(
                 &params.message,
                 &params.rings,
                 &params.real_input_indices,
                 &params.input_secrets,
                 &params.output_values_and_blindings,
+                fee,
                 &mut rng,
             )
             .unwrap();
@@ -669,10 +699,11 @@ mod rct_bulletproofs_tests {
                 &params.message,
                 &params.rings,
                 &params.get_output_commitments(),
+                fee,
                 &mut rng,
             );
 
-            assert_eq!(result, Err(Error::InvalidSignature));
+            assert_eq!(result, Err(Error::RangeProofError));
         }
 
         #[test]
@@ -684,6 +715,7 @@ mod rct_bulletproofs_tests {
         ) {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
             let mut params = SignatureParams::random(num_inputs, num_mixins, &mut rng);
+            let fee = 0;
 
             // Duplicate one of the rings.
             params.rings[2] = params.rings[3].clone();
@@ -697,6 +729,7 @@ mod rct_bulletproofs_tests {
                 &params.real_input_indices,
                 &params.input_secrets,
                 &params.output_values_and_blindings,
+                fee,
                 &mut rng,
             )
             .unwrap();
@@ -705,10 +738,11 @@ mod rct_bulletproofs_tests {
                 &params.message,
                 &params.rings,
                 &params.get_output_commitments(),
+                fee,
                 &mut rng,
             );
 
-            assert_eq!(result, Err(Error::InvalidSignature));
+            assert_eq!(result, Err(Error::DuplicateKeyImage));
         }
 
         #[test]
@@ -720,12 +754,14 @@ mod rct_bulletproofs_tests {
         ) {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
             let params = SignatureParams::random(num_inputs, num_mixins, &mut rng);
+            let fee = 0;
             let signature = SignatureRctBulletproofs::sign(
                 &params.message,
                 &params.rings,
                 &params.real_input_indices,
                 &params.input_secrets,
                 &params.output_values_and_blindings,
+                fee,
                 &mut rng,
             )
             .unwrap();

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -5,6 +5,7 @@ use core::{
     convert::{TryFrom, TryInto},
     fmt,
 };
+
 use curve25519_dalek::scalar::Scalar;
 use mc_common::{Hash, HashMap};
 use mc_crypto_digestible::Digestible;
@@ -193,25 +194,12 @@ impl TxPrefix {
             .collect()
     }
 
-    /// Get the commitment and blinding for the fee output.
-    pub fn fee_value_and_blinding(&self) -> (u64, Scalar) {
-        (self.fee, Scalar::zero())
-    }
-
-    /// Get all output commitments (including explicit outputs and the implicit fee output).
+    /// Get all output commitments.
     pub fn output_commitments(&self) -> Vec<CompressedCommitment> {
-        let mut commitments: Vec<CompressedCommitment> = self
-            .outputs
+        self.outputs
             .iter()
             .map(|output| output.amount.commitment)
-            .collect();
-
-        let fee_commitment = {
-            let (value, blinding) = self.fee_value_and_blinding();
-            CompressedCommitment::new(value, blinding)
-        };
-        commitments.push(fee_commitment);
-        commitments
+            .collect()
     }
 }
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -6,7 +6,6 @@ use core::{
     fmt,
 };
 
-use curve25519_dalek::scalar::Scalar;
 use mc_common::{Hash, HashMap};
 use mc_crypto_digestible::Digestible;
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate};

--- a/transaction/core/src/validation/error.rs
+++ b/transaction/core/src/validation/error.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 pub type TransactionValidationResult<T> = Result<T, TransactionValidationError>;
 
 /// Reasons why a single transaction may fail to be valid with respect to the current ledger.
-#[derive(Clone, Debug, Deserialize, Eq, Fail, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Fail, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum TransactionValidationError {
     /// Each input should have one membership proof.
     #[fail(display = "InputsProofsLengthMismatch")]
@@ -33,7 +33,7 @@ pub enum TransactionValidationError {
 
     /// The transaction must have a valid RingCT signature.
     #[fail(display = "InvalidTransactionSignature")]
-    InvalidTransactionSignature,
+    InvalidTransactionSignature(#[fail(cause)] crate::ring_signature::Error),
 
     /// All Range Proofs in the transaction must be valid.
     #[fail(display = "InvalidRangeProof")]

--- a/transaction/core/src/validation/mod.rs
+++ b/transaction/core/src/validation/mod.rs
@@ -4,4 +4,4 @@ mod error;
 mod validate;
 
 pub use error::{TransactionValidationError, TransactionValidationResult};
-pub use validate::{validate, validate_tombstone, validate_transaction_signature};
+pub use validate::{validate, validate_signature, validate_tombstone};

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -40,7 +40,7 @@ pub fn validate<R: RngCore + CryptoRng>(
 
     validate_membership_proofs(&tx.prefix, &root_proofs)?;
 
-    validate_transaction_signature(&tx, csprng)?;
+    validate_signature(&tx, csprng)?;
 
     validate_transaction_fee(&tx)?;
 
@@ -138,28 +138,39 @@ fn validate_key_images_are_unique(tx: &Tx) -> TransactionValidationResult<()> {
     Ok(())
 }
 
-pub fn validate_transaction_signature<R: RngCore + CryptoRng>(
+/// Verifies the transaction signature.
+///
+/// A valid RctBulletproofs signature implies that:
+/// * tx.prefix has not been modified,
+/// * The signer owns one element in each input ring,
+/// * Each key image corresponds to the spent ring element,
+/// * The outputs have values in [0,2^64),
+/// * The transaction does not create or destroy mobilecoins.
+pub fn validate_signature<R: RngCore + CryptoRng>(
     tx: &Tx,
     rng: &mut R,
 ) -> TransactionValidationResult<()> {
-    let tx_prefix_hash = tx.prefix.hash();
-    let message = tx_prefix_hash.as_bytes();
-
-    let mut rings: Vec<Vec<(CompressedRistrettoPublic, CompressedCommitment)>> = Vec::new();
-    for input in &tx.prefix.inputs {
-        let ring: Vec<(CompressedRistrettoPublic, CompressedCommitment)> = input
-            .ring
-            .iter()
-            .map(|tx_out| (tx_out.target_key, tx_out.amount.commitment))
-            .collect();
-        rings.push(ring);
-    }
+    let rings: Vec<Vec<(CompressedRistrettoPublic, CompressedCommitment)>> = tx
+        .prefix
+        .inputs
+        .iter()
+        .map(|input| {
+            input
+                .ring
+                .iter()
+                .map(|tx_out| (tx_out.target_key, tx_out.amount.commitment))
+                .collect()
+        })
+        .collect();
 
     let output_commitments = tx.prefix.output_commitments();
 
+    let tx_prefix_hash = tx.prefix.hash();
+    let message = tx_prefix_hash.as_bytes();
+
     tx.signature
-        .verify(message, &rings, &output_commitments, rng)
-        .map_err(|_e| TransactionValidationError::InvalidTransactionSignature)
+        .verify(message, &rings, &output_commitments, tx.prefix.fee, rng)
+        .map_err(TransactionValidationError::InvalidTransactionSignature)
 }
 
 /// The fee amount must be greater than or equal to `BASE_FEE`.
@@ -298,19 +309,18 @@ mod tests {
 
     use crate::{
         constants::{BASE_FEE, RING_SIZE},
-        ring_signature::Scalar,
         tx::{Tx, TxOutMembershipHash, TxOutMembershipProof},
         validation::{
             error::TransactionValidationError,
             validate::{
                 validate_key_images_are_unique, validate_membership_proofs,
                 validate_number_of_inputs, validate_number_of_outputs,
-                validate_ring_elements_are_unique, validate_ring_sizes, validate_tombstone,
-                validate_transaction_fee, validate_transaction_signature, MAX_TOMBSTONE_BLOCKS,
+                validate_ring_elements_are_unique, validate_ring_sizes, validate_signature,
+                validate_tombstone, validate_transaction_fee, MAX_TOMBSTONE_BLOCKS,
             },
         },
-        CompressedCommitment,
     };
+
     use mc_crypto_keys::CompressedRistrettoPublic;
     use mc_ledger_db::{Ledger, LedgerDB};
     use mc_transaction_core_test_utils::{
@@ -615,48 +625,64 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_transaction_signature() {
+    // `validate_signature` return OK for a valid transaction.
+    fn test_validate_signature_ok() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-        let (orig_tx, _ledger) = create_test_tx();
+        let (tx, _ledger) = create_test_tx();
+        assert_eq!(validate_signature(&tx, &mut rng), Ok(()));
+    }
 
-        // Valid signature
-        {
-            assert_eq!(validate_transaction_signature(&orig_tx, &mut rng), Ok(()));
+    #[test]
+    // Should return InvalidTransactionSignature if an input is modified.
+    fn test_transaction_signature_err_modified_input() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let (mut tx, _ledger) = create_test_tx();
+
+        // Remove an input.
+        tx.prefix.inputs[0].ring.pop();
+
+        match validate_signature(&tx, &mut rng) {
+            Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
+            Err(e) => {
+                panic!(alloc::format!("Unexpected error {}", e));
+            }
+            Ok(()) => panic!(),
         }
+    }
 
-        // Invalid signature due to altered input
-        {
-            let mut tx = orig_tx.clone();
-            tx.prefix.inputs[0].ring.pop();
+    #[test]
+    // Should return InvalidTransactionSignature if an output is modified.
+    fn test_transaction_signature_err_modified_output() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let (mut tx, _ledger) = create_test_tx();
 
-            assert_eq!(
-                validate_transaction_signature(&tx, &mut rng),
-                Err(TransactionValidationError::InvalidTransactionSignature)
-            );
+        // Add an output.
+        let output = tx.prefix.outputs.get(0).unwrap().clone();
+        tx.prefix.outputs.push(output);
+
+        match validate_signature(&tx, &mut rng) {
+            Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
+            Err(e) => {
+                panic!(alloc::format!("Unexpected error {}", e));
+            }
+            Ok(()) => panic!(),
         }
+    }
 
-        // Invalid signature due to altered output.
-        {
-            let mut tx = orig_tx.clone();
-            let wrong_commitment = {
-                let value = rng.next_u64();
-                let blinding = Scalar::random(&mut rng);
-                CompressedCommitment::new(value, blinding)
-            };
-            tx.prefix.outputs[0].amount.commitment = wrong_commitment;
+    #[test]
+    // Should return InvalidTransactionSignature if the fee is modified.
+    fn test_transaction_signature_err_modified_fee() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let (mut tx, _ledger) = create_test_tx();
 
-            assert_eq!(
-                validate_transaction_signature(&tx, &mut rng),
-                Err(TransactionValidationError::InvalidTransactionSignature)
-            );
-        }
+        tx.prefix.fee = tx.prefix.fee + 1;
 
-        // Sanity - a transaction with sum(inputs) = sum(outputs) validates.
-        {
-            // The amount here needs to be bigger than whatever is used in `initialize_ledger`.
-            let (tx, _ledger) =
-                create_test_tx_with_amount(INITIALIZE_LEDGER_AMOUNT - BASE_FEE, BASE_FEE);
-            assert_eq!(validate_transaction_signature(&tx, &mut rng), Ok(()));
+        match validate_signature(&tx, &mut rng) {
+            Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
+            Err(e) => {
+                panic!(alloc::format!("Unexpected error {}", e));
+            }
+            Ok(()) => panic!(),
         }
     }
 

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -329,7 +329,6 @@ mod tests {
     };
     use mc_util_serial::ReprBytes32;
     use rand::{rngs::StdRng, SeedableRng};
-    use rand_core::RngCore;
     use serde::{de::DeserializeOwned, ser::Serialize};
 
     // HACK: To test validation we need valid Tx objects. The code to create them is complicated,

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -148,7 +148,7 @@ impl TransactionBuilder {
             input_secrets.push((onetime_private_key, value, blinding));
         }
 
-        let mut output_values_and_blindings: Vec<(u64, Scalar)> = tx_prefix
+        let output_values_and_blindings: Vec<(u64, Scalar)> = tx_prefix
             .outputs
             .iter()
             .enumerate()
@@ -162,9 +162,6 @@ impl TransactionBuilder {
             })
             .collect();
 
-        // The fee output is implicit in the tx_prefix.
-        output_values_and_blindings.push(tx_prefix.fee_value_and_blinding());
-
         let message = tx_prefix.hash().0;
         let signature = SignatureRctBulletproofs::sign(
             &message,
@@ -172,6 +169,7 @@ impl TransactionBuilder {
             &real_input_indices,
             &input_secrets,
             &output_values_and_blindings,
+            self.fee,
             rng,
         )?;
 
@@ -241,7 +239,7 @@ pub mod transaction_builder_tests {
         onetime_keys::*,
         ring_signature::KeyImage,
         tx::TxOutMembershipProof,
-        validation::validate_transaction_signature,
+        validation::validate_signature,
     };
     use rand::{rngs::StdRng, SeedableRng};
     use std::convert::TryFrom;
@@ -420,7 +418,7 @@ pub mod transaction_builder_tests {
         }
 
         // The transaction should have a valid signature.
-        assert!(validate_transaction_signature(&tx, &mut rng).is_ok());
+        assert!(validate_signature(&tx, &mut rng).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
The fee is known to be a 64-bit number, so it is not necessary to include it in the range proof. This reduces* the range proof size and validation time.

*We aggregate proofs for 1,2,4,8,16.. values, "rounding up" to the next power of 2. For certain transactions, including the fee in the range proof bumps things up to the next power of 2.