### PR TITLE
Improve client experience during ledger catchup

### DIFF
--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -110,7 +110,7 @@ impl<L: Ledger + Sync> BlockchainConnection for MockBlockchainConnection<L> {
     }
 
     fn fetch_block_height(&mut self) -> ConnectionResult<BlockIndex> {
-        unimplemented!()
+        Ok(self.ledger.num_blocks().unwrap() - 1)
     }
 }
 

--- a/ledger/sync/src/network_state_trait.rs
+++ b/ledger/sync/src/network_state_trait.rs
@@ -21,6 +21,6 @@ pub trait NetworkState: Send {
     fn is_behind(&self, local_block_index: BlockIndex) -> bool;
 
     /// Returns the highest block index the network agrees on (the highest block index from a set
-    /// of peers that passes the "is blocking nad quorum" test).
+    /// of peers that passes the "is blocking and quorum" test).
     fn highest_block_index_on_network(&self) -> Option<BlockIndex>;
 }

--- a/ledger/sync/src/network_state_trait.rs
+++ b/ledger/sync/src/network_state_trait.rs
@@ -19,4 +19,8 @@ pub trait NetworkState: Send {
     /// # Arguments
     /// * `local_block_index` - The highest block externalized by this node.
     fn is_behind(&self, local_block_index: BlockIndex) -> bool;
+
+    /// Returns the highest block index the network agrees on (the highest block index from a set
+    /// of peers that passes the "is blocking nad quorum" test).
+    fn highest_block_index_on_network(&self) -> Option<BlockIndex>;
 }

--- a/ledger/sync/src/polling_network_state.rs
+++ b/ledger/sync/src/polling_network_state.rs
@@ -160,4 +160,10 @@ impl<BC: BlockchainConnection> NetworkState for PollingNetworkState<BC> {
     fn is_behind(&self, local_block_index: BlockIndex) -> bool {
         self.scp_network_state.is_behind(local_block_index)
     }
+
+    /// Returns the highest block index the network agrees on (the highest block index from a set
+    /// of peers that passes the "is blocking nad quorum" test).
+    fn highest_block_index_on_network(&self) -> Option<BlockIndex> {
+        self.scp_network_state.highest_block_index_on_network()
+    }
 }

--- a/ledger/sync/src/polling_network_state.rs
+++ b/ledger/sync/src/polling_network_state.rs
@@ -137,6 +137,10 @@ impl<BC: BlockchainConnection + 'static> PollingNetworkState<BC> {
         }
     }
 
+    pub fn peer_to_current_block_index(&self) -> &HashMap<ResponderId, BlockIndex> {
+        self.scp_network_state.peer_to_current_slot()
+    }
+
     fn get_retry_iterator() -> Box<dyn Iterator<Item = Duration>> {
         // Start at 50ms, make 10 attempts (total would be 7150ms)
         Box::new(Fibonacci::from_millis(50).take(10))

--- a/ledger/sync/src/scp_network_state.rs
+++ b/ledger/sync/src/scp_network_state.rs
@@ -15,7 +15,6 @@ use mc_transaction_core::BlockIndex;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{hash::Hash, iter::FromIterator};
 
-#[derive(Clone)]
 pub struct SCPNetworkState<ID: GenericNodeId = NodeID> {
     // The local node ID.
     local_node_id: ID,

--- a/ledger/sync/src/scp_network_state.rs
+++ b/ledger/sync/src/scp_network_state.rs
@@ -137,6 +137,37 @@ impl<ID: GenericNodeId + Send + AsRef<ResponderId> + DeserializeOwned + Serializ
                 .map(|node_id| node_id.as_ref().clone()),
         ))
     }
