### PR TITLE
MC-1396 Domain-separated hash_to_point and hash_to_scalar functions

### DIFF
--- a/transaction/core/src/domain_separators.rs
+++ b/transaction/core/src/domain_separators.rs
@@ -21,8 +21,11 @@ pub const AMOUNT_BLINDING_DOMAIN_TAG: &str = "mc_amount_blinding";
 /// Domain separator for Bulletproof transcript.
 pub const BULLETPROOF_DOMAIN_TAG: &str = "mc_bulletproof_transcript";
 
-// TODO:
-// pub const HASH_TO_POINT_DOMAIN_TAG: &str = "mc_hash_to_point";
+// /// Domain separator for onetime key "hash_to_point" function.
+// pub const HASH_TO_POINT_DOMAIN_TAG: &str = "mc_onetime_key_hash_to_point";
+
+/// Domain separator for onetime key "hash_to_scalar" function.
+pub const HASH_TO_SCALAR_DOMAIN_TAG: &str = "mc_onetime_key_hash_to_scalar";
 
 /// Domain separator for hashing a private view key and index into a subaddress.
 pub const SUBADDRESS_DOMAIN_TAG: &str = "mc_subaddress";

--- a/transaction/core/src/domain_separators.rs
+++ b/transaction/core/src/domain_separators.rs
@@ -21,8 +21,8 @@ pub const AMOUNT_BLINDING_DOMAIN_TAG: &str = "mc_amount_blinding";
 /// Domain separator for Bulletproof transcript.
 pub const BULLETPROOF_DOMAIN_TAG: &str = "mc_bulletproof_transcript";
 
-// /// Domain separator for onetime key "hash_to_point" function.
-// pub const HASH_TO_POINT_DOMAIN_TAG: &str = "mc_onetime_key_hash_to_point";
+/// Domain separator for onetime key "hash_to_point" function.
+pub const HASH_TO_POINT_DOMAIN_TAG: &str = "mc_onetime_key_hash_to_point";
 
 /// Domain separator for onetime key "hash_to_scalar" function.
 pub const HASH_TO_SCALAR_DOMAIN_TAG: &str = "mc_onetime_key_hash_to_scalar";

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -23,7 +23,7 @@ use rand_core::{CryptoRng, RngCore};
 
 const G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
 
-// This needs to be the same "Hp" function used by the onetime keys.
+/// Applies a hash function and returns a RistrettoPoint.
 pub fn hash_to_point(ristretto_public: &RistrettoPublic) -> RistrettoPoint {
     let mut hasher = Blake2b::new();
     hasher.input(&HASH_TO_POINT_DOMAIN_TAG);
@@ -33,10 +33,10 @@ pub fn hash_to_point(ristretto_public: &RistrettoPublic) -> RistrettoPoint {
 
 /// Applies a hash function and returns a Scalar.
 pub fn hash_to_scalar<B: AsRef<[u8]>>(data: B) -> Scalar {
-    let mut digest = Blake2b::new();
-    digest.input(&HASH_TO_SCALAR_DOMAIN_TAG);
-    digest.input(data);
-    Scalar::from_hash::<Blake2b>(digest)
+    let mut hasher = Blake2b::new();
+    hasher.input(&HASH_TO_SCALAR_DOMAIN_TAG);
+    hasher.input(data);
+    Scalar::from_hash::<Blake2b>(hasher)
 }
 
 /// Generate a tx pubkey for a subaddress transaction

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -8,7 +8,9 @@
 #![allow(non_snake_case)]
 
 use crate::{
-    account_keys::PublicAddress, domain_separators::HASH_TO_SCALAR_DOMAIN_TAG, view_key::ViewKey,
+    account_keys::PublicAddress,
+    domain_separators::{HASH_TO_POINT_DOMAIN_TAG, HASH_TO_SCALAR_DOMAIN_TAG},
+    view_key::ViewKey,
 };
 use blake2::{Blake2b, Digest};
 use curve25519_dalek::{
@@ -16,9 +18,18 @@ use curve25519_dalek::{
 };
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use mc_util_from_random::FromRandom;
+use mc_util_serial::ReprBytes32;
 use rand_core::{CryptoRng, RngCore};
 
 const G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
+
+// This needs to be the same "Hp" function used by the onetime keys.
+pub fn hash_to_point(ristretto_public: &RistrettoPublic) -> RistrettoPoint {
+    let mut hasher = Blake2b::new();
+    hasher.input(&HASH_TO_POINT_DOMAIN_TAG);
+    hasher.input(&ristretto_public.to_bytes());
+    RistrettoPoint::from_hash(hasher)
+}
 
 /// Applies a hash function and returns a Scalar.
 pub fn hash_to_scalar<B: AsRef<[u8]>>(data: B) -> Scalar {

--- a/transaction/core/src/ring_signature/key_image.rs
+++ b/transaction/core/src/ring_signature/key_image.rs
@@ -1,10 +1,9 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use super::Error;
-use crate::ring_signature::Scalar;
-use blake2::Blake2b;
+use crate::{onetime_keys::hash_to_point, ring_signature::Scalar};
 use core::{convert::TryFrom, fmt};
-use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
+use curve25519_dalek::ristretto::CompressedRistretto;
 use mc_crypto_digestible::Digestible;
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use mc_util_serial::{
@@ -39,7 +38,7 @@ impl fmt::Debug for KeyImage {
 impl From<&RistrettoPrivate> for KeyImage {
     fn from(x: &RistrettoPrivate) -> Self {
         let P = RistrettoPublic::from(x);
-        let Hp = RistrettoPoint::hash_from_bytes::<Blake2b>(&P.to_bytes());
+        let Hp = hash_to_point(&P);
         let point = x.as_ref() * Hp;
         KeyImage {
             point: point.compress(),

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -9,7 +9,7 @@ use blake2::{Blake2b, Digest};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use mc_crypto_digestible::Digestible;
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
-use mc_util_serial::{prost::Message, ReprBytes32};
+use mc_util_serial::prost::Message;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
@@ -17,15 +17,9 @@ use crate::{
     commitment::Commitment,
     compressed_commitment::CompressedCommitment,
     domain_separators::RING_MLSAG_CHALLENGE_DOMAIN_TAG,
+    onetime_keys::hash_to_point,
     ring_signature::{CurveScalar, Error, KeyImage, Scalar, GENERATORS},
 };
-
-// This needs to be the same "Hp" function used by the onetime keys.
-fn hash_to_point(ristretto_public: &RistrettoPublic) -> RistrettoPoint {
-    let mut hasher = Blake2b::new();
-    hasher.input(&ristretto_public.to_bytes());
-    RistrettoPoint::from_hash(hasher)
-}
 
 /// MLSAG for a ring of public keys and amount commitments.
 /// Note: Serialize and Deserialize appear to be cruft left over from sdk_json_interface.


### PR DESCRIPTION
Adds domain-separated hash_to_point and hash_to_scalar functions. Domain separation is the main goal here, but the new functions also simplify using the "right" hash function in various parts of the code that need these.