### PR TITLE
Add cumulative txo count to the block header

### DIFF
--- a/consensus/api/proto/blockchain.proto
+++ b/consensus/api/proto/blockchain.proto
@@ -57,12 +57,15 @@ message Block {
     // The index of this block in the blockchain.
     uint64 index = 4;
 
+    // The cumulative number of TXOs in the blockchain, including this block
+    uint64 cumulative_txo_count = 5;
+
     // Root hash of the membership proofs provided by the untrusted local system for validation.
     // This captures the state of all TxOuts in the ledger that this block was validated against.
-    external.TxOutMembershipElement root_element = 5;
+    external.TxOutMembershipElement root_element = 6;
 
     // Hash of the block's contents.
-    BlockContentsHash contents_hash = 6;
+    BlockContentsHash contents_hash = 7;
 }
 
 message BlockContents {

--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -743,6 +743,7 @@ impl From<&mc_transaction_core::Block> for blockchain::Block {
         block.set_version(other.version);
         block.set_parent_id(blockchain::BlockID::from(&other.parent_id));
         block.set_index(other.index);
+        block.set_cumulative_txo_count(other.cumulative_txo_count);
         block.set_root_element((&other.root_element).into());
         block.set_contents_hash(blockchain::BlockContentsHash::from(&other.contents_hash));
         block
@@ -765,6 +766,7 @@ impl TryFrom<&blockchain::Block> for mc_transaction_core::Block {
             version: value.version,
             parent_id,
             index: value.index,
+            cumulative_txo_count: value.cumulative_txo_count,
             root_element,
             contents_hash,
         };
@@ -940,6 +942,7 @@ mod conversion_tests {
             version: 1,
             parent_id: mc_transaction_core::BlockID::try_from(&[1u8; 32][..]).unwrap(),
             index: 99,
+            cumulative_txo_count: 400,
             root_element: TxOutMembershipElement {
                 range: Range::new(10, 20).unwrap(),
                 hash: TxOutMembershipHash::from([12u8; 32]),
@@ -953,6 +956,7 @@ mod conversion_tests {
         assert_eq!(block.get_version(), 1);
         assert_eq!(block.get_parent_id().get_data(), [1u8; 32]);
         assert_eq!(block.get_index(), 99);
+        assert_eq!(block.get_cumulative_txo_count(), 400);
         assert_eq!(block.get_root_element().get_range().get_from(), 10);
         assert_eq!(block.get_root_element().get_range().get_to(), 20);
         assert_eq!(block.get_root_element().get_hash().get_data(), &[12u8; 32]);
@@ -1005,6 +1009,7 @@ mod conversion_tests {
             version: 1,
             parent_id: mc_transaction_core::BlockID::try_from(&[1u8; 32][..]).unwrap(),
             index: 99,
+            cumulative_txo_count: 400,
             root_element: TxOutMembershipElement {
                 range: Range::new(10, 20).unwrap(),
                 hash: TxOutMembershipHash::from([12u8; 32]),

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -458,11 +458,9 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         let block_contents = BlockContents::new(key_images, outputs);
 
         // Form the block.
-        let block = Block::new(
+        let block = Block::new_with_parent(
             BLOCK_VERSION,
-            &parent_block.id,
-            parent_block.index + 1,
-            parent_block.cumulative_txo_count,
+            &parent_block,
             &root_elements[0],
             &block_contents,
         );

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -462,6 +462,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
             BLOCK_VERSION,
             &parent_block.id,
             parent_block.index + 1,
+            parent_block.cumulative_txo_count,
             &root_elements[0],
             &block_contents,
         );

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -210,6 +210,7 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
             BLOCK_VERSION,
             &parent_block.id,
             parent_block.index + 1,
+            parent_block.cumulative_txo_count,
             &root_elements[0],
             &block_contents,
         );

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -206,11 +206,9 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
 
         let block_contents = BlockContents::new(key_images, outputs);
 
-        let block = Block::new(
+        let block = Block::new_with_parent(
             BLOCK_VERSION,
-            &parent_block.id,
-            parent_block.index + 1,
-            parent_block.cumulative_txo_count,
+            &parent_block,
             &root_elements[0],
             &block_contents,
         );

--- a/consensus/service/src/blockchain_api_service.rs
+++ b/consensus/service/src/blockchain_api_service.rs
@@ -188,15 +188,14 @@ mod tests {
 
             let block = match parent_block {
                 None => Block::new_origin_block(&outputs),
-                Some(parent) => Block::new(
+                Some(parent) => Block::new_with_parent(
                     BLOCK_VERSION,
-                    &parent.id,
-                    block_index,
-                    parent.cumulative_txo_count,
+                    &parent,
                     &Default::default(),
                     &block_contents,
                 ),
             };
+            assert_eq!(block_index, block.index);
 
             db.append_block(&block, &block_contents, None)
                 .expect("failed writing initial transactions");

--- a/consensus/service/src/blockchain_api_service.rs
+++ b/consensus/service/src/blockchain_api_service.rs
@@ -192,6 +192,7 @@ mod tests {
                     BLOCK_VERSION,
                     &parent.id,
                     block_index,
+                    parent.cumulative_txo_count,
                     &Default::default(),
                     &block_contents,
                 ),

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -531,11 +531,9 @@ mod ledger_db_test {
 
             let block = match parent_block {
                 None => Block::new_origin_block(&outputs),
-                Some(parent) => Block::new(
+                Some(parent) => Block::new_with_parent(
                     BLOCK_VERSION,
-                    &parent.id,
-                    block_index,
-                    parent.cumulative_txo_count,
+                    &parent,
                     &Default::default(),
                     &block_contents,
                 ),
@@ -633,11 +631,9 @@ mod ledger_db_test {
         let key_images: Vec<KeyImage> = (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
 
         let block_contents = BlockContents::new(key_images.clone(), outputs);
-        let block = Block::new(
+        let block = Block::new_with_parent(
             BLOCK_VERSION,
-            &origin_block.id,
-            1,
-            origin_block.cumulative_txo_count,
+            &origin_block,
             &Default::default(),
             &block_contents,
         );
@@ -778,11 +774,9 @@ mod ledger_db_test {
         let outputs = vec![tx_out];
 
         let block_contents = BlockContents::new(key_images.clone(), outputs);
-        let block = Block::new(
+        let block = Block::new_with_parent(
             BLOCK_VERSION,
-            &origin_block.id,
-            1,
-            origin_block.cumulative_txo_count,
+            &origin_block,
             &Default::default(),
             &block_contents,
         );
@@ -826,14 +820,8 @@ mod ledger_db_test {
 
         let block_contents = BlockContents::new(key_images.clone(), outputs);
         let parent = ledger_db.get_block(n_blocks - 1).unwrap();
-        let block = Block::new(
-            BLOCK_VERSION,
-            &parent.id,
-            parent.index + 1,
-            parent.cumulative_txo_count,
-            &Default::default(),
-            &block_contents,
-        );
+        let block =
+            Block::new_with_parent(BLOCK_VERSION, &parent, &Default::default(), &block_contents);
 
         ledger_db
             .append_block(&block, &block_contents, None)
@@ -866,11 +854,9 @@ mod ledger_db_test {
         let outputs = Vec::new();
 
         let block_contents = BlockContents::new(key_images.clone(), outputs);
-        let block = Block::new(
+        let block = Block::new_with_parent(
             BLOCK_VERSION,
-            &origin_block.id,
-            1,
-            origin_block.cumulative_txo_count,
+            &origin_block,
             &Default::default(),
             &block_contents,
         );
@@ -990,11 +976,9 @@ mod ledger_db_test {
             BlockContents::new(block_one_key_images.clone(), outputs)
         };
 
-        let block_one = Block::new(
+        let block_one = Block::new_with_parent(
             BLOCK_VERSION,
-            &origin_block.id,
-            1,
-            origin_block.cumulative_txo_count,
+            &origin_block,
             &Default::default(),
             &block_one_contents,
         );
@@ -1017,11 +1001,9 @@ mod ledger_db_test {
             BlockContents::new(block_one_key_images.clone(), outputs)
         };
 
-        let block_two = Block::new(
+        let block_two = Block::new_with_parent(
             BLOCK_VERSION,
-            &block_one.id,
-            2,
-            block_one.cumulative_txo_count,
+            &block_one,
             &Default::default(),
             &block_two_contents,
         );
@@ -1141,9 +1123,7 @@ mod ledger_db_test {
             20,
             20,
             35,
-            origin_block.index + 1,
-            origin_block.id,
-            origin_block.cumulative_txo_count,
+            &origin_block,
             &mut rng,
         );
 

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -206,6 +206,8 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
         } else {
             // Create a normal block.
             let parent_id: BlockID = block_ids[block_index - 1].clone();
+            let parent_cumulative_txo_count =
+                blocks_and_contents[block_index - 1].0.cumulative_txo_count;
 
             let tx_out = TxOut::new(
                 16,
@@ -224,6 +226,7 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
                 BLOCK_VERSION,
                 &parent_id,
                 block_index as u64,
+                parent_cumulative_txo_count,
                 &TxOutMembershipElement::default(),
                 &block_contents,
             );
@@ -274,6 +277,7 @@ mod tests {
                 block.version,
                 &block.parent_id,
                 block.index,
+                block.cumulative_txo_count,
                 &block.root_element,
                 &block.contents_hash,
             );

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -205,10 +205,6 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
             blocks_and_contents.push((origin_block, block_contents));
         } else {
             // Create a normal block.
-            let parent_id: BlockID = block_ids[block_index - 1].clone();
-            let parent_cumulative_txo_count =
-                blocks_and_contents[block_index - 1].0.cumulative_txo_count;
-
             let tx_out = TxOut::new(
                 16,
                 &account_key.default_subaddress(),
@@ -222,11 +218,9 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
             let key_images = vec![KeyImage::from(rng.next_u64())];
             let block_contents = BlockContents::new(key_images, outputs);
 
-            let block = Block::new(
+            let block = Block::new_with_parent(
                 BLOCK_VERSION,
-                &parent_id,
-                block_index as u64,
-                parent_cumulative_txo_count,
+                &blocks_and_contents[block_index - 1].0,
                 &TxOutMembershipElement::default(),
                 &block_contents,
             );

--- a/ledger/sync/src/ledger_sync_service.rs
+++ b/ledger/sync/src/ledger_sync_service.rs
@@ -726,6 +726,7 @@ fn identify_safe_blocks<L: Ledger>(
             block.version,
             &block.parent_id,
             block.index,
+            block.cumulative_txo_count,
             &block.root_element,
             &block_contents.hash(),
         );

--- a/ledger/sync/src/test_app/main.rs
+++ b/ledger/sync/src/test_app/main.rs
@@ -36,9 +36,7 @@ fn _make_ledger_long(ledger: &mut LedgerDB) {
         1,
         1000,
         1000,
-        last_block.index + 1,
-        last_block.id,
-        last_block.cumulative_txo_count,
+        &last_block,
         &mut rng,
     );
 

--- a/ledger/sync/src/test_app/main.rs
+++ b/ledger/sync/src/test_app/main.rs
@@ -21,6 +21,7 @@ fn _make_ledger_long(ledger: &mut LedgerDB) {
 
     let num_blocks = ledger.num_blocks().unwrap();
     let last_block = ledger.get_block(num_blocks - 1).unwrap();
+    assert_eq!(last_block.cumulative_txo_count, ledger.num_txos().unwrap());
 
     let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
 
@@ -37,12 +38,14 @@ fn _make_ledger_long(ledger: &mut LedgerDB) {
         1000,
         last_block.index + 1,
         last_block.id,
+        last_block.cumulative_txo_count,
         &mut rng,
     );
 
     for (block, block_contents) in &results {
         println!("block {} containing {:?}", block.index, block_contents);
         ledger.append_block(block, block_contents, None).unwrap();
+        assert_eq!(block.cumulative_txo_count, ledger.num_txos().unwrap());
     }
 }
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1903,6 +1903,7 @@ mod test {
                 BLOCK_VERSION,
                 &parent.id,
                 num_blocks as BlockIndex,
+                parent.cumulative_txo_count,
                 &Default::default(),
                 &block_contents,
             );

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1058,7 +1058,7 @@ mod test {
         get_tx_out_shared_secret,
         onetime_keys::recover_onetime_private_key,
         tx::{Tx, TxOut},
-        Block, BlockContents, BlockIndex, BLOCK_VERSION,
+        Block, BlockContents, BLOCK_VERSION,
     };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
@@ -1899,11 +1899,9 @@ mod test {
             // Append to ledger.
             let num_blocks = ledger_db.num_blocks().unwrap();
             let parent = ledger_db.get_block(num_blocks - 1).unwrap();
-            let new_block = Block::new(
+            let new_block = Block::new_with_parent(
                 BLOCK_VERSION,
-                &parent.id,
-                num_blocks as BlockIndex,
-                parent.cumulative_txo_count,
+                &parent,
                 &Default::default(),
                 &block_contents,
             );

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -23,7 +23,7 @@ use mc_transaction_core::{
     account_keys::{AccountKey, PublicAddress, DEFAULT_SUBADDRESS_INDEX},
     ring_signature::KeyImage,
     tx::TxOut,
-    Block, BlockContents, BlockIndex, BLOCK_VERSION,
+    Block, BlockContents, BLOCK_VERSION,
 };
 use mc_util_from_random::FromRandom;
 use tempdir::TempDir;
@@ -169,14 +169,8 @@ pub fn add_block_to_ledger_db(
         let parent = ledger_db
             .get_block(num_blocks - 1)
             .expect("failed to get parent block");
-        new_block = Block::new(
-            BLOCK_VERSION,
-            &parent.id,
-            num_blocks as BlockIndex,
-            parent.cumulative_txo_count,
-            &Default::default(),
-            &block_contents,
-        );
+        new_block =
+            Block::new_with_parent(BLOCK_VERSION, &parent, &Default::default(), &block_contents);
     } else {
         new_block = Block::new_origin_block(&outputs);
     }

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -173,6 +173,7 @@ pub fn add_block_to_ledger_db(
             BLOCK_VERSION,
             &parent.id,
             num_blocks as BlockIndex,
+            parent.cumulative_txo_count,
             &Default::default(),
             &block_contents,
         );

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -34,13 +34,17 @@ pub struct Block {
     #[prost(uint64, tag = "4")]
     pub index: BlockIndex,
 
+    /// The cumulative number of Txos in the blockchain, including this block.
+    #[prost(uint64, tag = "5")]
+    pub cumulative_txo_count: u64,
+
     /// Root hash of the membership proofs provided by the untrusted local system for validation.
     /// This captures the state of all TxOuts in the ledger that this block was validated against.
-    #[prost(message, required, tag = "5")]
+    #[prost(message, required, tag = "6")]
     pub root_element: TxOutMembershipElement,
 
     /// Hash of the block's contents.
-    #[prost(message, required, tag = "6")]
+    #[prost(message, required, tag = "7")]
     pub contents_hash: BlockContentsHash,
 }
 
@@ -53,18 +57,26 @@ impl Block {
         let version = BLOCK_VERSION;
         let parent_id = BlockID::default();
         let index: BlockIndex = 0;
+        let cumulative_txo_count = outputs.len() as u64;
         let root_element = TxOutMembershipElement::default();
         // The origin block does not contain any key images.
         let key_images = Vec::new();
         let block_contents = BlockContents::new(key_images, outputs.to_vec());
         let contents_hash = block_contents.hash();
-
-        let id = compute_block_id(version, &parent_id, index, &root_element, &contents_hash);
+        let id = compute_block_id(
+            version,
+            &parent_id,
+            index,
+            cumulative_txo_count,
+            &root_element,
+            &contents_hash,
+        );
         Self {
             id,
             version,
             parent_id,
             index,
+            cumulative_txo_count,
             root_element,
             contents_hash,
         }
@@ -76,22 +88,34 @@ impl Block {
     /// * `version` - The block format version.
     /// * `parent_id` - `BlockID` of previous block in the blockchain.
     /// * `index` - The index of this block in the blockchain.
+    /// * `parent_cumulative_txo_count` - The cumulative txo count of the parent
     /// * `block_contents` - Contents of the block.
     pub fn new(
         version: u32,
         parent_id: &BlockID,
         index: BlockIndex,
+        parent_cumulative_txo_count: u64,
         root_element: &TxOutMembershipElement,
         block_contents: &BlockContents,
     ) -> Self {
+        let cumulative_txo_count =
+            parent_cumulative_txo_count + block_contents.outputs.len() as u64;
         let contents_hash = block_contents.hash();
-        let id = compute_block_id(version, &parent_id, index, &root_element, &contents_hash);
+        let id = compute_block_id(
+            version,
+            &parent_id,
+            index,
+            cumulative_txo_count,
+            &root_element,
+            &contents_hash,
+        );
 
         Self {
             id,
             version,
             parent_id: parent_id.clone(),
             index,
+            cumulative_txo_count,
             root_element: root_element.clone(),
             contents_hash,
         }
@@ -106,6 +130,7 @@ impl Block {
             self.version,
             &self.parent_id,
             self.index,
+            self.cumulative_txo_count,
             &self.root_element,
             &self.contents_hash,
         );
@@ -122,6 +147,7 @@ pub fn compute_block_id<D: Digest>(
     version: u32,
     parent_id: &BlockID<D>,
     index: BlockIndex,
+    cumulative_txo_count: u64,
     root_element: &TxOutMembershipElement,
     contents_hash: &BlockContentsHash<D>,
 ) -> BlockID<D> {
@@ -130,6 +156,7 @@ pub fn compute_block_id<D: Digest>(
     version.digest(&mut hasher);
     parent_id.digest(&mut hasher);
     index.digest(&mut hasher);
+    cumulative_txo_count.digest(&mut hasher);
     root_element.digest(&mut hasher);
     contents_hash.digest(&mut hasher);
 
@@ -177,7 +204,14 @@ mod block_tests {
 
         let key_images = Vec::new(); // TODO: include key images.
         let block_contents = BlockContents::new(key_images, outputs);
-        Block::new(BLOCK_VERSION, &parent_id, 3, &root_element, &block_contents)
+        Block::new(
+            BLOCK_VERSION,
+            &parent_id,
+            3,
+            400,
+            &root_element,
+            &block_contents,
+        )
     }
 
     #[test]

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -82,24 +82,50 @@ impl Block {
         }
     }
 
+    /// Creates a new `Block` intermediate in the block chain, from a parent block
+    /// Adds 1 to the parent.index, and adds block_contents.outputs.len()
+    /// to the parent.cumulative_txo_count, to compute values for the next block.
+    ///
+    /// # Arguments
+    /// * `version` - The block format version
+    /// * `parent` - The parent block
+    /// * `root_element` - The root element for membership proofs
+    /// * `block_contents - The Contents of the block.
+    pub fn new_with_parent(
+        version: u32,
+        parent: &Block,
+        root_element: &TxOutMembershipElement,
+        block_contents: &BlockContents,
+    ) -> Self {
+        Block::new(
+            version,
+            &parent.id,
+            parent.index + 1,
+            parent.cumulative_txo_count + block_contents.outputs.len() as u64,
+            root_element,
+            block_contents,
+        )
+    }
+
     /// Creates a new `Block`.
+    /// This low-level version doesn't require having the parent block in hand,
+    /// and takes all needed metadata for the block header as input.
     ///
     /// # Arguments
     /// * `version` - The block format version.
     /// * `parent_id` - `BlockID` of previous block in the blockchain.
     /// * `index` - The index of this block in the blockchain.
-    /// * `parent_cumulative_txo_count` - The cumulative txo count of the parent
+    /// * `cumulative_txo_count` - The cumulative txo count *including this block*
+    /// * `root_element` - The root element for membership proofs
     /// * `block_contents` - Contents of the block.
     pub fn new(
         version: u32,
         parent_id: &BlockID,
         index: BlockIndex,
-        parent_cumulative_txo_count: u64,
+        cumulative_txo_count: u64,
         root_element: &TxOutMembershipElement,
         block_contents: &BlockContents,
     ) -> Self {
-        let cumulative_txo_count =
-            parent_cumulative_txo_count + block_contents.outputs.len() as u64;
         let contents_hash = block_contents.hash();
         let id = compute_block_id(
             version,

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -235,7 +235,6 @@ pub fn initialize_ledger<L: Ledger, R: RngCore + CryptoRng>(
 }
 
 /// Generate a list of blocks, each with a random number of transactions.
-/// TODO: Maybe this should take the parent block as a &Block?
 pub fn get_blocks<T: Rng + RngCore + CryptoRng>(
     recipients: &[PublicAddress],
     n_blocks: usize,

--- a/transaction/core/tests/blockchain.rs
+++ b/transaction/core/tests/blockchain.rs
@@ -16,19 +16,18 @@ fn test_cumulative_txo_counts() {
             1,
             50,
             50,
-            origin.index + 1,
-            origin.id,
-            origin.cumulative_txo_count,
+            &origin,
             &mut rng,
         );
 
-        let mut prev_cumulative_txo_count = origin.cumulative_txo_count;
+        let mut prev = origin.clone();
         for (block, block_contents) in &results {
             assert_eq!(
                 block.cumulative_txo_count,
-                prev_cumulative_txo_count + block_contents.outputs.len() as u64
+                prev.cumulative_txo_count + block_contents.outputs.len() as u64
             );
-            prev_cumulative_txo_count = block.cumulative_txo_count;
+            assert_eq!(block.parent_id, prev.id);
+            prev = block.clone();
         }
     })
 }

--- a/transaction/core/tests/blockchain.rs
+++ b/transaction/core/tests/blockchain.rs
@@ -1,0 +1,34 @@
+use mc_transaction_core::{account_keys::AccountKey, Block, BlockContents};
+
+#[test]
+fn test_cumulative_txo_counts() {
+    mc_util_test_helper::run_with_several_seeds(|mut rng| {
+        let origin = Block::new_origin_block(&[]);
+
+        let accounts: Vec<AccountKey> = (0..20).map(|_i| AccountKey::random(&mut rng)).collect();
+        let recipient_pub_keys = accounts
+            .iter()
+            .map(|account| account.default_subaddress())
+            .collect::<Vec<_>>();
+
+        let results: Vec<(Block, BlockContents)> = mc_transaction_core_test_utils::get_blocks(
+            &recipient_pub_keys[..],
+            1,
+            50,
+            50,
+            origin.index + 1,
+            origin.id,
+            origin.cumulative_txo_count,
+            &mut rng,
+        );
+
+        let mut prev_cumulative_txo_count = origin.cumulative_txo_count;
+        for (block, block_contents) in &results {
+            assert_eq!(
+                block.cumulative_txo_count,
+                prev_cumulative_txo_count + block_contents.outputs.len() as u64
+            );
+            prev_cumulative_txo_count = block.cumulative_txo_count;
+        }
+    })
+}

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -66,14 +66,9 @@ pub fn bootstrap_ledger(
         let block_contents = BlockContents::new(key_images, outputs.clone());
 
         let block = match previous_block {
-            Some(parent) => Block::new(
-                BLOCK_VERSION,
-                &parent.id,
-                block_index,
-                parent.cumulative_txo_count,
-                &Default::default(),
-                &block_contents,
-            ),
+            Some(parent) => {
+                Block::new_with_parent(BLOCK_VERSION, &parent, &Default::default(), &block_contents)
+            }
             None => Block::new_origin_block(&outputs),
         };
         previous_block = Some(block.clone());

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -70,6 +70,7 @@ pub fn bootstrap_ledger(
                 BLOCK_VERSION,
                 &parent.id,
                 block_index,
+                parent.cumulative_txo_count,
                 &Default::default(),
                 &block_contents,
             ),


### PR DESCRIPTION
This will greatly simplify some post-processing stuff that happens
to the blockchain, it will mean that a bunch of services that
we have don't have to process the entire blockchain in order to
get these counts, which will become important when the blockchain
gets big.