### PR TITLE
Remove cmake-rs fork and update to 0.1.43

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
+checksum = "49f97562167906afc51aa3fd7e6c83c10a5c96d33bd18f98a4c06a1413134caa"
 dependencies = [
  "cc",
 ]

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -277,12 +277,10 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.42"
-source = "git+https://github.com/mobilecoinofficial/cmake-rs?tag=0.1.42.rev7#93ff3a1b1ffcb5c43b924362d95c96762f23454e"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -557,7 +555,7 @@ version = "2.18.1"
 source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.2#20e6fbb69f5cc675d18c22f985d682f718b66e27"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cmake 0.1.42 (git+https://github.com/mobilecoinofficial/cmake-rs?tag=0.1.42.rev7)",
+ "cmake 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1602,7 +1600,7 @@ dependencies = [
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
-"checksum cmake 0.1.42 (git+https://github.com/mobilecoinofficial/cmake-rs?tag=0.1.42.rev7)" = "<none>"
+"checksum cmake 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "49f97562167906afc51aa3fd7e6c83c10a5c96d33bd18f98a4c06a1413134caa"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -59,12 +59,4 @@ overflow-checks = false
 prost = { git = "https://github.com/cbeck88/prost", rev = "4e1905329369ca7a1cac3eda978ee9379167ee95" }
 prost-derive = { git = "https://github.com/cbeck88/prost", rev = "4e1905329369ca7a1cac3eda978ee9379167ee95" }
 
-# Overridden to support cross-compiling iOS.
-# * Fixes an issue with cmake-rs not setting compiler flags for asm files
-#     Upstream: https://github.com/alexcrichton/cmake-rs/pull/86
-# * Fixes an issue with cmake-rs not configuring cmake properly for ios cross-compilation when using cmake 3.14
-#     Upstream: https://github.com/alexcrichton/cmake-rs/issues/87
-# See sdk_json_interface/Cargo.toml to update version
-cmake = { git = "https://github.com/mobilecoinofficial/cmake-rs", tag = "0.1.42.rev7" }
-
 [workspace]


### PR DESCRIPTION
The 2 patches in our [cmake-rs fork](https://github.com/mobilecoinofficial/cmake-rs/commits/93ff3a1b1ffcb5c43b924362d95c96762f23454e) (see https://github.com/alexcrichton/cmake-rs/pull/86 and https://github.com/alexcrichton/cmake-rs/issues/87) have been merged/fixed upstream and a new version has been published (see https://github.com/alexcrichton/cmake-rs/issues/87). This PR removes reference to our fork and updates to the new version (`0.1.43`).