### PR TITLE
[MC-1470] Ring elements must be sorted

### DIFF
--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -1156,7 +1156,6 @@ mod conversion_tests {
             0,
             onetime_private_key,
             *alice.view_private_key(),
-            &mut rng,
         )
         .unwrap();
 

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -669,7 +669,6 @@ mod combine_tests {
             0,
             onetime_private_key,
             *alice.view_private_key(),
-            &mut rng,
         )
         .unwrap();
 
@@ -743,7 +742,6 @@ mod combine_tests {
                     0,
                     onetime_private_key,
                     *alice.view_private_key(),
-                    &mut rng,
                 )
                 .unwrap();
                 transaction_builder.add_input(input_credentials);
@@ -807,7 +805,6 @@ mod combine_tests {
                 0,
                 onetime_private_key,
                 *alice.view_private_key(),
-                &mut rng,
             )
             .unwrap();
 
@@ -840,7 +837,6 @@ mod combine_tests {
                 0,
                 onetime_private_key,
                 *alice.view_private_key(),
-                &mut rng,
             )
             .unwrap();
 
@@ -895,7 +891,6 @@ mod combine_tests {
                 0,
                 onetime_private_key,
                 *alice.view_private_key(),
-                &mut rng,
             )
             .unwrap();
 

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -645,7 +645,6 @@ impl<T: UserTxConnection + 'static> TransactionsManager<T> {
                     real_key_index,
                     onetime_private_key,
                     *from_account_key.view_private_key(),
-                    rng,
                 )
                 .or_else(|_| {
                     Err(Error::TxBuildError(

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -119,7 +119,6 @@ pub fn create_transaction_with_amount<L: Ledger, R: RngCore + CryptoRng>(
         real_index,
         onetime_private_key,
         *sender.view_private_key(),
-        rng,
     )
     .unwrap();
     transaction_builder.add_input(input_credentials);

--- a/transaction/std/src/input_credentials.rs
+++ b/transaction/std/src/input_credentials.rs
@@ -36,7 +36,6 @@ impl InputCredentials {
     /// * `real_index` - Index in `ring` of the output being spent.
     /// * `onetime_private_key` - Private key for the output being spent.
     /// * `view_private_key` - The view private key belonging to the owner of the real output.
-    /// * `rng` - Randomness.
     pub fn new(
         ring: Vec<TxOut>,
         membership_proofs: Vec<TxOutMembershipProof>,

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -318,7 +318,6 @@ pub mod transaction_builder_tests {
                 real_index,
                 onetime_private_key,
                 *sender.view_private_key(),
-                rng,
             )
             .unwrap();
             transaction_builder.add_input(input_credentials);
@@ -373,7 +372,6 @@ pub mod transaction_builder_tests {
             real_index,
             onetime_private_key,
             *sender.view_private_key(),
-            &mut rng,
         )
         .unwrap();
 
@@ -464,7 +462,6 @@ pub mod transaction_builder_tests {
             real_index,
             onetime_private_key,
             *alice.view_private_key(),
-            &mut rng,
         )
         .unwrap();
 
@@ -500,6 +497,23 @@ pub mod transaction_builder_tests {
         .unwrap();
         assert_eq!(tx.prefix.inputs.len(), MAX_INPUTS as usize);
         assert_eq!(tx.prefix.outputs.len(), MAX_OUTPUTS as usize);
+    }
+
+    #[test]
+    // Ring elements should be sorted by tx_out.public_key
+    fn test_ring_elements_are_sorted() {
+        let mut rng: StdRng = SeedableRng::from_seed([97u8; 32]);
+        let sender = AccountKey::random(&mut rng);
+        let recipient = AccountKey::random(&mut rng);
+        let num_inputs = 3;
+        let num_outputs = 11;
+        let tx = get_transaction(num_inputs, num_outputs, &sender, &recipient, &mut rng).unwrap();
+
+        for tx_in in tx.prefix.inputs {
+            let mut expected_ring = tx_in.ring.clone();
+            expected_ring.sort_by(|a, b| a.public_key.cmp(&b.public_key));
+            assert_eq!(tx_in.ring, expected_ring);
+        }
     }
 
     #[test]

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -509,10 +509,11 @@ pub mod transaction_builder_tests {
         let num_outputs = 11;
         let tx = get_transaction(num_inputs, num_outputs, &sender, &recipient, &mut rng).unwrap();
 
-        for tx_in in tx.prefix.inputs {
-            let mut expected_ring = tx_in.ring.clone();
-            expected_ring.sort_by(|a, b| a.public_key.cmp(&b.public_key));
-            assert_eq!(tx_in.ring, expected_ring);
+        for tx_in in &tx.prefix.inputs {
+            assert!(tx_in
+                .ring
+                .windows(2)
+                .all(|w| w[0].public_key < w[1].public_key));
         }
     }
 


### PR DESCRIPTION
Soundtrack of this PR: [April 26, 1992](https://www.youtube.com/watch?v=qi8KJ0boov8&t=91s)

### Motivation

Sorting ring elements prevents the ordering from leaking any information about the true input. 

### In this PR
* InputCredentials sorts the ring elements (instead of randomly shuffling them)
* validate.rs checks that each ring is sorted.
