### PR TITLE
Do not prescribe keyfile names

### DIFF
--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -60,13 +60,18 @@ pub fn write_default_keyfiles<P: AsRef<Path>>(
 pub fn read_default_pubfiles<P: AsRef<Path>>(
     path: P,
 ) -> Result<Vec<PublicAddress>, std::io::Error> {
-    let mut result = Vec::new();
+    let mut entries = Vec::new();
     for entry in fs::read_dir(path)? {
         let filename = entry?.path();
         if let Some("pub") = filename.extension().and_then(OsStr::to_str) {
-            result.push(read_pubfile(filename)?);
+            entries.push(filename);
         }
     }
+    entries.sort_by(|a, b| a.cmp(&b));
+    let result: Vec<PublicAddress> = entries
+        .iter()
+        .map(|f| read_pubfile(f).expect("Could not read pubfile"))
+        .collect();
     Ok(result)
 }
 
@@ -74,13 +79,18 @@ pub fn read_default_pubfiles<P: AsRef<Path>>(
 pub fn read_default_root_entropies<P: AsRef<Path>>(
     path: P,
 ) -> Result<Vec<RootIdentity>, std::io::Error> {
-    let mut result = Vec::new();
+    let mut entries = Vec::new();
     for entry in fs::read_dir(path)? {
         let filename = entry?.path();
         if let Some("json") = filename.extension().and_then(OsStr::to_str) {
-            result.push(read_keyfile(filename)?);
+            entries.push(filename);
         }
     }
+    entries.sort_by(|a, b| a.cmp(&b));
+    let result: Vec<RootIdentity> = entries
+        .iter()
+        .map(|f| read_keyfile(f).expect("Could not read keyfile"))
+        .collect();
     Ok(result)
 }
 

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -63,11 +63,8 @@ pub fn read_default_pubfiles<P: AsRef<Path>>(
     let mut result = Vec::new();
     for entry in fs::read_dir(path)? {
         let filename = entry?.path();
-        match filename.extension().and_then(OsStr::to_str) {
-            Some("pub") => {
-                result.push(read_pubfile(filename)?);
-            }
-            _ => {}
+        if let Some("pub") = filename.extension().and_then(OsStr::to_str) {
+            result.push(read_pubfile(filename)?);
         }
     }
     Ok(result)
@@ -80,11 +77,8 @@ pub fn read_default_root_entropies<P: AsRef<Path>>(
     let mut result = Vec::new();
     for entry in fs::read_dir(path)? {
         let filename = entry?.path();
-        match filename.extension().and_then(OsStr::to_str) {
-            Some("json") => {
-                result.push(read_keyfile(filename)?);
-            }
-            _ => {}
+        if let Some("json") =  filename.extension().and_then(OsStr::to_str) {
+            result.push(read_keyfile(filename)?);
         }
     }
     Ok(result)

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -77,7 +77,7 @@ pub fn read_default_root_entropies<P: AsRef<Path>>(
     let mut result = Vec::new();
     for entry in fs::read_dir(path)? {
         let filename = entry?.path();
-        if let Some("json") =  filename.extension().and_then(OsStr::to_str) {
+        if let Some("json") = filename.extension().and_then(OsStr::to_str) {
             result.push(read_keyfile(filename)?);
         }
     }

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -93,6 +93,7 @@ pub fn read_default_root_entropies<P: AsRef<Path>>(
 #[cfg(test)]
 mod testing {
     use super::*;
+    use std::{collections::HashSet, iter::FromIterator};
     use tempdir::TempDir;
 
     #[test]
@@ -157,16 +158,89 @@ mod testing {
         {
             let bin1 = read_default_root_entropies(&dir1).unwrap();
             assert_eq!(bin1.len(), 10);
-            assert_eq!(
-                bin1,
-                vec![RootIdentity {
+            // Order doesn't matter for the keys - just that they are all processed.
+            let bin_set: HashSet<RootIdentity> = HashSet::from_iter(bin1.iter().cloned());
+            let expected = vec![
+                RootIdentity {
                     root_entropy: [
                         2, 154, 47, 57, 69, 168, 246, 187, 31, 181, 177, 26, 84, 40, 58, 64, 82,
-                        109, 40, 35, 89, 36, 57, 5, 241, 163, 13, 184, 42, 158, 89, 124
+                        109, 40, 35, 89, 36, 57, 5, 241, 163, 13, 184, 42, 158, 89, 124,
                     ],
-                    fog_url: None
-                }]
-            );
+                    fog_url: None,
+                },
+                RootIdentity {
+                    root_entropy: [
+                        145, 231, 241, 91, 240, 144, 214, 193, 230, 37, 152, 119, 69, 3, 60, 14,
+                        43, 117, 90, 203, 54, 133, 25, 210, 33, 104, 135, 216, 57, 67, 62, 212,
+                    ],
+                    fog_url: None,
+                },
+                RootIdentity {
+                    root_entropy: [
+                        29, 186, 225, 89, 96, 98, 80, 144, 202, 70, 150, 149, 157, 150, 60, 120,
+                        14, 200, 137, 235, 152, 231, 77, 80, 71, 212, 32, 82, 69, 206, 81, 55,
+                    ],
+                    fog_url: None,
+                },
+                RootIdentity {
+                    root_entropy: [
+                        28, 126, 75, 230, 193, 96, 159, 197, 223, 166, 62, 106, 153, 87, 184, 180,
+                        126, 12, 188, 128, 238, 64, 134, 207, 195, 142, 37, 20, 117, 39, 246, 63,
+                    ],
+                    fog_url: None,
+                },
+                RootIdentity {
+                    root_entropy: [
+                        86, 38, 184, 6, 231, 115, 110, 86, 143, 103, 115, 30, 138, 38, 216, 229,
+                        129, 195, 47, 10, 175, 253, 198, 67, 251, 189, 171, 114, 161, 235, 87, 8,
+                    ],
+                    fog_url: None,
+                },
+                RootIdentity {
+                    root_entropy: [
+                        77, 190, 236, 181, 53, 105, 80, 210, 166, 168, 216, 199, 228, 200, 146, 11,
+                        243, 21, 55, 191, 160, 155, 194, 74, 110, 129, 37, 21, 75, 113, 65, 97,
+                    ],
+                    fog_url: None,
+                },
+                RootIdentity {
+                    root_entropy: [
+                        79, 213, 120, 85, 72, 42, 9, 104, 143, 186, 253, 144, 137, 115, 37, 43,
+                        155, 47, 60, 75, 157, 110, 124, 55, 155, 101, 175, 167, 95, 235, 51, 66,
+                    ],
+                    fog_url: None,
+                },
+                RootIdentity {
+                    root_entropy: [
+                        235, 248, 189, 155, 66, 104, 44, 250, 214, 183, 186, 1, 207, 223, 8, 175,
+                        44, 56, 144, 124, 175, 51, 183, 218, 248, 136, 152, 109, 7, 181, 84, 156,
+                    ],
+                    fog_url: None,
+                },
+                RootIdentity {
+                    root_entropy: [
+                        114, 112, 34, 231, 208, 185, 252, 112, 117, 246, 59, 224, 40, 126, 182,
+                        209, 39, 130, 89, 86, 102, 77, 203, 73, 253, 88, 59, 238, 85, 130, 15, 200,
+                    ],
+                    fog_url: None,
+                },
+                RootIdentity {
+                    root_entropy: [
+                        79, 44, 181, 167, 130, 174, 148, 20, 20, 23, 100, 145, 154, 136, 48, 168,
+                        119, 124, 91, 161, 187, 53, 159, 117, 252, 55, 199, 84, 204, 164, 37, 64,
+                    ],
+                    fog_url: None,
+                },
+                RootIdentity {
+                    root_entropy: [
+                        2, 154, 47, 57, 69, 168, 246, 187, 31, 181, 177, 26, 84, 40, 58, 64, 82,
+                        109, 40, 35, 89, 36, 57, 5, 241, 163, 13, 184, 42, 158, 89, 124,
+                    ],
+                    fog_url: None,
+                },
+            ];
+
+            assert_eq!(bin_set, HashSet::from_iter(expected.iter().cloned()),);
         }
     }
 }

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -77,13 +77,8 @@ pub fn read_default_root_entropies<P: AsRef<Path>>(
     path: P,
 ) -> Result<Vec<RootIdentity>, std::io::Error> {
     let mut result = Vec::new();
-    loop {
-        let name = keyfile_name(result.len());
-        let file = path.as_ref().join(name).with_extension("json");
-        if !file.exists() {
-            break;
-        }
-        result.push(read_keyfile(file)?);
+    for entry in fs::read_dir(path)? {
+        result.push(read_keyfile(entry?.path())?);
     }
     Ok(result)
 }

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -67,7 +67,7 @@ pub fn read_default_pubfiles<P: AsRef<Path>>(
             entries.push(filename);
         }
     }
-    entries.sort_by(|a, b| a.cmp(&b));
+    entries.sort();
     let result: Vec<PublicAddress> = entries
         .iter()
         .map(|f| read_pubfile(f).expect("Could not read pubfile"))
@@ -86,7 +86,7 @@ pub fn read_default_root_entropies<P: AsRef<Path>>(
             entries.push(filename);
         }
     }
-    entries.sort_by(|a, b| a.cmp(&b));
+    entries.sort();
     let result: Vec<RootIdentity> = entries
         .iter()
         .map(|f| read_keyfile(f).expect("Could not read keyfile"))


### PR DESCRIPTION
Currently, the keyfile test management requires files to be named account_keys_0.json, account_keys_1.json, etc, and to start at 0. This change allows keyfiles to be named arbitrarily.