### PR TITLE
Fix CSS-injected builds of mc-mobilecoind when SGX SDK not installed.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,7 +2228,6 @@ dependencies = [
  "mc-util-build-enclave",
  "mc-util-build-script",
  "mc-util-build-sgx",
- "pkg-config",
 ]
 
 [[package]]

--- a/consensus/enclave/measurement/Cargo.toml
+++ b/consensus/enclave/measurement/Cargo.toml
@@ -19,4 +19,3 @@ mc-util-build-sgx = { path = "../../../util/build/sgx" }
 mc-util-build-script = { path = "../../../util/build/script" }
 
 cargo-emit = "0.1"
-pkg-config = "0.3"

--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -8,9 +8,6 @@ use mc_util_build_script::Environment;
 use mc_util_build_sgx::{IasMode, SgxEnvironment, SgxMode, TcsPolicy};
 use std::{env::var, path::PathBuf};
 
-const SGX_LIBS: &[&str] = &["libsgx_urts", "libsgx_epid"];
-const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
-
 // Changing this version is a breaking change, you must update the crate version if you do.
 const SGX_VERSION: &str = "2.9.101.2";
 
@@ -23,18 +20,14 @@ fn main() {
     let env = Environment::default();
     let sgx = SgxEnvironment::new(&env).expect("Could not read SGX environment");
 
-    let sgx_libs = if sgx.sgx_mode() == SgxMode::Simulation {
+    if sgx.sgx_mode() == SgxMode::Simulation {
         rustc_cfg!("feature=\"sgx-sim\"");
-        SGX_SIMULATION_LIBS
-    } else {
-        SGX_LIBS
-    };
+    }
 
     let mut builder = Builder::new(
         &env,
         &sgx,
         SGX_VERSION,
-        sgx_libs,
         CONSENSUS_ENCLAVE_NAME,
         CONSENSUS_ENCLAVE_DIR.as_ref(),
     )

--- a/util/build/enclave/src/lib.rs
+++ b/util/build/enclave/src/lib.rs
@@ -13,12 +13,11 @@ use mbedtls_sys::types::{
 };
 use mc_sgx_css::{Error as SignatureError, Signature};
 use mc_util_build_script::{rerun_if_path_changed, CargoBuilder, Environment};
-use mc_util_build_sgx::{
-    ConfigBuilder, IasMode, SgxEnvironment, SgxLibraryCollection, SgxMode, SgxSign,
-};
-use pkg_config::{Error as PkgConfigError, Library};
+use mc_util_build_sgx::{ConfigBuilder, IasMode, SgxEnvironment, SgxMode, SgxSign};
+use pkg_config::{Config, Error as PkgConfigError};
 use rand::{thread_rng, RngCore};
 use std::{
+    collections::HashSet,
     convert::TryFrom,
     fs,
     io::Error as IoError,
@@ -123,28 +122,73 @@ impl From<SignatureError> for Error {
 /// if they aren't specified
 #[derive(Clone, Debug)]
 pub struct Builder {
+    /// The cargo command builder
     pub cargo_builder: CargoBuilder,
+
+    /// The SGX configuration XML builder
     pub config_builder: ConfigBuilder,
 
+    /// The name of the enclave
     name: String,
+
+    /// A set of PkgConfig configurations and the libraries to use with it
+    sgx_version: String,
+
+    /// A set of PkgConfig configurations and the libraries to use with it
+    sgx_libs: Vec<String>,
+
+    /// The cargo metadata of the trusted crate
     staticlib: Metadata,
-    signer: SgxSign,
+
+    /// The OUT_DIR path
     out_dir: PathBuf,
+
+    /// The target architecture
+    target_arch: String,
+
+    /// The CARGO_TARGET_DIR path
     target_dir: PathBuf,
+
+    /// The CARGO_TARGET_DIR/profile path
     profile_target_dir: PathBuf,
+
+    /// The name of the profile we're building for
     profile: String,
-    link_paths: Vec<PathBuf>,
+
+    /// The path to the linker to use
     linker: PathBuf,
+
+    /// The configured SGX mode
     sgx_mode: SgxMode,
+
+    /// An optional explicit path to an existing CSS (sigstruct) file
     css: Option<PathBuf>,
+
+    /// An optional explicit path to an existing sigstruct text dump
     dump: Option<PathBuf>,
+
+    /// An optional explicit path to a pre-signed enclave
     signed_enclave: Option<PathBuf>,
+
+    /// An optional explicit path to a pre-existing SGX config XML file
     config_xml: Option<PathBuf>,
+
+    /// An optional explicit path to a pre-existing unsigned enclave binary
     unsigned_enclave: Option<PathBuf>,
+
+    /// An optional explicit path to a pre-existing public key
     pubkey: Option<PathBuf>,
+
+    /// An optional explicit path to a pre-existing private key
     privkey: Option<PathBuf>,
+
+    /// An optional explicit path to pre-existing data under signature
     gendata: Option<PathBuf>,
+
+    /// An optional explicit path to a file containing a detached signature
     signature: Option<PathBuf>,
+
+    /// an option explicit path to a linker script
     lds: Option<PathBuf>,
 }
 
@@ -153,7 +197,8 @@ impl Builder {
     pub fn new(
         env: &Environment,
         sgx: &SgxEnvironment,
-        sgx_libs: &[Library],
+        sgx_version: &str,
+        sgx_libs: &[&str],
         enclave_name: &str,
         staticlib_dir: &Path,
     ) -> Result<Self, Error> {
@@ -172,38 +217,20 @@ impl Builder {
             .features(CargoOpt::SomeFeatures(features_vec))
             .exec()?;
 
-        let link_paths = sgx_libs
-            .link_paths()
-            .into_iter()
-            .map(|path| {
-                // We would like to try and use the static libs which are built
-                // with LVI mitigation.
-                if sgx.sgx_mode() != SgxMode::Simulation {
-                    let cve_load = path.join("cve_2020_0551_load");
-                    if cve_load.exists() {
-                        cve_load
-                    } else {
-                        PathBuf::from(path)
-                    }
-                } else {
-                    PathBuf::from(path)
-                }
-            })
-            .collect::<Vec<PathBuf>>();
-
-        let signer = SgxSign::new(env)?;
+        let sgx_libs = sgx_libs.iter().map(|value| String::from(*value)).collect();
 
         Ok(Self {
             cargo_builder: CargoBuilder::new(&env, staticlib_dir, false),
             config_builder: ConfigBuilder::default(),
             name: enclave_name.to_owned(),
             staticlib,
-            signer,
+            target_arch: env.target_arch().to_owned(),
             out_dir: env.out_dir().to_owned(),
             target_dir: env.target_dir().to_owned(),
             profile_target_dir: env.profile_target_dir().to_owned(),
             profile: env.profile().to_owned(),
-            link_paths,
+            sgx_libs,
+            sgx_version: sgx_version.to_owned(),
             linker: env.linker().to_owned(),
             sgx_mode: sgx.sgx_mode(),
             css: None,
@@ -365,8 +392,7 @@ impl Builder {
 
         let mut dump_path = self.out_dir.join(&self.name);
         dump_path.set_extension("dump");
-        if self
-            .signer
+        if SgxSign::new(&self.target_arch)?
             .dump(&signed_enclave, css_path, &dump_path)
             .status()?
             .success()
@@ -416,8 +442,7 @@ impl Builder {
         // Re-create the gendata from the unsigned enclave
         let mut gendata = self.out_dir.join(&self.name);
         gendata.set_extension("dat");
-        if !self
-            .signer
+        if !SgxSign::new(&self.target_arch)?
             .gendata(&unsigned_enclave, &config_xml, &gendata)
             .status()?
             .success()
@@ -484,8 +509,7 @@ impl Builder {
                 .to_str()
                 .expect("Invalid UTF-8 in pubkey path"));
 
-            if !self
-                .signer
+            if !SgxSign::new(&self.target_arch)?
                 .catsig(
                     &unsigned_enclave,
                     &config_xml,
@@ -512,8 +536,7 @@ impl Builder {
         private_key: &Path,
         output_enclave: &Path,
     ) -> Result<(), Error> {
-        if self
-            .signer
+        if SgxSign::new(&self.target_arch)?
             .sign(
                 &unsigned_enclave,
                 &config_path,
@@ -624,9 +647,30 @@ impl Builder {
             .args(&["-z", "relro", "-z", "now", "-z", "noexecstack"])
             .args(&["--no-undefined", "-nostdlib"]);
 
-        // We're only using link paths here, actual linkage is hard-coded.
-        for libdir in &self.link_paths {
-            command.arg(format!("-L{}", libdir.display()));
+        let mut config = Config::new();
+        config
+            .exactly_version(&self.sgx_version)
+            .print_system_libs(true)
+            .cargo_metadata(false)
+            .env_metadata(true);
+
+        let lib_paths = self
+            .sgx_libs
+            .iter()
+            .map(|libname| Ok(config.probe(libname.as_str())?.link_paths))
+            .collect::<Result<Vec<Vec<PathBuf>>, PkgConfigError>>()?
+            .into_iter()
+            .flatten()
+            .collect::<HashSet<PathBuf>>();
+
+        for path in lib_paths {
+            if self.sgx_mode == SgxMode::Simulation {
+                let cve_load = path.join("cve_2020_0551_load");
+                if cve_load.exists() {
+                    command.arg(format!("-L{}", cve_load.display()));
+                }
+            }
+            command.arg(format!("-L{}", path.display()));
         }
 
         command

--- a/util/build/sgx/src/sign.rs
+++ b/util/build/sgx/src/sign.rs
@@ -3,7 +3,6 @@
 //! Builder wrapper around SgxSign.
 
 use crate::utils::get_binary;
-use mc_util_build_script::Environment;
 use pkg_config::Error as PkgConfigError;
 use std::{
     path::{Path, PathBuf},
@@ -25,8 +24,8 @@ pub struct SgxSign {
 
 impl SgxSign {
     /// Create a new SGX signing utility from the current environment.
-    pub fn new(env: &Environment) -> Result<Self, PkgConfigError> {
-        get_binary(env.target_arch(), "sgx_sign").map(Self::from)
+    pub fn new(target_arch: &str) -> Result<Self, PkgConfigError> {
+        get_binary(target_arch, "sgx_sign").map(Self::from)
     }
 
     /// Relocations are generally forbidden in the enclave shared object, this tells the `sgx_sign`


### PR DESCRIPTION
[Soundtrack of this PR](https://www.youtube.com/watch?v=rFBnlO46xUk)

### Motivation

Right now, all builds require the SGX SDK to be installed, even if they are simply injecting a CSS file.

### In this PR

 - Update `mc_util_build_sgx::SgxSign` to just take a `target_arch` on construction.
 - Update `mc_util_build_enclave::Builder` to just take the required SGX version.
 - Update `mc_util_build_enclave::Builder` to delay hitting pkg-config until actually needed.
