### PR TITLE
remove no longer relevant comment

### DIFF
--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -268,7 +268,6 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> ConsensusPeerApi for PeerApiService<E,
             }
 
             // Validate message signature
-            // FIXME: Additional verification for quorum set members that public key matches expected
             let consensus_msg: mc_peers::VerifiedConsensusMsg = match unverified_consensus_msg
                 .clone()
                 .try_into()


### PR DESCRIPTION
Soundtrack of this PR: [https://www.youtube.com/watch?v=C7K0rInwDR4](what I happen to be listening to right now)

### Motivation

MC-1055 specifies we should reject consensus messages that do not verify at the RPC entry point, but this is already taking place: 
https://github.com/mobilecoinofficial/mobilecoin/commit/e98a65a323c25919efcab3dfa5bb4db22da3745b#diff-d6a3701358007ab768cdea687051b1bdR273
https://github.com/mobilecoinofficial/mobilecoin/blob/e98a65a323c25919efcab3dfa5bb4db22da3745b/peers/src/consensus_msg.rs#L51-L58

The code also has a FIXME comment that says `Additional verification for quorum set members that public key matches expected`, how ever we moved to a world where the node id is this public key, so if the public key is changed it will no longer be part of our quorum set and we wont act on that message.

### In this PR
Removal of a stale comment.

### Future Work
N/A
