### PR TITLE
Sync mob tool with internal version

### DIFF
--- a/mob
+++ b/mob
@@ -30,7 +30,7 @@ the image and doesn't run it or give you a prompt. `--dry-run` just
 shows you the shell commands without executing them. `--no-pull` means you don't
 pull a docker image at all.
 
-`mob` tool attemps to mount the `/dev/isgx` device correctly if it is avialable
+`mob` tool attemps to mount the `/dev/isgx` device correctly if it is available
 and you selected `--hw` mode, so that you can run tests in hardware mode.
 
 usage notes (ssh)
@@ -38,9 +38,9 @@ usage notes (ssh)
 
 The `--ssh-dir` and `--ssh-agent` options can be used if the build requires
 access to private repos on github (mobilecoin repo sources will be mounted so
-ssh stuff is not needed for that, this is for any private dependencies of mobilcoin
+ssh stuff is not needed for that, this is for any private dependencies of the mobilecoin
 repo.) If provided, these options will try to get your credentials from the host
-enviornment into the container so that cargo can pull.
+environment into the container so that cargo can pull.
 
 usage notes (changing the Dockerfile)
 -------------------------------------

--- a/mob
+++ b/mob
@@ -409,7 +409,7 @@ if args.action == "prompt":
             docker_run.extend(["--expose", port])
     if args.publish is not None:
         for port in args.publish:
-            docker_run.extend(["--publish", port])
+            docker_run.extend(["--publish", "{}:{}".format(port, port)])
 
 # Map in the ssh directory, or the ssh-agent socket
 if args.ssh_dir:

--- a/mob
+++ b/mob
@@ -212,19 +212,25 @@ mobconf.read(".mobconf")
 
 verbose_chdir(top_level)
 
-# Find and parse dockerfile version file
-docker_dir = os.path.dirname(mobconf['image']['dockerfile'])
-docker_file = os.path.basename(mobconf['image']['dockerfile'])
-docker_ver_file = os.path.join(docker_dir, 'Dockerfile-version')
-with open(os.path.join(top_level, docker_ver_file), 'r') as file:
-    data = file.read().strip()
-    ver_segments = data.split('_')
-    if len(ver_segments) != 2:
-        raise Exception("Expected form A_B for Dockerfile-version, found '" + data + "' which parsed as: " + str(ver_segments))
-    major_ver = ver_segments[0]
-    minor_ver = int(ver_segments[1])
-    if minor_ver < 0:
-        raise Exception("Invalid minor ver: " + minor_ver)
+# Get dockerfile-version data Find and parse dockerfile version file
+if 'dockerfile' in mobconf['image']:
+    docker_dir = os.path.dirname(mobconf['image']['dockerfile'])
+    docker_ver_file = os.path.join(docker_dir, 'Dockerfile-version')
+    with open(os.path.join(top_level, docker_ver_file), 'r') as file:
+        version_data = file.read().strip()
+elif 'Dockerfile-version' in mobconf['image']:
+    version_data = mobconf['image']['Dockerfile-version']
+else:
+    raise Exception("Neither 'dockerfile' nor 'Dockerfile-version' was found in .mobconf")
+
+# Parse what version data we found
+ver_segments = version_data.split('_')
+if len(ver_segments) != 2:
+    raise Exception("Expected form A_B for Dockerfile-version, found '" + data + "' which parsed as: " + str(ver_segments))
+major_ver = ver_segments[0]
+minor_ver = int(ver_segments[1])
+if minor_ver < 0:
+    raise Exception("Invalid minor ver: " + minor_ver)
 
 # Calculate default tag.
 repo = mobconf['image']['repository'] if 'repository' in mobconf['image'] else ""


### PR DESCRIPTION
This allows the .mobconf to contain Dockerfile-version so that
the tool can be used in a repo that doesn't contain Dockerfile
or Dockerfile-version files.
