### PR TITLE
MC-1378 Subaddress hash functions use domain separator

### DIFF
--- a/transaction/core/src/account_keys.rs
+++ b/transaction/core/src/account_keys.rs
@@ -12,7 +12,7 @@
 
 #![allow(non_snake_case)]
 
-use crate::view_key::ViewKey;
+use crate::{domain_separators::SUBADDRESS_DOMAIN_TAG, view_key::ViewKey};
 use alloc::string::{String, ToString};
 use blake2::{Blake2b, Digest};
 use core::{
@@ -284,6 +284,7 @@ impl AccountKey {
         let Hs: Scalar = {
             let n = Scalar::from(index);
             let mut digest = Blake2b::new();
+            digest.input(SUBADDRESS_DOMAIN_TAG);
             digest.input(a.as_bytes());
             digest.input(n.as_bytes());
             Scalar::from_hash::<Blake2b>(digest)
@@ -306,6 +307,7 @@ impl AccountKey {
         let Hs: Scalar = {
             let n = Scalar::from(index);
             let mut digest = Blake2b::new();
+            digest.input(SUBADDRESS_DOMAIN_TAG);
             digest.input(a.as_bytes());
             digest.input(n.as_bytes());
             Scalar::from_hash::<Blake2b>(digest)

--- a/transaction/core/src/constants.rs
+++ b/transaction/core/src/constants.rs
@@ -71,20 +71,20 @@ mod tests {
         let view_public_key_bytes: [u8; 32] = fee_subaddress.view_public_key().to_bytes();
         let view_private_key_bytes: [u8; 32] = fee_account.view_private_key().to_bytes();
 
-        println!(
-            "pub const FEE_SPEND_PUBLIC_KEY: [u8; 32] = {:?};",
-            spend_public_key_bytes
-        );
-
-        println!(
-            "pub const FEE_VIEW_PUBLIC_KEY: [u8; 32] = {:?};",
-            view_public_key_bytes
-        );
-
-        println!(
-            "pub const FEE_VIEW_PRIVATE_KEY: [u8; 32] = {:?};",
-            view_private_key_bytes
-        );
+        // println!(
+        //     "pub const FEE_SPEND_PUBLIC_KEY: [u8; 32] = {:?};",
+        //     spend_public_key_bytes
+        // );
+        //
+        // println!(
+        //     "pub const FEE_VIEW_PUBLIC_KEY: [u8; 32] = {:?};",
+        //     view_public_key_bytes
+        // );
+        //
+        // println!(
+        //     "pub const FEE_VIEW_PRIVATE_KEY: [u8; 32] = {:?};",
+        //     view_private_key_bytes
+        // );
 
         assert_eq!(view_private_key_bytes, FEE_VIEW_PRIVATE_KEY);
         assert_eq!(view_public_key_bytes, FEE_VIEW_PUBLIC_KEY);

--- a/transaction/core/src/domain_separators.rs
+++ b/transaction/core/src/domain_separators.rs
@@ -24,6 +24,9 @@ pub const BULLETPROOF_DOMAIN_TAG: &str = "mc_bulletproof_transcript";
 // TODO:
 // pub const HASH_TO_POINT_DOMAIN_TAG: &str = "mc_hash_to_point";
 
+/// Domain separator for hashing a private view key and index into a subaddress.
+pub const SUBADDRESS_DOMAIN_TAG: &str = "mc_subaddress";
+
 /// Domain separator for hashing a TxOut leaf node in a Merkle tree.
 pub const TXOUT_MERKLE_LEAF_DOMAIN_TAG: &str = "mc_tx_out_merkle_leaf";
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -377,21 +377,18 @@ prost_message_helper32! { TxOutMembershipHash }
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
-    use mc_crypto_keys::RistrettoPublic;
-    use mc_util_from_random::FromRandom;
-    use mc_util_serial::ReprBytes32;
-    use prost::Message;
-    use rand::{rngs::StdRng, SeedableRng};
-
     use crate::{
-        account_keys::AccountKey,
         amount::Amount,
-        constants::{BASE_FEE, FEE_SPEND_PUBLIC_KEY, FEE_VIEW_PRIVATE_KEY, FEE_VIEW_PUBLIC_KEY},
+        constants::BASE_FEE,
         encrypted_fog_hint::EncryptedFogHint,
         ring_signature::SignatureRctBulletproofs,
         tx::{Tx, TxIn, TxOut, TxPrefix},
     };
+    use alloc::vec::Vec;
+    use mc_crypto_keys::RistrettoPublic;
+    use mc_util_from_random::FromRandom;
+    use prost::Message;
+    use rand::{rngs::StdRng, SeedableRng};
 
     #[test]
     // `serialize_tx` should create a Tx, encode/decode it, and compare
@@ -448,29 +445,5 @@ mod tests {
         tx.encode(&mut buf).expect("failed to serialize into slice");
         let recovered_tx: Tx = Tx::decode(&buf[..]).unwrap();
         assert_eq!(tx, recovered_tx);
-    }
-
-    #[test]
-    fn generate_fee_view_key() {
-        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-        let account_key = AccountKey::random(&mut rng);
-        let account_public_addr = account_key.default_subaddress();
-
-        let spend_public_key = account_public_addr.spend_public_key();
-        let spend_public_key_bytes: [u8; 32] = spend_public_key.to_bytes();
-
-        let view_public_key = account_public_addr.view_public_key();
-        let view_public_key_bytes: [u8; 32] = view_public_key.to_bytes();
-
-        let view_private_key = *account_key.view_private_key();
-        let view_private_key_bytes: [u8; 32] = view_private_key.to_bytes();
-
-        //println!("view private key {:?}", view_private_key_bytes);
-        //println!("view public key {:?}", view_public_key_bytes);
-        //println!("spend public key {:?}", spend_public_key_bytes);
-
-        assert_eq!(view_private_key_bytes, FEE_VIEW_PRIVATE_KEY);
-        assert_eq!(view_public_key_bytes, FEE_VIEW_PUBLIC_KEY);
-        assert_eq!(spend_public_key_bytes, FEE_SPEND_PUBLIC_KEY);
     }
 }


### PR DESCRIPTION
Adds a domain separator tag to the subaddress hashes, and updates the Fee account keys.

This changes all subaddresses, which breaks compatibility with the existing ledger.