### PR TITLE
Fix wallet example

### DIFF
--- a/mobilecoind/clients/python/Wallet.ipynb
+++ b/mobilecoind/clients/python/Wallet.ipynb
@@ -13,6 +13,7 @@
     "To run this notebook, make sure you have the requirements installed, and that you have compiled the grpc protos.\n",
     "\n",
     "```\n",
+    "cd mobilecoind/clients/python/mob_client\n",
     "pip3 install -r requirements.txt\n",
     "./compile_protos.sh\n",
     "```"
@@ -33,8 +34,9 @@
     "\n",
     "import cmd\n",
     "\n",
-    "sys.path.append('./mob_client')\n"
-    "from mob_client import mob_client, MonitorNotFound"
+    "import sys\n",
+    "sys.path.append('./mob_client')\n",
+    "from mob_client.mob_client import mob_client, MonitorNotFound"
    ]
   },
   {


### PR DESCRIPTION
Soundtrack of this PR: [Hazey](https://www.youtube.com/watch?v=nOHEuhJf7nA)

### Motivation

A previous change to the organization of the python clients dir resulted in the Wallet.ipynb no longer running.

### In this PR
* Fixes the Wallet.ipynb by adding a sys path append to add the mob_client dir.

