### PR TITLE
Remove duplicate dev-dependency in mc-common crate

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -67,7 +67,6 @@ slog-stdlog = { version = "4.0.0", optional = true }
 slog-term = { version = "2.4", optional = true }
 
 [dev-dependencies]
-mc-crypto-rand = { path = "../crypto/rand" }
 scoped_threadpool = "0.1.*"
 
 [dev-dependencies.proptest]


### PR DESCRIPTION
`mc-crypto-rand` is listed as a `dependency` and a `dev-dependency` in the `mc-common` crate. This PR removes the duplicate entry from the `dev-dependency` section.