### PR TITLE
[MC-1477] MLSAG Key Prefixing

### DIFF
--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -173,10 +173,12 @@ impl RingMLSAG {
                 (L0, R0, L1)
             };
 
+            let P_i_compressed = &ring[i].0;
             c[(i + 1) % ring_size] = {
                 let mut hasher = Blake2b::new();
                 hasher.input(&RING_MLSAG_CHALLENGE_DOMAIN_TAG);
                 hasher.input(message);
+                hasher.input(P_i_compressed);
                 hasher.input(&key_image);
                 hasher.input(L0.compress().as_bytes());
                 hasher.input(R0.compress().as_bytes());
@@ -287,10 +289,12 @@ impl RingMLSAG {
             let R0 = r[2 * i] * hash_to_point(P_i) + c_i * I;
             let L1 = r[2 * i + 1] * H + c_i * (output_commitment.point - input_commitment.point);
 
+            let P_i_compressed = &ring[i].0;
             recomputed_c[(i + 1) % ring_size] = {
                 let mut hasher = Blake2b::new();
                 hasher.input(&RING_MLSAG_CHALLENGE_DOMAIN_TAG);
                 hasher.input(message);
+                hasher.input(P_i_compressed);
                 hasher.input(&self.key_image);
                 hasher.input(L0.compress().as_bytes());
                 hasher.input(R0.compress().as_bytes());

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -174,12 +174,15 @@ impl RingMLSAG {
             };
 
             let P_i_compressed = &ring[i].0;
+            let difference_compressed =
+                CompressedRistrettoPublic::from(output_commitment.point - input_commitment.point);
             c[(i + 1) % ring_size] = {
                 let mut hasher = Blake2b::new();
                 hasher.input(&RING_MLSAG_CHALLENGE_DOMAIN_TAG);
                 hasher.input(message);
                 hasher.input(P_i_compressed);
                 hasher.input(&key_image);
+                hasher.input(&difference_compressed);
                 hasher.input(L0.compress().as_bytes());
                 hasher.input(R0.compress().as_bytes());
                 hasher.input(L1.compress().as_bytes());
@@ -290,12 +293,15 @@ impl RingMLSAG {
             let L1 = r[2 * i + 1] * H + c_i * (output_commitment.point - input_commitment.point);
 
             let P_i_compressed = &ring[i].0;
+            let difference_compressed =
+                CompressedRistrettoPublic::from(output_commitment.point - input_commitment.point);
             recomputed_c[(i + 1) % ring_size] = {
                 let mut hasher = Blake2b::new();
                 hasher.input(&RING_MLSAG_CHALLENGE_DOMAIN_TAG);
                 hasher.input(message);
                 hasher.input(P_i_compressed);
                 hasher.input(&self.key_image);
+                hasher.input(&difference_compressed);
                 hasher.input(L0.compress().as_bytes());
                 hasher.input(R0.compress().as_bytes());
                 hasher.input(L1.compress().as_bytes());


### PR DESCRIPTION
### Motivation
"Key prefixing" is a conservative idea meant to address concerns about "multi-key" attacks against Schnorr signatures. The concern is that forging a signature for one of several public keys may be an easier problem than forging a signature for a particular public key. DJB showed that including the signer's public key in the challenge hash of a Schnorr signature makes the multi-key attack as difficult as the single-key attack. See https://mailarchive.ietf.org/arch/msg/cfrg/44gJyZlZ7-myJqWkChhpEF1KE9M/

### In this PR

This PR updates the MLSAG challenge hash to include all three public keys related to the challenge: the ring element, the commitment to zero, and the key image.
