### PR TITLE
Make CompressedRistrettoPublic implement From<&[u8;32]>

### DIFF
--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -380,6 +380,12 @@ derive_into_vec_from_repr_bytes!(CompressedRistrettoPublic);
 derive_serde_from_repr_bytes!(CompressedRistrettoPublic);
 derive_prost_message_from_repr_bytes!(CompressedRistrettoPublic);
 
+impl From<&[u8; 32]> for CompressedRistrettoPublic {
+    fn from(src: &[u8; 32]) -> Self {
+        Self(CompressedRistretto::from_slice(&src[..]))
+    }
+}
+
 impl AsRef<[u8; 32]> for CompressedRistrettoPublic {
     fn as_ref(&self) -> &[u8; 32] {
         self.0.as_bytes()


### PR DESCRIPTION
This will allows some code back end services, to be
simplified a little bit, there are a couple places where I am
using try_from to convert from &[u8;32] into this object, even
though the conversion cannot fail.

Soundtrack of this PR: https://www.youtube.com/watch?v=vwfO6tT1ZnU&t=12s