### PR TITLE
simplify ResponderId implementation

### DIFF
--- a/common/src/responder_id.rs
+++ b/common/src/responder_id.rs
@@ -7,15 +7,11 @@ use alloc::{
     vec::Vec,
 };
 use core::{
-    convert::TryFrom,
     fmt::{Display, Formatter, Result as FmtResult},
     str::FromStr,
 };
 use failure::Fail;
 use serde::{Deserialize, Serialize};
-
-/// The type of data used by a ResponderId (must implement AsRef<[u8]>, Display,
-pub type ResponderIdType = String;
 
 /// Potential parse errors
 #[derive(Debug, Fail, Ord, PartialOrd, Eq, PartialEq, Clone)]
@@ -26,19 +22,13 @@ pub enum ResponderIdParseError {
     InvalidFormat(String),
 }
 
-/// Node unique identifier (this will eventually be the node's TLS name).
+/// Node unique identifier.
 #[derive(Clone, Default, Debug, Eq, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Hash)]
-pub struct ResponderId(pub ResponderIdType);
+pub struct ResponderId(pub String);
 
 impl Display for ResponderId {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         write!(f, "{}", self.0)
-    }
-}
-
-impl AsRef<[u8]> for ResponderId {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
     }
 }
 
@@ -53,23 +43,6 @@ impl FromStr for ResponderId {
         }
 
         Ok(Self(src.to_string()))
-    }
-}
-
-impl TryFrom<Vec<u8>> for ResponderId {
-    type Error = ResponderIdParseError;
-
-    fn try_from(val: Vec<u8>) -> Result<Self, Self::Error> {
-        Self::from_str(
-            &String::from_utf8(val.clone())
-                .map_err(|_| ResponderIdParseError::FromUtf8Error(val))?,
-        )
-    }
-}
-
-impl ResponderId {
-    pub fn as_bytes(&self) -> &[u8] {
-        self.0.as_bytes()
     }
 }
 

--- a/consensus/api/proto/consensus_peer.proto
+++ b/consensus/api/proto/consensus_peer.proto
@@ -27,9 +27,8 @@ service ConsensusPeerAPI {
 }
 
 message ConsensusMsg {
-    // Serialized ReponsderId this message is coming from.
-    // This will get replace by an Enclave Session ID at some point.
-    bytes from_responder_id = 1;
+    // ReponsderId this message is coming from.
+    string from_responder_id = 1;
 
     // Serialized peers::ConsensusMsg.
     bytes payload = 2;

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -34,6 +34,7 @@ use mc_util_metrics::SVC_COUNTERS;
 use mc_util_serial::deserialize;
 use std::{
     convert::{TryFrom, TryInto},
+    str::FromStr,
     sync::Arc,
 };
 
@@ -236,8 +237,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> ConsensusPeerApi for PeerApiService<E,
                 };
 
             // Get the peer who delivered this message to us.
-            let from_responder_id: ResponderId = match deserialize(request.get_from_responder_id())
-            {
+            let from_responder_id = match ResponderId::from_str(request.get_from_responder_id()) {
                 Ok(val) => val,
                 Err(err) => {
                     send_result(

--- a/peers/src/connection.rs
+++ b/peers/src/connection.rs
@@ -236,7 +236,7 @@ impl<Enclave: ConsensusEnclaveProxy> ConsensusConnection for PeerConnection<Encl
 
     fn send_consensus_msg(&mut self, msg: &ConsensusMsg) -> Result<ConsensusMsgResponse> {
         let mut grpc_msg = GrpcConsensusMsg::default();
-        grpc_msg.set_from_responder_id(serialize(&self.local_node_id.responder_id)?);
+        grpc_msg.set_from_responder_id(self.local_node_id.responder_id.to_string());
         grpc_msg.set_payload(serialize(&msg)?);
 
         let response =


### PR DESCRIPTION
Previously `ResponderId` was passed over grpc as a serde-serialized object, but we could simplify that and pass it as the string that it is (and that's unlikely to change any time soon or at all). This PR takes care of that.