### PR TITLE
Change test ledger generation for smaller balances

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
             sh '../bin/sample-keys --num 1000'
             sh '../bin/generate-sample-ledger -t 100'
             // Remove extra keys otherwise test_client will try all combinations
-            sh 'rm -rf sample_data/keys/*_[6-999].*'
+            sh 'for i in $(seq 6 999); do rm -rf sample_data/keys/*_${i}.*; done'
             sh 'rm -f ./ledger/lock.mdb'
           }
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -74,8 +74,11 @@ pipeline {
 
           // Generate sample data
           dir('ops/sample_data') {
-            sh '../bin/sample-keys --num 6'
+            // Generate lots of account keys to keep balances smaller
+            sh '../bin/sample-keys --num 1000'
             sh '../bin/generate-sample-ledger -t 100'
+            // Remove extra keys otherwise test_client will try all combinations
+            sh 'rm -rf sample_data/keys/*_[6-999].*'
             sh 'rm -f ./ledger/lock.mdb'
           }
 


### PR DESCRIPTION
Generating more accounts with 100tx (and then throwing away the unused keys) so that test_client doesn't run into the u64 error message.