+
+    fn highest_block_index_on_network(&self) -> Option<BlockIndex> {
+        // Create a sorted list of unique slot indexes. These are potential candidates for the
+        // highest slot index the network agrees on.
+        let mut seen_block_indexes: Vec<BlockIndex> =
+            self.peer_to_current_slot().values().cloned().collect();
+        seen_block_indexes.sort();
+        seen_block_indexes.dedup();
+
+        // For each potential block index we saw (from the highest to the lowest), see if we can pass
+        // the is_blocking_and_quorum test.
+        for highest_block_index in seen_block_indexes.iter().rev() {
+            let peers_on_higher_block: Vec<ID> = self
+                .peer_to_current_slot()
+                .iter()
+                .filter(|&(_id, block_index)| block_index >= highest_block_index)
+                .map(|(id, _block_index)| id.clone())
+                .collect();
+
+            if self.is_blocking_and_quorum(&HashSet::from_iter(
+                peers_on_higher_block
+                    .iter()
+                    .map(|node_id| node_id.as_ref().clone()),
+            )) {
+                // Found a block index the network agrees on.
+                return Some(*highest_block_index);
+            }
+        }
+
+        None
+    }
 }
 
 #[cfg(test)]
@@ -491,6 +522,156 @@ mod tests {
                 test_node_id(2).responder_id
             ])),
             true
+        );
+    }
+
+    #[test_with_logger]
+    // NetworkState highest_block_index_on_network should only return the highest block index
+    // a blocking set and quorum agrees on.
+    fn test_highest_block_index_on_network(logger: Logger) {
+        let local_node_quorum_set: QuorumSet = {
+            let inner_quorum_set_one: QuorumSet = QuorumSet::new_with_node_ids(
+                2,
+                vec![test_node_id(2), test_node_id(3), test_node_id(4)],
+            );
+            let inner_quorum_set_two: QuorumSet = QuorumSet::new_with_node_ids(
+                2,
+                vec![test_node_id(5), test_node_id(6), test_node_id(7)],
+            );
+            QuorumSet::new_with_inner_sets(2, vec![inner_quorum_set_one, inner_quorum_set_two])
+        };
+        let local_node_id = test_node_id(1);
+        let mut network_state = SCPNetworkState::new(local_node_id, local_node_quorum_set, logger);
+        let local_block = 5;
+
+        // Nodes 2 and 3 are a blocking set.
+        let node_2_id = test_node_id(2);
+        let node_2_quorum_set =
+            QuorumSet::new_with_node_ids(1, vec![test_node_id(3), test_node_id(4)]);
+
+        let node_3_id = test_node_id(3);
+        let node_3_quorum_set =
+            QuorumSet::new_with_node_ids(1, vec![test_node_id(2), test_node_id(4)]);
+
+        let node_5_id = test_node_id(5);
+        let node_5_quorum_set =
+            QuorumSet::new_with_node_ids(1, vec![test_node_id(6), test_node_id(7)]);
+
+        let node_6_id = test_node_id(6);
+        let node_6_quorum_set =
+            QuorumSet::new_with_node_ids(1, vec![test_node_id(5), test_node_id(7)]);
+
+        // No messages issued so far, so we don't know where the network is.
+        assert_eq!(network_state.highest_block_index_on_network(), None);
+
+        // Send a message from node 2. Nothing should change.
+        network_state.push(Msg::<&str>::new(
+            node_2_id.clone(),
+            node_2_quorum_set.clone(),
+            local_block + 5,
+            Topic::Externalize(ExternalizePayload {
+                C: Ballot::new(1, &["bleh"]),
+                HN: 0,
+            }),
+        ));
+        assert_eq!(network_state.highest_block_index_on_network(), None);
+
+        // Send a message from node 3, so we have a blocking set but no quorum.
+        network_state.push(Msg::<&str>::new(
+            node_3_id.clone(),
+            node_3_quorum_set.clone(),
+            local_block + 5,
+            Topic::Externalize(ExternalizePayload {
+                C: Ballot::new(1, &["bleh"]),
+                HN: 0,
+            }),
+        ));
+        assert_eq!(network_state.highest_block_index_on_network(), None);
+
+        // Send a message from node 5, not forming quorum.
+        network_state.push(Msg::<&str>::new(
+            node_5_id.clone(),
+            node_5_quorum_set.clone(),
+            local_block + 5,
+            Topic::Externalize(ExternalizePayload {
+                C: Ballot::new(1, &["bleh"]),
+                HN: 0,
+            }),
+        ));
+        assert_eq!(network_state.highest_block_index_on_network(), None);
+
+        // Send a message from node 6, we now have a blocking set and quorum agreeing on
+        // block `local_block + 5` (even though node 6 is on block +10, the rest of the network is
+        // on block +5).
+        network_state.push(Msg::<&str>::new(
+            node_6_id.clone(),
+            node_6_quorum_set.clone(),
+            local_block + 10,
+            Topic::Externalize(ExternalizePayload {
+                C: Ballot::new(1, &["bleh"]),
+                HN: 0,
+            }),
+        ));
+        assert_eq!(
+            network_state.highest_block_index_on_network(),
+            Some(local_block + 5)
+        );
+
+        // Node 2 and 3 advance to local_block+12 - the network continues to agree on local_block + 5.
+        network_state.push(Msg::<&str>::new(
+            node_2_id,
+            node_2_quorum_set,
+            local_block + 12,
+            Topic::Externalize(ExternalizePayload {
+                C: Ballot::new(1, &["bleh"]),
+                HN: 0,
+            }),
+        ));
+
+        network_state.push(Msg::<&str>::new(
+            node_3_id,
+            node_3_quorum_set,
+            local_block + 12,
+            Topic::Externalize(ExternalizePayload {
+                C: Ballot::new(1, &["bleh"]),
+                HN: 0,
+            }),
+        ));
+        assert_eq!(
+            network_state.highest_block_index_on_network(),
+            Some(local_block + 5)
+        );
+
+        // Node 5 moves to block local_block + 10, the network agrees on block local_block+10
+        // (since node 6 is on local_block + 10).
+        network_state.push(Msg::<&str>::new(
+            node_5_id,
+            node_5_quorum_set,
+            local_block + 12,
+            Topic::Externalize(ExternalizePayload {
+                C: Ballot::new(1, &["bleh"]),
+                HN: 0,
+            }),
+        ));
+        assert_eq!(
+            network_state.highest_block_index_on_network(),
+            Some(local_block + 10)
+        );
+
+        // Node 6 moves to block local_block + 12, the network agrees on local_block + 12 as all
+        // nodes have reported that.
+        network_state.push(Msg::<&str>::new(
+            node_6_id,
+            node_6_quorum_set,
+            local_block + 12,
+            Topic::Externalize(ExternalizePayload {
+                C: Ballot::new(1, &["bleh"]),
+                HN: 0,
+            }),
+        ));
+        assert_eq!(
+            network_state.highest_block_index_on_network(),
+            Some(local_block + 12)
         );
     }
 }

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -47,6 +47,9 @@ service MobilecoindAPI {
     // Convenience calls
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceResponse) {}
     rpc SendPayment (SendPaymentRequest) returns (SendPaymentResponse) {}
