### PR TITLE
Add a pre-push hook, prevents accidentally pushing branches to origin

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -2,15 +2,19 @@
 # Use this file to prevent pushes to origin
 # Based on https://gist.githubusercontent.com/stefansundin/d465f1e331fc5c632088/raw/pre-push-2
 #
-# This is not installed by install_git_settings.sh, to turn this on, use a similar command
+# This is not installed by install_git_settings.sh.
+# To turn this on, use a similar command
 # as the one there that creates a symlink in .git/hooks
+#
+# It may require manual configuration depending on how you have configured your remotes
+# https://git-scm.com/docs/githooks#_pre_push
 
 ORIGIN="$1"
 REMOTE_URL="$2"
 
-if [[ "$REMOTE_URL" == *"origin/"* ]]; then
+if [[ "$REMOTE_URL" == *"mobilecoinofficial/"* ]]; then
   echo
-  echo "Prevented pushing to origin. Please push to your fork instead."
+  echo "Prevented pushing to mobilecoinofficial/mobilecoin. Please push to your fork instead."
   echo "If you really want to do this, use --no-verify to bypass this pre-push hook."
   echo
   exit 1

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Use this file to prevent pushes to origin
+# Based on https://gist.githubusercontent.com/stefansundin/d465f1e331fc5c632088/raw/pre-push-2
+#
+# This is not installed by install_git_settings.sh, to turn this on, use a similar command
+# as the one there that creates a symlink in .git/hooks
+
+ORIGIN="$1"
+REMOTE_URL="$2"
+
+if [[ "$REMOTE_URL" == *"origin/"* ]]; then
+  echo
+  echo "Prevented pushing to origin. Please push to your fork instead."
+  echo "If you really want to do this, use --no-verify to bypass this pre-push hook."
+  echo
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
When we set up mobilecoin repo, some engineers wanted that we prevent
new branches from being created for pull requests in the main repo
itself, they want everyone to use forks, and this makes some tools
work better.

Initially we tried to make github itself reject such pushes but
it was found that there is no way to do it.

Instead, this pre-push hook can be installed locally to prevent
accidentally pushing to origin, and suggest pushing to fork and
opening a PR from your fork instead.