### PR TITLE
mobilecoind: add optional monitor name

### DIFF
--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -191,6 +191,9 @@ message MonitorStatus {
 
     // Next block we are waiting to sync.
     uint64 next_block = 5;
+
+    // Optional monitor name.
+    string name = 6;
 }
 
 
@@ -217,6 +220,9 @@ message AddMonitorRequest {
 
     // Block index to start monitoring from.
     uint64 first_block = 4;
+
+    // Optional name.
+    string name = 5;
 }
 message AddMonitorResponse {
     bytes monitor_id = 1;

--- a/mobilecoind/src/database.rs
+++ b/mobilecoind/src/database.rs
@@ -251,6 +251,7 @@ mod test {
             0,  // first_subaddress
             10, // num_subaddresses
             0,  // first_block
+            "", // name
         )
         .unwrap();
 
@@ -264,6 +265,7 @@ mod test {
             0,  // first_subaddress
             10, // num_subaddresses
             0,  // first_block
+            "", // name
         )
         .unwrap();
 
@@ -279,6 +281,7 @@ mod test {
             5,  // first_subaddress
             10, // num_subaddresses
             0,  // first_block
+            "", // name
         )
         .unwrap();
 
@@ -295,6 +298,7 @@ mod test {
             0,  // first_subaddress
             10, // num_subaddresses
             10, // first_block
+            "", // name
         )
         .unwrap();
 
@@ -310,6 +314,7 @@ mod test {
             10, // first_subaddress
             10, // num_subaddresses
             0,  // first_block
+            "", // name
         )
         .unwrap();
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -161,6 +161,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             request.first_subaddress,
             request.num_subaddresses,
             request.first_block,
+            &request.name,
         )
         .map_err(|err| rpc_internal_error("monitor_data.new", err, &self.logger))?;
 
@@ -1127,6 +1128,7 @@ mod test {
             DEFAULT_SUBADDRESS_INDEX, // first_subaddress
             1,                        // num_subaddresses
             0,                        // first_block
+            "",                       // name
         )
         .expect("failed to create data");
 
@@ -1170,6 +1172,7 @@ mod test {
                     DEFAULT_SUBADDRESS_INDEX, // first_subaddress
                     1,                        // num_subaddresses
                     0,                        // first_block
+                    "",                       // name
                 )
                 .unwrap();
                 mobilecoind_db.add_monitor(&data).unwrap()
@@ -1210,6 +1213,7 @@ mod test {
                     DEFAULT_SUBADDRESS_INDEX, // first_subaddress
                     1,                        // num_subaddresses
                     0,                        // first_block
+                    "",                       // name
                 )
                 .unwrap();
                 let id = mobilecoind_db.add_monitor(&data).unwrap();
@@ -1257,6 +1261,7 @@ mod test {
             10, // first_subaddress
             20, // num_subaddresses
             30, // first_block
+            "", // name
         )
         .unwrap();
 
@@ -1310,6 +1315,7 @@ mod test {
             0,  // first_subaddress
             20, // num_subaddresses
             0,  // first_block
+            "", // name
         )
         .unwrap();
 
@@ -1463,6 +1469,7 @@ mod test {
             10, // first_subaddress
             20, // num_subaddresses
             0,  // first_block
+            "", // name
         )
         .unwrap();
 
@@ -1723,6 +1730,7 @@ mod test {
             0,  // first_subaddress
             20, // num_subaddresses
             0,  // first_block
+            "", // name
         )
         .unwrap();
 
@@ -1866,6 +1874,7 @@ mod test {
                 0,  // first_subaddress
                 20, // num_subaddresses
                 0,  // first_block
+                "", // name
             )
             .unwrap();
 
@@ -1914,6 +1923,7 @@ mod test {
             0,  // first_subaddress
             20, // num_subaddresses
             0,  // first_block
+            "", // name
         )
         .unwrap();
 
@@ -1988,6 +1998,7 @@ mod test {
                 DEFAULT_SUBADDRESS_INDEX, // first_subaddress
                 1,                        // num_subaddresses
                 0,                        // first_block
+                "",                       // name
             )
             .unwrap();
 
@@ -2025,6 +2036,7 @@ mod test {
             0,  // first_subaddress
             20, // num_subaddresses
             0,  // first_block
+            "", // name
         )
         .unwrap();
 
@@ -2122,6 +2134,7 @@ mod test {
             0,  // first_subaddress
             20, // num_subaddresses
             0,  // first_block
+            "", // name
         )
         .unwrap();
 
@@ -2302,6 +2315,7 @@ mod test {
             0,  // first_subaddress
             20, // num_subaddresses
             0,  // first_block
+            "", // name
         )
         .unwrap();
 
@@ -2368,6 +2382,7 @@ mod test {
             0,  // first_subaddress
             20, // num_subaddresses
             0,  // first_block
+            "", // name
         )
         .unwrap();
 

--- a/mobilecoind/src/sync.rs
+++ b/mobilecoind/src/sync.rs
@@ -430,6 +430,7 @@ mod test {
             DEFAULT_SUBADDRESS_INDEX, // first subaddress
             5,                        // number of subaddresses
             0,                        // first block
+            "",                       // name
         )
         .unwrap();
 

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -106,6 +106,7 @@ pub fn get_test_monitor_data_and_id(
         DEFAULT_SUBADDRESS_INDEX, // first_subaddress
         1,                        // num_subaddresses
         0,                        // first_block
+        "",                       // name
     )
     .unwrap();
 


### PR DESCRIPTION
This PR adds an optional user-provided name that can be associated with each monitor mobilecoind has. This allows user to give their monitors friendly names, and they can later locate them by querying the list of monitors and matching by name.