### PR TITLE
MC-1447 Upgrades log message from info to error

### DIFF
--- a/consensus/service/src/tx_manager.rs
+++ b/consensus/service/src/tx_manager.rs
@@ -282,7 +282,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger, UI: UntrustedInterfaces> TxManager<E, 
             if let Some(entry) = cache.get(&tx_hash) {
                 tx_contexts.push(entry.context());
             } else {
-                log::info!(self.logger, "ignoring non-existent tx hash {:?}", tx_hash);
+                log::error!(self.logger, "Ignoring non-existent TxHash {:?}", tx_hash);
             }
         }
 


### PR DESCRIPTION
The combine function should be deterministic across all nodes. Currently, a node would omit a TxHash while combining if it it has not cached the corresponding Tx, which would be a non-deterministic deviation from the protocol.

Unclear if that actually happens in practice, so this PR elevates the log message from `info` to `error`.