### PR TITLE
[MC-1475] Unit test that MLSAG signature validation fails if a key image fails to decompress

### DIFF
--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -328,6 +328,7 @@ mod mlsag_tests {
         CompressedCommitment,
     };
     use alloc::vec::Vec;
+    use curve25519_dalek::ristretto::CompressedRistretto;
     use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
     use mc_util_from_random::FromRandom;
     use proptest::prelude::*;
@@ -640,8 +641,48 @@ mod mlsag_tests {
         }
 
         #[test]
-        // `verify` should reject a signature with invalid key image.
-        fn test_verify_rejects_invalid_key_image(
+        // `verify` should reject a signature if the key image is not canonically encoded.
+        fn test_verify_rejects_noncanonical_key_image(
+            num_mixins in 1..17usize,
+            seed in any::<[u8; 32]>(),
+        ) {
+            let mut rng: StdRng = SeedableRng::from_seed(seed);
+            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
+
+            let mut signature = RingMLSAG::sign(
+                &params.message,
+                &params.ring,
+                params.real_index,
+                &params.onetime_private_key,
+                params.value,
+                &params.blinding,
+                &params.pseudo_output_blinding,
+                &mut rng,
+            )
+            .unwrap();
+
+            // Replace the key image with a non-canonical compressed Ristretto point.
+            // This is constants::EDWARDS_D.to_bytes(), which is a negative point, so decompression should fail.
+            // Edwards `d` value, equal to `-121665/121666 mod p`.
+            let edwards_d : [u8; 32] = [163, 120, 89, 19, 202, 77, 235, 117, 171, 216, 65, 65, 77, 10, 112, 0, 152, 232, 121, 119, 121, 64, 199, 140, 115, 254, 111, 43, 238, 108, 3, 82];
+            let bad_compressed = CompressedRistretto(edwards_d);
+            assert!(bad_compressed.decompress().is_none());
+
+            signature.key_image = KeyImage{point: bad_compressed};
+
+            let output_commitment = CompressedCommitment::new(params.value, params.pseudo_output_blinding);
+
+            match signature.verify(&params.message, &params.ring, &output_commitment) {
+                Err(Error::InvalidKeyImage) => {} // This is expected.
+                Err(e) => panic!(format!("Unexpected error {}", e)),
+                Ok(()) => panic!("Signature should be rejected."),
+            }
+        }
+
+        #[test]
+        // `verify` should reject a signature with modified key image.
+        fn test_verify_rejects_modified_key_image(
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
         ) {


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR](https://www.youtube.com/watch?v=JTEFKFiXSx4)

### Motivation

Signature validation should reject CompressedRistretto points that don't canonically encode a Ristretto point. Roughly, the canonical points are the nice prime-ordered group that Ristretto provides us with, and the non-canonical ones are everything else.

### In this PR
Unit tests that MLSAG signature verification rejects a signature with a non-canonical Key Image, and returns the correct Error type.