### PR TITLE
Remove mc-common dependency from generate-sample-ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3060,7 +3060,6 @@ version = "0.2.0"
 dependencies = [
  "curve25519-dalek",
  "hex 0.3.2",
- "mc-common",
  "mc-crypto-keys",
  "mc-ledger-db",
  "mc-transaction-core",

--- a/util/generate-sample-ledger/Cargo.toml
+++ b/util/generate-sample-ledger/Cargo.toml
@@ -9,7 +9,6 @@ name = "generate-sample-ledger"
 path = "src/bin/generate_sample_ledger.rs"
 
 [dependencies]
-mc-common = { path = "../../common" }
 mc-crypto-keys = { path = "../../crypto/keys" }
 mc-ledger-db = { path = "../../ledger/db" }
 mc-transaction-core = { path = "../../transaction/core" }


### PR DESCRIPTION
The `mc-common` crate isn't being used in the `generate-sample-ledger` crate. This PR removes the dependency.