### PR TITLE
Make product ID and security version optional if MrEnclave matches

### DIFF
--- a/attest/ake/src/state.rs
+++ b/attest/ake/src/state.rs
@@ -19,11 +19,13 @@ pub struct Start {
     /// The measurement we expect from authenticated counterparties
     pub(crate) expected_measurements: Vec<Measurement>,
 
-    /// The product ID remote enclaves must be running
-    pub(crate) expected_product_id: u16,
+    /// The product ID remote enclaves must be running, compatible with
+    /// Measurement::MrSigner, as the Measurement::MrEnclave encompasses this value.
+    pub(crate) expected_product_id: Option<u16>,
 
-    /// The minimum security version remote enclaves must be running
-    pub(crate) expected_minimum_svn: u16,
+    /// The minimum security version remote enclaves must be running, compatible with
+    /// Measurement::MrSigner, as the Measurement::MrEnclave encompasses this value.
+    pub(crate) expected_minimum_svn: Option<u16>,
 
     /// Whether or not to allow remote enclaves to run in debug
     pub(crate) allow_debug: bool,
@@ -38,8 +40,8 @@ impl Start {
     pub fn new(
         responder_id: String,
         expected_measurements: Vec<Measurement>,
-        expected_product_id: u16,
-        expected_minimum_svn: u16,
+        expected_product_id: Option<u16>,
+        expected_minimum_svn: Option<u16>,
         allow_debug: bool,
     ) -> Self {
         Self {
@@ -68,9 +70,9 @@ where
     /// The enclave measurement we expect in the AuthResponse
     pub(crate) expected_measurements: Vec<Measurement>,
     /// The product ID remote enclaves must be running
-    pub(crate) expected_product_id: u16,
+    pub(crate) expected_product_id: Option<u16>,
     /// The minimum security version remote enclaves must be running
-    pub(crate) expected_minimum_svn: u16,
+    pub(crate) expected_minimum_svn: Option<u16>,
     /// Whether or not to allow remote enclaves to run in debug
     pub(crate) allow_debug: bool,
 
@@ -95,8 +97,8 @@ where
     pub(crate) fn new(
         state: HandshakeState<KexAlgo, Cipher, DigestType>,
         expected_measurements: Vec<Measurement>,
-        expected_product_id: u16,
-        expected_minimum_svn: u16,
+        expected_product_id: Option<u16>,
+        expected_minimum_svn: Option<u16>,
         allow_debug: bool,
         trust_anchors: Option<Vec<String>>,
     ) -> Self {

--- a/attest/core/src/error.rs
+++ b/attest/core/src/error.rs
@@ -308,8 +308,12 @@ pub enum ReportBodyVerifyError {
     DebugNotAllowed,
     #[fail(display = "Product ID mismatch, expected {}, got {}", _0, _1)]
     ProductId(u16, u16),
+    #[fail(display = "Product ID not provided to verify, but only MrSigner matches")]
+    ProductIdNone,
     #[fail(display = "The enclave's security version was not at least {}", _0)]
     SecurityVersion(u16),
+    #[fail(display = "The Security Version was not provided to verify, but only MrSigner matches")]
+    SecurityVersionNone,
     #[fail(
         display = "Measurement error, expected one of {:?}, got MRENCLAVE {}, and MRSIGNER {}",
         _0, _1, _2

--- a/attest/core/src/ias/verify.rs
+++ b/attest/core/src/ias/verify.rs
@@ -212,8 +212,8 @@ impl VerificationReportData {
         expected_type: QuoteSignType,
         allow_debug: bool,
         expected_measurements: &[Measurement],
-        expected_product_id: u16,
-        minimum_security_version: u16,
+        expected_product_id: Option<u16>,
+        minimum_security_version: Option<u16>,
         expected_data: &ReportDataMask,
     ) -> Result<(), VerifyError> {
         self.verify_data(

--- a/attest/core/src/quote.rs
+++ b/attest/core/src/quote.rs
@@ -295,8 +295,8 @@ impl Quote {
         expected_type: QuoteSignType,
         allow_debug: bool,
         expected_measurements: &[Measurement],
-        expected_product_id: ProductId,
-        minimum_security_version: SecurityVersion,
+        expected_product_id: Option<ProductId>,
+        minimum_security_version: Option<SecurityVersion>,
         expected_data: &ReportDataMask,
     ) -> Result<(), QuoteError> {
         if let Some(expected) = expected_gid {


### PR DESCRIPTION
Soundtrack of this PR: [Regard - Ride It](https://www.youtube.com/watch?v=ucVUEmjKsko)

### Motivation

Currently, we require product ID and minimum security version, even though those values are encompassed in the MrEnclave measurement. These values are needed in the case where only the MrSigner is provided, so this PR addresses these cases to give more flexibility to client implementations that use attestation.

### In this PR
* Make `product_id` and `minimum_security_version` optional in enclave report verification and only check them if there was no MrEnclave match, and there is a MrSigner match.

#done [FOG-5](https://mobilecoin.atlassian.net/browse/FOG-5)

