### PR TITLE
More serde->prost changes in Ledger + introducing metadata versioning storage

### DIFF
--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -48,6 +48,9 @@ pub enum Error {
 
     #[fail(display = "RangeError")]
     RangeError,
+
+    #[fail(display = "Database version {} is incompatible with {}", _0, _1)]
+    VersionIncompatible(u64, u64),
 }
 
 impl From<lmdb::Error> for Error {

--- a/ledger/db/src/metadata.rs
+++ b/ledger/db/src/metadata.rs
@@ -6,6 +6,7 @@ use prost::Message;
 // Default database version. This should be bumped when breaking changes are introduced.
 // If this is properly maintained, we could check during ledger db opening for any
 // incompatibilities, and either refuse to open or perform a migration.
+#[allow(clippy::unreadable_literal)]
 pub const LATEST_VERSION: u64 = 20200427;
 
 // Metadata information about the ledger databse.

--- a/ledger/db/src/metadata.rs
+++ b/ledger/db/src/metadata.rs
@@ -1,0 +1,87 @@
+use crate::Error;
+use lmdb::{Database, DatabaseFlags, Environment, Transaction, WriteFlags};
+use mc_util_serial::{decode, encode};
+use prost::Message;
+
+// Default database version. This should be bumped when breaking changes are introduced.
+// If this is properly maintained, we could check during ledger db opening for any
+// incompatibilities, and either refuse to open or perform a migrate.
+pub const LATEST_VERSION: u64 = 20200427;
+
+// Metadata information about the ledger databse.
+#[derive(Clone, Message)]
+pub struct MetadataVersion {
+    // Database format version.
+    #[prost(uint64)]
+    pub database_format_version: u64,
+
+    // Crate version that created the database. This could be bumped by a migration in a future
+    // release.
+    #[prost(string)]
+    pub created_by_crate_version: String,
+}
+
+impl MetadataVersion {
+    /// Construct a MetadataVersion instance with the most up to date versioning information.
+    pub fn latest() -> Self {
+        Self {
+            database_format_version: LATEST_VERSION,
+            created_by_crate_version: env!("CARGO_PKG_VERSION").to_owned(),
+        }
+    }
+
+    /// Check if a given version is compatible with the latest version.
+    pub fn is_compatible_with_latest(&self) -> Result<(), Error> {
+        let latest = Self::latest();
+        if self.database_format_version != latest.database_format_version {
+            Err(Error::VersionIncompatible(
+                self.database_format_version,
+                latest.database_format_version,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+// LMDB Database names.
+const METADATA_DB_NAME: &str = "ledger_db_metadata";
+
+// Keys in the metadata database
+const METADATA_VERSION_KEY: &str = "version";
+
+#[derive(Clone)]
+pub struct MetadataStore {
+    metadata: Database,
+}
+
+impl MetadataStore {
+    /// Opens an existing MetadataStore.
+    pub fn new(env: &Environment) -> Result<Self, Error> {
+        Ok(Self {
+            metadata: env.open_db(Some(METADATA_DB_NAME))?,
+        })
+    }
+
+    // Creates a fresh MetadataStore on disk.
+    pub fn create(env: &Environment) -> Result<(), Error> {
+        let metadata = env.create_db(Some(METADATA_DB_NAME), DatabaseFlags::empty())?;
+
+        let mut db_transaction = env.begin_rw_txn()?;
+
+        db_transaction.put(
+            metadata,
+            &METADATA_VERSION_KEY,
+            &encode(&MetadataVersion::latest()),
+            WriteFlags::empty(),
+        )?;
+
+        db_transaction.commit()?;
+        Ok(())
+    }
+
+    // Get version data from the database.
+    pub fn get_version(&self, db_txn: &impl Transaction) -> Result<MetadataVersion, Error> {
+        Ok(decode(db_txn.get(self.metadata, &METADATA_VERSION_KEY)?)?)
+    }
+}

--- a/ledger/db/src/metadata.rs
+++ b/ledger/db/src/metadata.rs
@@ -5,7 +5,7 @@ use prost::Message;
 
 // Default database version. This should be bumped when breaking changes are introduced.
 // If this is properly maintained, we could check during ledger db opening for any
-// incompatibilities, and either refuse to open or perform a migrate.
+// incompatibilities, and either refuse to open or perform a migration.
 pub const LATEST_VERSION: u64 = 20200427;
 
 // Metadata information about the ledger databse.

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -31,7 +31,7 @@ use mc_transaction_core::{
     range::Range,
     tx::{TxOut, TxOutMembershipProof},
 };
-use mc_util_serial::{deserialize, serialize};
+use mc_util_serial::{decode, encode};
 
 // LMDB Database names.
 const COUNTS_DB_NAME: &str = "tx_out_store:counts";
@@ -48,7 +48,7 @@ pub struct TxOutStore {
     /// * `NUM_TX_OUTS_KEY` --> Number (u64) of TxOuts in the ledger.
     counts: Database,
 
-    /// TxOut by index. `key_bytes_to_u64(index) -> serialize(&tx_out)`
+    /// TxOut by index. `key_bytes_to_u64(index) -> encode(&tx_out)`
     tx_out_by_index: Database,
 
     /// `tx_out.hash() -> u64_to_key_bytes(index)`
@@ -111,7 +111,7 @@ impl TxOutStore {
             WriteFlags::empty(),
         )?;
 
-        let tx_out_bytes: Vec<u8> = serialize(tx_out)?;
+        let tx_out_bytes: Vec<u8> = encode(tx_out);
 
         db_transaction.put(
             self.tx_out_by_index,
@@ -149,7 +149,7 @@ impl TxOutStore {
         db_transaction: &T,
     ) -> Result<TxOut, Error> {
         let tx_out_bytes = db_transaction.get(self.tx_out_by_index, &u64_to_key_bytes(index))?;
-        let tx_out: TxOut = deserialize(tx_out_bytes)?;
+        let tx_out: TxOut = decode(tx_out_bytes)?;
         Ok(tx_out)
     }
 
@@ -202,7 +202,7 @@ impl TxOutStore {
             merkle_hash.copy_from_slice(bytes);
             Ok(merkle_hash)
         } else {
-            // Failed to deserialize the Merkle hash.
+            // Failed to decode the Merkle hash.
             Err(Error::Deserialization)
         }
     }

--- a/tools/local-network/bootstrap.sh
+++ b/tools/local-network/bootstrap.sh
@@ -67,5 +67,5 @@ fi
 if [ -f $PROJECT_ROOT/target/release/generate_sample_ledger ]; then
     $PROJECT_ROOT/target/release/generate_sample_ledger --txs ${BOOTSTRAP_NUM}
 else
-    cargo run --bin mc-util-generate_sample_ledger --release -- --txs ${BOOTSTRAP_NUM}
+    cargo run --bin mc-util-generate-sample-ledger --release -- --txs ${BOOTSTRAP_NUM}
 fi


### PR DESCRIPTION
This PR:
* Changes TxOutStore and key images storage to encode using Prost instead of serializing using Serde. This makes the entire ledger lmdb file contents be protobufs, so it could be read by other implementations, and fields could easily be added as long as the tag numbers do not conflict.
* It also adds a new database that stores a u64 version number, and the crate version string that created the database. My hope is that when we introduce breaking changes we would be able to write code that looks at these version numbers and perform migrations / alert the user about the incompatibility. This would rely on us remembering to update this code when we make breaking changes. It would've been nice if this could happen automatically, but I couldn't figure out reasonable way to do it (for example, https://github.com/danburkert/prost/issues/235 would've been nice for such a thing). If we decode this is useless we could always drop it later, that won't break anything.