### PR TITLE
Bootstrap fixes

### DIFF
--- a/tools/local-network/bootstrap.sh
+++ b/tools/local-network/bootstrap.sh
@@ -55,17 +55,5 @@ cd $TARGET
 
 set -x
 
-# We are using if else here because `cargo run` often causes things to be rebuilt unnecessarily,
-# because the features will be different if keyfile is the only target (because cargo).
-# In workflows where you simply build all, you don't want to reinvoke cargo usually.
-if [ -f $PROJECT_ROOT/target/release/sample-keys ]; then
-    $PROJECT_ROOT/target/release/sample-keys --num ${SAMPLE_KEYS_NUM} --output-dir keys
-else
-    cargo run -p mc-util-keyfile --bin sample-keys --release -- --num ${SAMPLE_KEYS_NUM} --output-dir keys
-fi
-
-if [ -f $PROJECT_ROOT/target/release/generate_sample_ledger ]; then
-    $PROJECT_ROOT/target/release/generate_sample_ledger --txs ${BOOTSTRAP_NUM}
-else
-    cargo run --bin mc-util-generate-sample-ledger --release -- --txs ${BOOTSTRAP_NUM}
-fi
+cargo run -p mc-util-keyfile --bin sample-keys --release -- --num ${SAMPLE_KEYS_NUM} --output-dir keys
+cargo run -p mc-util-generate-sample-ledger --bin generate-sample-ledger --release -- --txs ${BOOTSTRAP_NUM}

--- a/tools/local-network/bootstrap.sh
+++ b/tools/local-network/bootstrap.sh
@@ -26,7 +26,7 @@ echo "PWD: $PWD"
 PROJECT_ROOT=$PWD
 
 # Collect parameters for the bootstrap
-SAMPLE_KEYS_NUM=${NUM_KEYS:-10}
+SAMPLE_KEYS_NUM=${NUM_KEYS:-20}
 BOOTSTRAP_NUM=${NUM_UTXOS_PER_ACCOUNT:-100}
 
 TARGET="./target/sample_data"


### PR DESCRIPTION
This PR fixes a few small issues:
- It changes the local-network bootstrap shell script to create 20 accounts instead of 10 so that the balance held by each account can be represented in a `u64`.
- It gets rid of janky logic that prevents recompilation of the relevant binaries - bootstrapping doesn't happen often and this logic is more likely to bite someone than to provide useful value (case in point: I failed at bootstrapping a correct ledger until it occurred to me that the binaries are just old ones, from a previous commit).
- It changes `mobilecoind`'s `GetBalance` API to error if the balance does not fit in a `u64`.