### PR TITLE
Add versioning to S3Block

### DIFF
--- a/consensus/api/proto/blockchain.proto
+++ b/consensus/api/proto/blockchain.proto
@@ -78,7 +78,8 @@ message BlockSignature {
     external.Ed25519Public signer = 2;
 }
 
-message S3BlockV1 {
+// Version 1 of an archived block.
+message ArchiveBlockV1 {
     // Block
     Block block = 1;
 
@@ -89,8 +90,9 @@ message S3BlockV1 {
     BlockSignature signature = 3;
 }
 
-message S3Block {
+// An archived block.
+message ArchiveBlock {
     oneof block {
-        S3BlockV1 v1 = 1;
+        ArchiveBlockV1 v1 = 1;
     }
 }

--- a/consensus/api/proto/blockchain.proto
+++ b/consensus/api/proto/blockchain.proto
@@ -78,7 +78,7 @@ message BlockSignature {
     external.Ed25519Public signer = 2;
 }
 
-message S3Block {
+message S3BlockV1 {
     // Block
     Block block = 1;
 
@@ -87,4 +87,10 @@ message S3Block {
 
     // Block signature, when available.
     BlockSignature signature = 3;
+}
+
+message S3Block {
+    oneof block {
+        S3BlockV1 v1 = 1;
+    }
 }

--- a/ledger/distribution/src/main.rs
+++ b/ledger/distribution/src/main.rs
@@ -153,17 +153,17 @@ impl BlockHandler for S3BlockWriter {
         let bc_block = blockchain::Block::from(block);
         let bc_block_contents = blockchain::BlockContents::from(block_contents);
 
-        let mut s3_block_v1 = blockchain::S3BlockV1::new();
-        s3_block_v1.set_block(bc_block);
-        s3_block_v1.set_block_contents(bc_block_contents);
+        let mut archive_block_v1 = blockchain::ArchiveBlockV1::new();
+        archive_block_v1.set_block(bc_block);
+        archive_block_v1.set_block_contents(bc_block_contents);
 
         if let Some(signature) = signature {
             let bc_signature = blockchain::BlockSignature::from(signature);
-            s3_block_v1.set_signature(bc_signature);
+            archive_block_v1.set_signature(bc_signature);
         }
 
-        let mut s3_block = blockchain::S3Block::new();
-        s3_block.set_v1(s3_block_v1);
+        let mut archive_block = blockchain::ArchiveBlock::new();
+        archive_block.set_v1(archive_block_v1);
 
         let dest = self
             .path
@@ -176,9 +176,9 @@ impl BlockHandler for S3BlockWriter {
         self.write_bytes_to_s3(
             dir.to_str().unwrap(),
             filename.to_str().unwrap(),
-            &s3_block
+            &archive_block
                 .write_to_bytes()
-                .expect("failed to serialize S3Block"),
+                .expect("failed to serialize ArchiveBlock"),
         );
     }
 }
@@ -209,21 +209,21 @@ impl BlockHandler for LocalBlockWriter {
         let bc_block = blockchain::Block::from(block);
         let bc_block_contents = blockchain::BlockContents::from(block_contents);
 
-        let mut s3_block_v1 = blockchain::S3BlockV1::new();
-        s3_block_v1.set_block(bc_block);
-        s3_block_v1.set_block_contents(bc_block_contents);
+        let mut archive_block_v1 = blockchain::ArchiveBlockV1::new();
+        archive_block_v1.set_block(bc_block);
+        archive_block_v1.set_block_contents(bc_block_contents);
 
         if let Some(signature) = signature {
             let bc_signature = blockchain::BlockSignature::from(signature);
-            s3_block_v1.set_signature(bc_signature);
+            archive_block_v1.set_signature(bc_signature);
         }
 
-        let mut s3_block = blockchain::S3Block::new();
-        s3_block.set_v1(s3_block_v1);
+        let mut archive_block = blockchain::ArchiveBlock::new();
+        archive_block.set_v1(archive_block_v1);
 
-        let bytes = s3_block
+        let bytes = archive_block
             .write_to_bytes()
-            .expect("failed to serialize S3Block");
+            .expect("failed to serialize ArchiveBlock");
 
         let dest = self
             .path

--- a/ledger/distribution/src/main.rs
+++ b/ledger/distribution/src/main.rs
@@ -153,14 +153,17 @@ impl BlockHandler for S3BlockWriter {
         let bc_block = blockchain::Block::from(block);
         let bc_block_contents = blockchain::BlockContents::from(block_contents);
 
-        let mut s3_block = blockchain::S3Block::new();
-        s3_block.set_block(bc_block);
-        s3_block.set_block_contents(bc_block_contents);
+        let mut s3_block_v1 = blockchain::S3BlockV1::new();
+        s3_block_v1.set_block(bc_block);
+        s3_block_v1.set_block_contents(bc_block_contents);
 
         if let Some(signature) = signature {
             let bc_signature = blockchain::BlockSignature::from(signature);
-            s3_block.set_signature(bc_signature);
+            s3_block_v1.set_signature(bc_signature);
         }
+
+        let mut s3_block = blockchain::S3Block::new();
+        s3_block.set_v1(s3_block_v1);
 
         let dest = self
             .path
@@ -206,14 +209,17 @@ impl BlockHandler for LocalBlockWriter {
         let bc_block = blockchain::Block::from(block);
         let bc_block_contents = blockchain::BlockContents::from(block_contents);
 
-        let mut s3_block = blockchain::S3Block::new();
-        s3_block.set_block(bc_block);
-        s3_block.set_block_contents(bc_block_contents);
+        let mut s3_block_v1 = blockchain::S3BlockV1::new();
+        s3_block_v1.set_block(bc_block);
+        s3_block_v1.set_block_contents(bc_block_contents);
 
         if let Some(signature) = signature {
             let bc_signature = blockchain::BlockSignature::from(signature);
-            s3_block.set_signature(bc_signature);
+            s3_block_v1.set_signature(bc_signature);
         }
+
+        let mut s3_block = blockchain::S3Block::new();
+        s3_block.set_v1(s3_block_v1);
 
         let bytes = s3_block
             .write_to_bytes()


### PR DESCRIPTION
This PR uses protobuf's [oneof](https://developers.google.com/protocol-buffers/docs/proto3#oneof) to add future-compatibility to our S3 block proto message.