### PR TITLE
Fix mc-common tests without features

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
-#![cfg_attr(not(feature = "log"), no_std)]
+#![cfg_attr(not(any(test, feature = "log")), no_std)]
 #![feature(optin_builtin_traits)]
 #![warn(unused_extern_crates)]
 


### PR DESCRIPTION
Running `cargo test -p mc-common` results in a compile error on account of `no_std` being set when the `log` feature isn't enabled. This PR changes the conditional for `no_std` to include whether we're running tests or not.