### PR TITLE
MC-1404 Improve consensus enclave startup debugging #in-review

### DIFF
--- a/consensus/enclave/src/lib.rs
+++ b/consensus/enclave/src/lib.rs
@@ -56,12 +56,7 @@ impl ConsensusServiceSgxEnclave {
             &mut launch_token_updated,
             &mut misc_attr,
         )
-        .unwrap_or_else(|_| {
-            panic!(
-                "SgxEnclave::create(file_name={:?}, debug={}) failed",
-                &enclave_path, DEBUG_ENCLAVE as i32
-            )
-        });
+        .expect("Could not create consensus enclave");
 
         let sgx_enclave = ConsensusServiceSgxEnclave {
             enclave: Arc::new(enclave),


### PR DESCRIPTION
This removes the gonzo `unwrap_or_else(|_e| panic!("unhelpful message"))` in favor of `expect()`.