+
+    // Network status
+    rpc GetNetworkStatus (google.protobuf.Empty) returns (GetNetworkStatusResponse) {}
 }
 
 //*********************************
@@ -496,4 +499,19 @@ message SendPaymentResponse {
     // The TxProposal that was submitted to the network. The fee that was paid can be checked at
     // tx_proposal.tx.prefix.fee
     TxProposal tx_proposal = 3;
+}
+
+//
+// Network status
+//
+
+// Get information about the network.
+// - empty request
+message GetNetworkStatusResponse {
+    // Total highest block number the network agrees on.
+    // (This is the block number we will try to sync to).
+    uint64 network_highest_block_index = 1;
+
+    // A map of node responder id to the block index reported by it.
+    map<string, uint64> peer_block_index_map = 2;
 }

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -517,4 +517,7 @@ message GetNetworkStatusResponse {
 
     // The local ledger block index.
     uint64 local_block_index = 3;
+
+    // Whether we are behind.
+    bool is_behind = 4;
 }

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -514,4 +514,7 @@ message GetNetworkStatusResponse {
 
     // A map of node responder id to the block index reported by it.
     map<string, uint64> peer_block_index_map = 2;
+
+    // The local ledger block index.
+    uint64 local_block_index = 3;
 }

--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -10,7 +10,11 @@ use mc_ledger_sync::{LedgerSyncServiceThread, PollingNetworkState, ReqwestTransa
 use mc_mobilecoind::{
     config::Config, database::Database, payments::TransactionsManager, service::Service,
 };
-use std::{convert::TryFrom, path::Path};
+use std::{
+    convert::TryFrom,
+    path::Path,
+    sync::{Arc, Mutex},
+};
 use structopt::StructOpt;
 
 fn main() {
@@ -28,8 +32,11 @@ fn main() {
     );
 
     // Create network state, transactions fetcher and ledger sync.
-    let network_state =
-        PollingNetworkState::new(config.quorum_set(), peer_manager.clone(), logger.clone());
+    let network_state = Arc::new(Mutex::new(PollingNetworkState::new(
+        config.quorum_set(),
+        peer_manager.clone(),
+        logger.clone(),
+    )));
 
     let transactions_fetcher =
         ReqwestTransactionsFetcher::new(config.tx_source_urls.clone(), logger.clone())

--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -48,7 +48,7 @@ fn main() {
     let _ledger_sync_service_thread = LedgerSyncServiceThread::new(
         ledger_db.clone(),
         peer_manager.clone(),
-        network_state,
+        network_state.clone(),
         transactions_fetcher,
         config.poll_interval,
         logger.clone(),
@@ -75,6 +75,7 @@ fn main() {
                 ledger_db,
                 mobilecoind_db,
                 transactions_manager,
+                network_state,
                 *service_port,
                 config.num_workers,
                 logger,

--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -62,7 +62,7 @@ fn main() {
             let _ = std::fs::create_dir_all(mobilecoind_db);
 
             let mobilecoind_db = Database::new(mobilecoind_db, logger.clone())
-                .expect("Could not open mobilecoinddb");
+                .expect("Could not open mobilecoind_db");
 
             let transactions_manager = TransactionsManager::new(
                 ledger_db.clone(),

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -988,6 +988,13 @@ impl<T: UserTxConnection + 'static> ServiceApi<T> {
         response.set_tx_proposal(proto_tx_proposal);
         Ok(response)
     }
+
+    fn get_network_status_impl(
+        &mut self,
+        _request: mobilecoind_api::Empty,
+    ) -> Result<mobilecoind_api::GetNetworkStatusResponse, RpcStatus> {
+        todo!();
+    }
 }
 
 macro_rules! build_api {
@@ -1037,7 +1044,8 @@ build_api! {
     get_tx_status_as_sender GetTxStatusAsSenderRequest GetTxStatusAsSenderResponse get_tx_status_as_sender_impl,
     get_tx_status_as_receiver GetTxStatusAsReceiverRequest GetTxStatusAsReceiverResponse get_tx_status_as_receiver_impl,
     get_balance GetBalanceRequest GetBalanceResponse get_balance_impl,
-    send_payment SendPaymentRequest SendPaymentResponse send_payment_impl
+    send_payment SendPaymentRequest SendPaymentResponse send_payment_impl,
+    get_network_status Empty GetNetworkStatusResponse get_network_status_impl
 }
 
 #[cfg(test)]

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -34,7 +34,10 @@ use mc_util_b58_payloads::payloads::{RequestPayload, TransferPayload};
 use mc_util_grpc::{rpc_internal_error, rpc_logger, send_result, BuildInfoService};
 use mc_util_serial::ReprBytes32;
 use protobuf::RepeatedField;
-use std::{convert::TryFrom, sync::Arc};
+use std::{
+    convert::TryFrom,
+    sync::{Arc, Mutex},
+};
 
 pub struct Service {
     /// Sync thread.
@@ -2149,13 +2152,13 @@ mod test {
             let mut opt_submitted_tx: Option<Tx> = None;
             for mock_peer in server_conn_manager.conns() {
                 let inner = mock_peer.read();
-                match (inner.submitted_txs.len(), opt_submitted_tx.clone()) {
+                match (inner.proposed_txs.len(), opt_submitted_tx.clone()) {
                     (0, _) => {
                         // Nothing submitted to the current peer.
                     }
                     (1, None) => {
                         // Found our tx.
-                        opt_submitted_tx = Some(inner.submitted_txs[0].clone())
+                        opt_submitted_tx = Some(inner.proposed_txs[0].clone())
                     }
                     (1, Some(_)) => {
                         panic!("Tx submitted to two peers?!");
@@ -2375,13 +2378,13 @@ mod test {
         let mut opt_submitted_tx: Option<Tx> = None;
         for mock_peer in server_conn_manager.conns() {
             let inner = mock_peer.read();
-            match (inner.submitted_txs.len(), opt_submitted_tx.clone()) {
+            match (inner.proposed_txs.len(), opt_submitted_tx.clone()) {
                 (0, _) => {
                     // Nothing submitted to the current peer.
                 }
                 (1, None) => {
                     // Found our tx.
-                    opt_submitted_tx = Some(inner.submitted_txs[0].clone())
+                    opt_submitted_tx = Some(inner.proposed_txs[0].clone())
                 }
                 (1, Some(_)) => {
                     panic!("Tx submitted to two peers?!");

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1014,6 +1014,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                 Some("no bootstrap block".to_owned()),
             ));
         }
+        let local_block_index = num_blocks - 1;
 
         let mut response = mc_mobilecoind_api::GetNetworkStatusResponse::new();
 
@@ -1027,7 +1028,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                 .map(|(responder_id, block_index)| (responder_id.to_string(), *block_index))
                 .collect(),
         );
-        response.set_local_block_index(num_blocks - 1);
+        response.set_local_block_index(local_block_index);
+        response.set_is_behind(network_state.is_behind(local_block_index));
 
         Ok(response)
     }
@@ -2651,7 +2653,7 @@ mod test {
             get_testing_environment(3, &vec![], &vec![], logger.clone(), &mut rng);
 
         let network_status = client
-            .get_network_status(&mobilecoind_api::Empty::new())
+            .get_network_status(&mc_mobilecoind_api::Empty::new())
             .unwrap();
 
         assert_eq!(

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2642,4 +2642,26 @@ mod test {
             assert_eq!(response.get_memo(), "test memo");
         }
     }
+
+    #[test_with_logger]
+    fn test_get_network_status(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([23u8; 32]);
+
+        let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
+            get_testing_environment(3, &vec![], &vec![], logger.clone(), &mut rng);
+
+        let network_status = client
+            .get_network_status(&mobilecoind_api::Empty::new())
+            .unwrap();
+
+        assert_eq!(
+            network_status.network_highest_block_index,
+            ledger_db.num_blocks().unwrap() - 1
+        );
+
+        assert_eq!(
+            network_status.local_block_index,
+            ledger_db.num_blocks().unwrap() - 1
+        );
+    }
 }

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -215,6 +215,11 @@ fn setup_server(
         logger.clone(),
     )));
 
+    {
+        let mut network_state = network_state.lock().unwrap();
+        network_state.poll();
+    }
+
     let transactions_manager = TransactionsManager::new(
         ledger_db.clone(),
         mobilecoind_db.clone(),


### PR DESCRIPTION
This PR does the following:
* Modify `ledger_sync::*NetworkState` objects to expose the highest block index the network currently agrees on.
* Change`ledger_sync::LedgerSync*` objects to accept a network state wrapped in `Arc<Mutex<>>`, allowing it to be shared and be used by other consumers.
* Building on these changes, introduce a new `GetNetworkStatus` API to mobilecoind.
* Change the test client to take this new information into account.

The end result is that if it takes time to sync the ledger, users would have more visibility to that and not just see a 0 balance.