### PR TITLE
MC-511 TransactionBuilder sorts outputs by public key

### DIFF
--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1108,7 +1108,10 @@ mod test {
     };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
-    use std::{convert::TryFrom, iter::FromIterator};
+    use std::{
+        convert::{TryFrom, TryInto},
+        iter::FromIterator,
+    };
 
     #[test_with_logger]
     fn test_add_monitor_impl(logger: Logger) {
@@ -2237,18 +2240,22 @@ mod test {
                 response.get_receiver_tx_receipt_list().len() + 1, // There's a change output that is not part of the receipts
                 tx.prefix.outputs.len()
             );
-            for (tx_out, receipt) in tx
+
+            let tx_out_hashes: Vec<_> = tx.prefix.outputs.iter().map(TxOut::hash).collect();
+            let tx_out_public_keys: Vec<_> = tx
                 .prefix
                 .outputs
                 .iter()
-                .zip(response.get_receiver_tx_receipt_list().iter())
-            {
-                assert_eq!(tx_out.hash(), receipt.get_tx_out_hash(),);
+                .map(|tx_out| tx_out.public_key.to_bytes())
+                .collect();
 
-                assert_eq!(
-                    tx_out.public_key.as_bytes(),
-                    receipt.get_tx_public_key().get_data(),
-                );
+            for receipt in response.get_receiver_tx_receipt_list().iter() {
+                let hash: [u8; 32] = receipt.get_tx_out_hash().try_into().unwrap();
+                assert!(tx_out_hashes.contains(&hash));
+
+                let public_key: [u8; 32] =
+                    receipt.get_tx_public_key().get_data().try_into().unwrap();
+                assert!(tx_out_public_keys.contains(&public_key));
             }
 
             // Check that attempted_spend_height got updated for the relevant utxos.

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1804,23 +1804,38 @@ mod test {
                 outlays.len() + 1
             ); // Extra output for change.
 
-            // Sanity test output amounts
             let tx = Tx::try_from(tx_proposal.get_tx()).unwrap();
 
-            let change = test_utils::PER_RECIPIENT_AMOUNT
+            // The transaction should contain an output for each outlay, and one for change.
+            assert_eq!(tx.prefix.outputs.len(), outlays.len() + 1);
+
+            let change_value = test_utils::PER_RECIPIENT_AMOUNT
                 - outlays.iter().map(|outlay| outlay.value).sum::<u64>()
                 - BASE_FEE;
 
-            for (account_key, tx_out, expected_amount) in &[
-                (&receiver1, &tx.prefix.outputs[0], outlays[0].value),
-                (&receiver2, &tx.prefix.outputs[1], outlays[1].value),
-                (&sender, &tx.prefix.outputs[2], change),
+            for (account_key, expected_value) in &[
+                (&receiver1, outlays[0].value),
+                (&receiver2, outlays[1].value),
+                (&sender, change_value),
             ] {
-                let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
-                let shared_secret =
-                    get_tx_out_shared_secret(account_key.view_private_key(), &tx_public_key);
-                let (value, _blinding) = tx_out.amount.get_value(&shared_secret).unwrap();
-                assert_eq!(value, *expected_amount);
+                // Find the first output belonging to the account, and get its value.
+                // This assumes that each output is sent to a different account key.
+                let (value, _blinding) = tx
+                    .prefix
+                    .outputs
+                    .iter()
+                    .find_map(|tx_out| {
+                        let output_public_key =
+                            RistrettoPublic::try_from(&tx_out.public_key).unwrap();
+                        let shared_secret = get_tx_out_shared_secret(
+                            account_key.view_private_key(),
+                            &output_public_key,
+                        );
+                        tx_out.amount.get_value(&shared_secret).ok()
+                    })
+                    .expect("There should be an output belonging to the account key.");
+
+                assert_eq!(value, *expected_value);
             }
 
             // Santity test fee

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -25,8 +25,7 @@ use std::collections::HashSet;
 #[derive(Debug)]
 pub struct TransactionBuilder {
     input_credentials: Vec<InputCredentials>,
-    outputs: Vec<TxOut>,
-    output_shared_secrets: Vec<RistrettoPublic>,
+    outputs_and_shared_secrets: Vec<(TxOut, RistrettoPublic)>,
     tombstone_block: u64,
     pub fee: u64,
 }
@@ -36,8 +35,7 @@ impl TransactionBuilder {
     pub fn new() -> Self {
         TransactionBuilder {
             input_credentials: Vec::new(),
-            outputs: Vec::new(),
-            output_shared_secrets: Vec::new(),
+            outputs_and_shared_secrets: Vec::new(),
             tombstone_block: u64::max_value(),
             fee: BASE_FEE,
         }
@@ -69,8 +67,8 @@ impl TransactionBuilder {
         let (tx_out, shared_secret) =
             create_output(value, recipient, recipient_fog_ingest_key, rng)?;
 
-        self.outputs.push(tx_out.clone());
-        self.output_shared_secrets.push(shared_secret);
+        self.outputs_and_shared_secrets
+            .push((tx_out.clone(), shared_secret));
         Ok(tx_out)
     }
 
@@ -91,7 +89,7 @@ impl TransactionBuilder {
     }
 
     /// Consume the builder and return the transaction.
-    pub fn build<RNG: CryptoRng + RngCore>(&mut self, rng: &mut RNG) -> Result<Tx, TxBuilderError> {
+    pub fn build<RNG: CryptoRng + RngCore>(mut self, rng: &mut RNG) -> Result<Tx, TxBuilderError> {
         if self.input_credentials.is_empty() {
             return Err(TxBuilderError::NoInputs);
         }
@@ -117,7 +115,26 @@ impl TransactionBuilder {
             })
             .collect();
 
-        let tx_prefix = TxPrefix::new(inputs, self.outputs.clone(), self.fee, self.tombstone_block);
+        // Sort outputs by public key.
+        self.outputs_and_shared_secrets
+            .sort_by(|(a, _), (b, _)| a.public_key.cmp(&b.public_key));
+
+        let output_values_and_blindings: Vec<(u64, Scalar)> = self
+            .outputs_and_shared_secrets
+            .iter()
+            .map(|(tx_out, shared_secret)| {
+                let amount = &tx_out.amount;
+                let (value, blinding) = amount
+                    .get_value(shared_secret)
+                    .expect("TransactionBuilder created an invalid Amount");
+                (value, blinding)
+            })
+            .collect();
+
+        let (outputs, _shared_serets): (Vec<TxOut>, Vec<_>) =
+            self.outputs_and_shared_secrets.into_iter().unzip();
+
+        let tx_prefix = TxPrefix::new(inputs, outputs.clone(), self.fee, self.tombstone_block);
 
         let mut rings: Vec<Vec<(CompressedRistrettoPublic, CompressedCommitment)>> = Vec::new();
         for input in &tx_prefix.inputs {
@@ -147,20 +164,6 @@ impl TransactionBuilder {
             let (value, blinding) = amount.get_value(&shared_secret)?;
             input_secrets.push((onetime_private_key, value, blinding));
         }
-
-        let output_values_and_blindings: Vec<(u64, Scalar)> = tx_prefix
-            .outputs
-            .iter()
-            .enumerate()
-            .map(|(index, tx_out)| {
-                let amount = &tx_out.amount;
-                let shared_secret = &self.output_shared_secrets[index];
-                let (value, blinding) = amount
-                    .get_value(shared_secret)
-                    .expect("TransactionBuilder created an invalid Amount");
-                (value, blinding)
-            })
-            .collect();
 
         let message = tx_prefix.hash().0;
         let signature = SignatureRctBulletproofs::sign(
@@ -497,5 +500,21 @@ pub mod transaction_builder_tests {
         .unwrap();
         assert_eq!(tx.prefix.inputs.len(), MAX_INPUTS as usize);
         assert_eq!(tx.prefix.outputs.len(), MAX_OUTPUTS as usize);
+    }
+
+    #[test]
+    // Transaction outputs should be sorted by public key.
+    fn test_outputs_are_sorted() {
+        let mut rng: StdRng = SeedableRng::from_seed([92u8; 32]);
+        let sender = AccountKey::random(&mut rng);
+        let recipient = AccountKey::random(&mut rng);
+        let num_inputs = 3;
+        let num_outputs = 11;
+        let tx = get_transaction(num_inputs, num_outputs, &sender, &recipient, &mut rng).unwrap();
+
+        let outputs = tx.prefix.outputs;
+        let mut expected_outputs = outputs.clone();
+        expected_outputs.sort_by(|a, b| a.public_key.cmp(&b.public_key));
+        assert_eq!(outputs, expected_outputs);
     }
 }

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -134,7 +134,7 @@ impl TransactionBuilder {
         let (outputs, _shared_serets): (Vec<TxOut>, Vec<_>) =
             self.outputs_and_shared_secrets.into_iter().unzip();
 
-        let tx_prefix = TxPrefix::new(inputs, outputs.clone(), self.fee, self.tombstone_block);
+        let tx_prefix = TxPrefix::new(inputs, outputs, self.fee, self.tombstone_block);
 
         let mut rings: Vec<Vec<(CompressedRistrettoPublic, CompressedCommitment)>> = Vec::new();
         for input in &tx_prefix.inputs {


### PR DESCRIPTION
TransactionBuilder should be misuse-resistant. Here, TransactionBuilder sorts the transaction outputs so that patterns in client code, like always adding a change output last, do not leak into submitted transactions.

Also updates mobilecoind unit tests which assumed that the change output was the last output in the transaction.