### PR TITLE
AccountKey cleanup

### DIFF
--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -1152,7 +1152,7 @@ mod conversion_tests {
         let onetime_private_key = recover_onetime_private_key(
             &public_key,
             alice.view_private_key(),
-            &alice.default_subaddress_spend_key(),
+            &alice.default_subaddress_spend_private(),
         );
 
         let membership_proofs: Vec<TxOutMembershipProof> = ring

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -647,7 +647,7 @@ mod combine_tests {
         let onetime_private_key = recover_onetime_private_key(
             &tx_public_key_for_txo,
             alice.view_private_key(),
-            &alice.default_subaddress_spend_key(),
+            &alice.default_subaddress_spend_private(),
         );
 
         let ring: Vec<TxOut> = vec![tx_out];
@@ -720,7 +720,7 @@ mod combine_tests {
                 let onetime_private_key = recover_onetime_private_key(
                     &tx_public_key_for_txo,
                     alice.view_private_key(),
-                    &alice.default_subaddress_spend_key(),
+                    &alice.default_subaddress_spend_private(),
                 );
 
                 // Create InputCredentials to spend the TxOut.
@@ -783,7 +783,7 @@ mod combine_tests {
         let onetime_private_key = recover_onetime_private_key(
             &RistrettoPublic::try_from(&tx_out.public_key).unwrap(),
             alice.view_private_key(),
-            &alice.default_subaddress_spend_key(),
+            &alice.default_subaddress_spend_private(),
         );
 
         // Create a transaction that sends the full value of  `tx_out` to bob.
@@ -873,7 +873,7 @@ mod combine_tests {
             let onetime_private_key = recover_onetime_private_key(
                 &tx_public_key_for_txo,
                 alice.view_private_key(),
-                &alice.default_subaddress_spend_key(),
+                &alice.default_subaddress_spend_private(),
             );
 
             let ring: Vec<TxOut> = vec![tx_out];

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -625,7 +625,7 @@ impl<T: UserTxConnection + 'static> TransactionsManager<T> {
             let onetime_private_key = recover_onetime_private_key(
                 &public_key,
                 from_account_key.view_private_key(),
-                &from_account_key.subaddress_spend_key(utxo.subaddress_index),
+                &from_account_key.subaddress_spend_private(utxo.subaddress_index),
             );
 
             let key_image = KeyImage::from(&onetime_private_key);

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1329,7 +1329,7 @@ mod test {
                 let onetime_private_key = recover_onetime_private_key(
                     &tx_public_key,
                     account_key.view_private_key(),
-                    &account_key.subaddress_spend_key(0),
+                    &account_key.subaddress_spend_private(0),
                 );
                 let key_image = KeyImage::from(&onetime_private_key);
 

--- a/mobilecoind/src/sync.rs
+++ b/mobilecoind/src/sync.rs
@@ -386,7 +386,7 @@ fn match_tx_outs_into_utxos(
         let onetime_private_key = recover_onetime_private_key(
             &tx_public_key,
             account_key.view_private_key(),
-            &account_key.subaddress_spend_key(subaddress_id.index),
+            &account_key.subaddress_spend_private(subaddress_id.index),
         );
 
         let key_image = KeyImage::from(&onetime_private_key);

--- a/transaction/core/src/account_keys.rs
+++ b/transaction/core/src/account_keys.rs
@@ -252,12 +252,12 @@ impl AccountKey {
     /// Get the account's i^th subaddress.
     pub fn subaddress(&self, index: u64) -> PublicAddress {
         let subaddress_view_public = {
-            let subaddress_view_private = self.subaddress_view_key(index);
+            let subaddress_view_private = self.subaddress_view_private(index);
             RistrettoPublic::from(&subaddress_view_private)
         };
 
         let subaddress_spend_public = {
-            let subaddress_spend_private = self.subaddress_spend_key(index);
+            let subaddress_spend_private = self.subaddress_spend_private(index);
             RistrettoPublic::from(&subaddress_spend_private)
         };
 
@@ -272,12 +272,12 @@ impl AccountKey {
     }
 
     /// The private spend key for the default subaddress.
-    pub fn default_subaddress_spend_key(&self) -> RistrettoPrivate {
-        self.subaddress_spend_key(DEFAULT_SUBADDRESS_INDEX)
+    pub fn default_subaddress_spend_private(&self) -> RistrettoPrivate {
+        self.subaddress_spend_private(DEFAULT_SUBADDRESS_INDEX)
     }
 
     /// The private spend key for the i^th subaddress.
-    pub fn subaddress_spend_key(&self, index: u64) -> RistrettoPrivate {
+    pub fn subaddress_spend_private(&self, index: u64) -> RistrettoPrivate {
         let a: &Scalar = self.view_private_key.as_ref();
 
         // `Hs(a || n)`
@@ -294,12 +294,12 @@ impl AccountKey {
     }
 
     /// The private view key for the default subaddress.
-    pub fn default_subaddress_view_key(&self) -> RistrettoPrivate {
-        self.subaddress_view_key(DEFAULT_SUBADDRESS_INDEX)
+    pub fn default_subaddress_view_private(&self) -> RistrettoPrivate {
+        self.subaddress_view_private(DEFAULT_SUBADDRESS_INDEX)
     }
 
     /// The private view key for the i^th subaddress.
-    pub fn subaddress_view_key(&self, index: u64) -> RistrettoPrivate {
+    pub fn subaddress_view_private(&self, index: u64) -> RistrettoPrivate {
         let a: &Scalar = self.view_private_key.as_ref();
 
         // `Hs(a || n)`
@@ -351,11 +351,11 @@ mod account_key_tests {
 
         let account_key = AccountKey::new(&spend_private, &view_private);
 
-        let subaddress_index = rng.next_u64();
-        let subaddress = account_key.subaddress(subaddress_index);
+        let index = rng.next_u64();
+        let subaddress = account_key.subaddress(index);
 
-        let subaddress_view_private = account_key.subaddress_view_key(subaddress_index);
-        let subaddress_spend_private = account_key.subaddress_spend_key(subaddress_index);
+        let subaddress_view_private = account_key.subaddress_view_private(index);
+        let subaddress_spend_private = account_key.subaddress_spend_private(index);
 
         let expected_subaddress_view_public = RistrettoPublic::from(&subaddress_view_private);
         let expected_subaddress_spend_public = RistrettoPublic::from(&subaddress_spend_private);

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -18,6 +18,17 @@ use rand_core::{CryptoRng, RngCore};
 
 const G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
 
+/// Generate a tx pubkey for a subaddress transaction
+pub fn compute_tx_pubkey(
+    tx_secret_key: &RistrettoPrivate,
+    recipient_spend_key: &RistrettoPublic,
+) -> RistrettoPublic {
+    let s: &Scalar = tx_secret_key.as_ref();
+    let D = recipient_spend_key.as_ref();
+    let R = s * D;
+    RistrettoPublic::from(R)
+}
+
 /// Creates the one-time public key `P = Hs(s*C)*G + D`.
 ///
 /// # Arguments
@@ -148,17 +159,6 @@ pub fn generate_tx_keypair<T: CryptoRng + RngCore>(
     let tx_pubkey = compute_tx_pubkey(&tx_secret_key, &recipient_spend_key);
 
     (tx_pubkey, tx_secret_key)
-}
-
-/// Generate a tx pubkey for a subaddress transaction
-pub fn compute_tx_pubkey(
-    tx_secret_key: &RistrettoPrivate,
-    recipient_spend_key: &RistrettoPublic,
-) -> RistrettoPublic {
-    let s: &Scalar = tx_secret_key.as_ref();
-    let D = recipient_spend_key.as_ref();
-    let R = s * D;
-    RistrettoPublic::from(R)
 }
 
 #[cfg(test)]

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -216,7 +216,7 @@ mod tests {
         let onetime_private_key = recover_onetime_private_key(
             &tx_pub_key,
             account.view_private_key(),
-            &account.default_subaddress_spend_key(),
+            &account.default_subaddress_spend_private(),
         );
         assert_eq!(
             onetime_public_key,

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -105,7 +105,7 @@ pub fn create_transaction_with_amount<L: Ledger, R: RngCore + CryptoRng>(
         .collect::<Vec<u64>>();
     let membership_proofs = ledger.get_tx_out_proof_of_memberships(&indexes).unwrap();
 
-    let spend_private_key = sender.subaddress_spend_key(DEFAULT_SUBADDRESS_INDEX);
+    let spend_private_key = sender.subaddress_spend_private(DEFAULT_SUBADDRESS_INDEX);
     let tx_out_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
     let onetime_private_key = recover_onetime_private_key(
         &tx_out_public_key,

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -299,7 +299,7 @@ pub mod transaction_builder_tests {
             let onetime_private_key = recover_onetime_private_key(
                 &RistrettoPublic::try_from(&real_output.public_key).unwrap(),
                 &sender.view_private_key(),
-                &sender.subaddress_spend_key(DEFAULT_SUBADDRESS_INDEX),
+                &sender.subaddress_spend_private(DEFAULT_SUBADDRESS_INDEX),
             );
 
             let membership_proofs: Vec<TxOutMembershipProof> = ring
@@ -352,7 +352,7 @@ pub mod transaction_builder_tests {
         let onetime_private_key = recover_onetime_private_key(
             &RistrettoPublic::try_from(&real_output.public_key).unwrap(),
             &sender.view_private_key(),
-            &sender.subaddress_spend_key(DEFAULT_SUBADDRESS_INDEX),
+            &sender.subaddress_spend_private(DEFAULT_SUBADDRESS_INDEX),
         );
 
         let key_image = KeyImage::from(&onetime_private_key);
@@ -445,7 +445,7 @@ pub mod transaction_builder_tests {
         let onetime_private_key = recover_onetime_private_key(
             &RistrettoPublic::try_from(&real_output.public_key).unwrap(),
             &alice.view_private_key(),
-            &alice.subaddress_spend_key(DEFAULT_SUBADDRESS_INDEX),
+            &alice.subaddress_spend_private(DEFAULT_SUBADDRESS_INDEX),
         );
 
         let membership_proofs: Vec<TxOutMembershipProof> = ring


### PR DESCRIPTION
- Updates PublicAddress docs to refer to subaddresses
- Unit tests that private subaddress keys agree with public subaddress keys.
- Removes redundant math in AccountKey.subaddress()
