### PR TITLE
scp metamesh topology

### DIFF
--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -544,7 +544,7 @@ pub fn run_test(mut network: SCPNetwork, network_name: &str, logger: Logger) {
 
     let start = Instant::now();
 
-    let mut rng = test_helper::get_seeded_rng();
+    let mut rng = mc_util_test_helper::get_seeded_rng();
 
     let mut values = Vec::<String>::new();
 
@@ -557,7 +557,7 @@ pub fn run_test(mut network: SCPNetwork, network_name: &str, logger: Logger) {
     };
 
     for i in 0..VALUES_TO_PUSH {
-        let value = test_helper::random_str(&mut rng, 20);
+        let value = mc_util_test_helper::random_str(&mut rng, 20);
 
         if SUBMIT_VALUES_IN_PARALLEL {
             // simulate broadcast of values to all nodes in parallel

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -51,6 +51,7 @@ const OVERRIDE_LAST_SEEN_HISTORY_SIZE: usize = 100000;
 /// Because thread testing doesn't implement catchup, increase the lrucache used to store externalized slots.
 const OVERRIDE_MAX_EXTERNALIZED_SLOTS: usize = 1000;
 
+#[allow(dead_code)]
 pub struct NodeOptions {
     thread_name: String,
     peers: Vec<u32>,
@@ -78,6 +79,7 @@ pub struct SCPNetwork {
 
 impl SCPNetwork {
     // creates a network based on node_options
+    #[allow(dead_code)]
     pub fn new(
         node_options: Vec<NodeOptions>,
         validity_fn: ValidityFn<String, TransactionValidationError>,

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -665,18 +665,3 @@ pub fn run_test(mut network: SCPNetwork, network_name: &str, logger: Logger) {
     // allow log to flush
     std::thread::sleep(Duration::from_millis(LOG_FLUSH_DELAY_MILLIS)); 
 }
-
-pub fn random_str(rng: &mut StdRng, len: usize) -> String {
-    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
-                            abcdefghijklmnopqrstuvwxyz\
-                            0123456789";
-
-    let output: String = (0..len)
-        .map(|_| {
-            let idx = (rng.next_u64() % CHARSET.len() as u64) as usize;
-            char::from(CHARSET[idx])
-        })
-        .collect();
-
-    output
-}

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -192,27 +192,6 @@ impl SCPNetwork {
             .clone()
     }
 
-    /// Wait for this node's ledger to grow to a specific block height
-    #[allow(dead_code)]
-    pub fn wait_for_block_height(&self, node_id: &NodeID, block_height: usize, max_wait: Duration) {
-        let deadline = Instant::now() + max_wait;
-        while Instant::now() < deadline {
-            let cur_block_height = self.get_shared_data(node_id).ledger.len();
-            if cur_block_height >= block_height {
-                return;
-            }
-
-            thread::sleep(Duration::from_millis(10));
-        }
-
-        let cur_block_height = self.get_shared_data(node_id).ledger.len();
-
-        panic!(
-            "{:?}: timeout while waiting for block height {} (currently at {})",
-            node_id, block_height, cur_block_height
-        );
-    }
-
     pub fn broadcast_msg(
         logger: Logger,
         nodes_map: &Arc<Mutex<HashMap<NodeID, SCPNode>>>,

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -33,7 +33,7 @@ use std::{
 const SUBMIT_VALUES_IN_PARALLEL: bool = true;
 
 /// Total number of values to submit. Tests run until all values are externalized by all nodes.
-const VALUES_TO_PUSH: u32 = 2000;
+const VALUES_TO_PUSH: u32 = 200;
 
 /// Approximate rate that values are submitted to nodes.
 const VALUES_PER_SEC: u64 = 2000;

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -564,7 +564,6 @@ impl SCPNode {
 
 /// Injects values to a network and waits for completion
 pub fn run_test(mut network: SCPNetwork, network_name: &str, logger: Logger) {
-
     if SUBMIT_VALUES_IN_PARALLEL {
         log::info!(
             logger,

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -204,7 +204,7 @@ impl SCPNetwork {
         );
     }
 
-    fn broadcast_msg(
+    pub fn broadcast_msg(
         logger: Logger,
         nodes_map: &Arc<Mutex<HashMap<NodeID, SCPNode>>>,
         peers: &HashSet<NodeID>,
@@ -287,7 +287,7 @@ impl SCPNodeSharedData {
 struct SCPNode {
     local_node: Arc<Mutex<Node<String, TransactionValidationError>>>,
     sender: crossbeam_channel::Sender<SCPNodeTaskMessage>,
-    shared_data: Arc<Mutex<SCPNodeSharedData>>,
+    pub shared_data: Arc<Mutex<SCPNodeSharedData>>,
 }
 
 impl SCPNode {

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -284,7 +284,7 @@ impl SCPNodeSharedData {
     }
 }
 
-struct SCPNode {
+pub struct SCPNode {
     local_node: Arc<Mutex<Node<String, TransactionValidationError>>>,
     sender: crossbeam_channel::Sender<SCPNodeTaskMessage>,
     pub shared_data: Arc<Mutex<SCPNodeSharedData>>,

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -11,7 +11,6 @@ use mc_consensus_scp::{
     quorum_set::QuorumSet,
     test_utils::{test_node_id, TransactionValidationError},
 };
-use rand::{rngs::StdRng, RngCore};
 use std::{
     collections::BTreeSet,
     iter::FromIterator,
@@ -661,7 +660,7 @@ pub fn run_test(mut network: SCPNetwork, network_name: &str, logger: Logger) {
         VALUES_TO_PUSH,
         VALUES_PER_SEC,
     );
-    
+
     // allow log to flush
-    std::thread::sleep(Duration::from_millis(LOG_FLUSH_DELAY_MILLIS)); 
+    std::thread::sleep(Duration::from_millis(LOG_FLUSH_DELAY_MILLIS));
 }

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -73,7 +73,7 @@ pub struct SCPNetwork {
     pub nodes_map: Arc<Mutex<HashMap<NodeID, SCPNode>>>,
     pub thread_handles: HashMap<NodeID, Option<JoinHandle<()>>>,
     pub nodes_shared_data: HashMap<NodeID, Arc<Mutex<SCPNodeSharedData>>>,
-    logger: Logger,
+    pub logger: Logger,
 }
 
 impl SCPNetwork {

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -70,9 +70,9 @@ impl NodeOptions {
 }
 
 pub struct SCPNetwork {
-    nodes_map: Arc<Mutex<HashMap<NodeID, SCPNode>>>,
-    thread_handles: HashMap<NodeID, Option<JoinHandle<()>>>,
-    nodes_shared_data: HashMap<NodeID, Arc<Mutex<SCPNodeSharedData>>>,
+    pub nodes_map: Arc<Mutex<HashMap<NodeID, SCPNode>>>,
+    pub thread_handles: HashMap<NodeID, Option<JoinHandle<()>>>,
+    pub nodes_shared_data: HashMap<NodeID, Arc<Mutex<SCPNodeSharedData>>>,
     logger: Logger,
 }
 

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -1,5 +1,14 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
+// Not all of the separated integration tests use all of the common code.
+// https://github.com/rust-lang/rust/issues/46379
+// Specifically, the metamesh codes don't use NodeOptions:new() or
+// SCPNetwork::new() since we construct the network more directly for those
+// tests. We should fix this by allowing arbitrary quorum sets in NodeOptions
+// rather than assuming k-of-n
+
+#![allow(dead_code)]
+
 use mc_common::{
     logger::{log, o, Logger},
     HashMap, HashSet, NodeID,
@@ -51,7 +60,6 @@ const OVERRIDE_LAST_SEEN_HISTORY_SIZE: usize = 100000;
 /// Because thread testing doesn't implement catchup, increase the lrucache used to store externalized slots.
 const OVERRIDE_MAX_EXTERNALIZED_SLOTS: usize = 1000;
 
-#[allow(dead_code)]
 pub struct NodeOptions {
     thread_name: String,
     peers: Vec<u32>,
@@ -79,7 +87,6 @@ pub struct SCPNetwork {
 
 impl SCPNetwork {
     // creates a network based on node_options
-    #[allow(dead_code)]
     pub fn new(
         node_options: Vec<NodeOptions>,
         validity_fn: ValidityFn<String, TransactionValidationError>,

--- a/consensus/scp/tests/test_cyclic_networks.rs
+++ b/consensus/scp/tests/test_cyclic_networks.rs
@@ -25,6 +25,37 @@ fn skip_slow_tests() -> bool {
 // Cyclic tests (similar to Figure 4 in the SCP whitepaper)
 ///////////////////////////////////////////////////////////////////////////////
 
+/// Constructs a cyclic network (e.g. 1->2->3->4->1)
+fn new_cyclic(
+    num_nodes: usize,
+    validity_fn: ValidityFn<String, TransactionValidationError>,
+    combine_fn: CombineFn<String>,
+    logger: Logger,
+) -> SCPNetwork {
+    let mut node_options = Vec::<NodeOptions>::new();
+    for node_id in 0..num_nodes {
+        let next_node_id: u32 = if node_id + 1 < num_nodes {
+            node_id as u32 + 1
+        } else {
+            0
+        };
+
+        let other_node_ids: Vec<u32> = (0..num_nodes)
+            .filter(|other_node_id| other_node_id != &node_id)
+            .map(|other_node_id| other_node_id as u32)
+            .collect();
+
+        node_options.push(NodeOptions::new(
+            format!("c-{}-node{}", num_nodes, node_id),
+            other_node_ids,
+            vec![next_node_id],
+            1,
+        ));
+    }
+
+    SCPNetwork::new(node_options, validity_fn, combine_fn, logger)
+}
+
 fn cyclic_test_helper(num_nodes: usize, logger: Logger) {
     if skip_slow_tests() {
         return;

--- a/consensus/scp/tests/test_cyclic_networks.rs
+++ b/consensus/scp/tests/test_cyclic_networks.rs
@@ -62,7 +62,7 @@ fn cyclic_test_helper(num_nodes: usize, logger: Logger) {
         return;
     }
     
-    let network = mock_network::SCPNetwork::new_cyclic(
+    let network = new_cyclic(
         num_nodes,
         Arc::new(test_utils::trivial_validity_fn::<String>),
         Arc::new(test_utils::trivial_combine_fn::<String>),
@@ -70,7 +70,7 @@ fn cyclic_test_helper(num_nodes: usize, logger: Logger) {
     );
 
     let network_name = format!("cyclic{}", num_nodes);
-    mock_network::run_test(network, values_to_push, logger.clone(), &network_name);
+    mock_network::run_test(network, &network_name, logger.clone());
 }
 
 #[test_with_logger]

--- a/consensus/scp/tests/test_cyclic_networks.rs
+++ b/consensus/scp/tests/test_cyclic_networks.rs
@@ -31,8 +31,8 @@ fn new_cyclic(
     validity_fn: ValidityFn<String, TransactionValidationError>,
     combine_fn: CombineFn<String>,
     logger: Logger,
-) -> SCPNetwork {
-    let mut node_options = Vec::<NodeOptions>::new();
+) -> mock_network::SCPNetwork {
+    let mut node_options = Vec::<mock_network::NodeOptions>::new();
     for node_id in 0..num_nodes {
         let next_node_id: u32 = if node_id + 1 < num_nodes {
             node_id as u32 + 1
@@ -45,7 +45,7 @@ fn new_cyclic(
             .map(|other_node_id| other_node_id as u32)
             .collect();
 
-        node_options.push(NodeOptions::new(
+        node_options.push(mock_network::NodeOptions::new(
             format!("c-{}-node{}", num_nodes, node_id),
             other_node_ids,
             vec![next_node_id],
@@ -53,7 +53,7 @@ fn new_cyclic(
         ));
     }
 
-    SCPNetwork::new(node_options, validity_fn, combine_fn, logger)
+    mock_network::SCPNetwork::new(node_options, validity_fn, combine_fn, logger)
 }
 
 fn cyclic_test_helper(num_nodes: usize, logger: Logger) {
@@ -65,7 +65,7 @@ fn cyclic_test_helper(num_nodes: usize, logger: Logger) {
     let mut rng: StdRng = SeedableRng::from_seed([193u8; 32]);
     let start = Instant::now();
 
-    let network = mock_network::SCPNetwork::new_cyclic(
+    let network = new_cyclic(
         num_nodes,
         Arc::new(test_utils::trivial_validity_fn::<String>),
         //                Arc::new(test_utils::get_bounded_combine_fn::<String>(200)),

--- a/consensus/scp/tests/test_cyclic_networks.rs
+++ b/consensus/scp/tests/test_cyclic_networks.rs
@@ -3,17 +3,13 @@
 mod mock_network;
 
 use mc_common::{
-    logger::{log, test_with_logger, Logger},
-    HashSet,
+    logger::{test_with_logger, Logger},
 };
 
 use mc_consensus_scp::{core_types::{CombineFn, ValidityFn}, test_utils};
-use rand::{rngs::StdRng, Rng, SeedableRng};
 use serial_test_derive::serial;
 use std::{
     sync::Arc,
-    thread::sleep,
-    time::{Duration, Instant},
 };
 
 /// Hack to skip certain tests (that are currently too slow) from running
@@ -66,7 +62,7 @@ fn cyclic_test_helper(num_nodes: usize, logger: Logger) {
         return;
     }
     
-    let network = SCPNetwork::new_cyclic(
+    let network = mock_network::SCPNetwork::new_cyclic(
         num_nodes,
         Arc::new(test_utils::trivial_validity_fn::<String>),
         Arc::new(test_utils::trivial_combine_fn::<String>),

--- a/consensus/scp/tests/test_cyclic_networks.rs
+++ b/consensus/scp/tests/test_cyclic_networks.rs
@@ -2,15 +2,14 @@
 
 mod mock_network;
 
-use mc_common::{
-    logger::{test_with_logger, Logger},
-};
+use mc_common::logger::{test_with_logger, Logger};
 
-use mc_consensus_scp::{core_types::{CombineFn, ValidityFn}, test_utils};
-use serial_test_derive::serial;
-use std::{
-    sync::Arc,
+use mc_consensus_scp::{
+    core_types::{CombineFn, ValidityFn},
+    test_utils,
 };
+use serial_test_derive::serial;
+use std::sync::Arc;
 
 /// Hack to skip certain tests (that are currently too slow) from running
 fn skip_slow_tests() -> bool {
@@ -57,11 +56,11 @@ fn cyclic_test_helper(num_nodes: usize, logger: Logger) {
     if num_nodes < 3 {
         return;
     }
-    
+
     if skip_slow_tests() {
         return;
     }
-    
+
     let network = new_cyclic(
         num_nodes,
         Arc::new(test_utils::trivial_validity_fn::<String>),

--- a/consensus/scp/tests/test_cyclic_networks.rs
+++ b/consensus/scp/tests/test_cyclic_networks.rs
@@ -7,7 +7,7 @@ use mc_common::{
     HashSet,
 };
 
-use mc_consensus_scp::test_utils;
+use mc_consensus_scp::{core_types::{CombineFn, ValidityFn}, test_utils};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use serial_test_derive::serial;
 use std::{
@@ -28,7 +28,7 @@ fn skip_slow_tests() -> bool {
 /// Constructs a cyclic network (e.g. 1->2->3->4->1)
 fn new_cyclic(
     num_nodes: usize,
-    validity_fn: ValidityFn<String, TransactionValidationError>,
+    validity_fn: ValidityFn<String, test_utils::TransactionValidationError>,
     combine_fn: CombineFn<String>,
     logger: Logger,
 ) -> mock_network::SCPNetwork {

--- a/consensus/scp/tests/test_mesh_networks.rs
+++ b/consensus/scp/tests/test_mesh_networks.rs
@@ -3,17 +3,13 @@
 mod mock_network;
 
 use mc_common::{
-    logger::{log, test_with_logger, Logger},
-    HashSet,
+    logger::{test_with_logger, Logger},
 };
 
 use mc_consensus_scp::{core_types::{CombineFn, ValidityFn}, test_utils};
-use rand::{rngs::StdRng, Rng, SeedableRng};
 use serial_test_derive::serial;
 use std::{
     sync::Arc,
-    thread::sleep,
-    time::{Duration, Instant},
 };
 
 /// Hack to skip certain tests (that are currently too slow) from running
@@ -57,7 +53,7 @@ fn mesh_test_helper(num_nodes: usize, k: u32, logger: Logger) {
     if num_nodes < 3 || num_nodes as u64 <= k as u64 {
         return;
     }
-    
+
     if skip_slow_tests() {
         return;
     }
@@ -71,7 +67,7 @@ fn mesh_test_helper(num_nodes: usize, k: u32, logger: Logger) {
     );
 
     let network_name = format!("mesh{}k{}", num_nodes, k);
-    run_test(network, &network_name, logger.clone());
+    mock_network::run_test(network, &network_name, logger.clone());
 }
 
 #[test_with_logger]

--- a/consensus/scp/tests/test_mesh_networks.rs
+++ b/consensus/scp/tests/test_mesh_networks.rs
@@ -26,6 +26,32 @@ fn skip_slow_tests() -> bool {
 /// (N nodes, each node has all other nodes as it's validators)
 ///////////////////////////////////////////////////////////////////////////////
 
+/// Constructs a mesh network, where each node has all of it's peers as validators.
+pub fn new_mesh(
+    num_nodes: usize,
+    k: u32,
+    validity_fn: ValidityFn<String, TransactionValidationError>,
+    combine_fn: CombineFn<String>,
+    logger: Logger,
+) -> SCPNetwork {
+    let mut node_options = Vec::<NodeOptions>::new();
+    for node_id in 0..num_nodes {
+        let other_node_ids: Vec<u32> = (0..num_nodes)
+            .filter(|other_node_id| other_node_id != &node_id)
+            .map(|other_node_id| other_node_id as u32)
+            .collect();
+
+        node_options.push(NodeOptions::new(
+            format!("m-{}-{}-node{}", num_nodes, k, node_id),
+            other_node_ids.clone(),
+            other_node_ids,
+            k,
+        ));
+    }
+
+    SCPNetwork::new(node_options, validity_fn, combine_fn, logger)
+}
+
 /// Performs a simple consensus test where a network of `num_nodes` nodes is started,
 /// and values are submitted only to the middle node.
 fn mesh_test_helper(num_nodes: usize, k: u32, logger: Logger) {

--- a/consensus/scp/tests/test_mesh_networks.rs
+++ b/consensus/scp/tests/test_mesh_networks.rs
@@ -27,21 +27,21 @@ fn skip_slow_tests() -> bool {
 ///////////////////////////////////////////////////////////////////////////////
 
 /// Constructs a mesh network, where each node has all of it's peers as validators.
-pub fn new_mesh(
+fn new_mesh(
     num_nodes: usize,
     k: u32,
     validity_fn: ValidityFn<String, TransactionValidationError>,
     combine_fn: CombineFn<String>,
     logger: Logger,
 ) -> SCPNetwork {
-    let mut node_options = Vec::<NodeOptions>::new();
+    let mut node_options = Vec::<mock_network::NodeOptions>::new();
     for node_id in 0..num_nodes {
         let other_node_ids: Vec<u32> = (0..num_nodes)
             .filter(|other_node_id| other_node_id != &node_id)
             .map(|other_node_id| other_node_id as u32)
             .collect();
 
-        node_options.push(NodeOptions::new(
+        node_options.push(mock_network::NodeOptions::new(
             format!("m-{}-{}-node{}", num_nodes, k, node_id),
             other_node_ids.clone(),
             other_node_ids,
@@ -49,7 +49,7 @@ pub fn new_mesh(
         ));
     }
 
-    SCPNetwork::new(node_options, validity_fn, combine_fn, logger)
+    mock_network::SCPNetwork::new(node_options, validity_fn, combine_fn, logger)
 }
 
 /// Performs a simple consensus test where a network of `num_nodes` nodes is started,
@@ -62,7 +62,7 @@ fn mesh_test_helper(num_nodes: usize, k: u32, logger: Logger) {
     let mut rng: StdRng = SeedableRng::from_seed([97u8; 32]);
     let start = Instant::now();
 
-    let network = mock_network::SCPNetwork::new_mesh(
+    let network = new_mesh(
         num_nodes,
         k,
         Arc::new(test_utils::trivial_validity_fn::<String>),

--- a/consensus/scp/tests/test_mesh_networks.rs
+++ b/consensus/scp/tests/test_mesh_networks.rs
@@ -33,7 +33,7 @@ fn new_mesh(
     validity_fn: ValidityFn<String, test_utils::TransactionValidationError>,
     combine_fn: CombineFn<String>,
     logger: Logger,
-) -> SCPNetwork {
+) -> mock_network::SCPNetwork {
     let mut node_options = Vec::<mock_network::NodeOptions>::new();
     for node_id in 0..num_nodes {
         let other_node_ids: Vec<u32> = (0..num_nodes)

--- a/consensus/scp/tests/test_mesh_networks.rs
+++ b/consensus/scp/tests/test_mesh_networks.rs
@@ -7,7 +7,7 @@ use mc_common::{
     HashSet,
 };
 
-use mc_consensus_scp::test_utils;
+use mc_consensus_scp::{core_types::{CombineFn, ValidityFn}, test_utils};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use serial_test_derive::serial;
 use std::{
@@ -30,7 +30,7 @@ fn skip_slow_tests() -> bool {
 fn new_mesh(
     num_nodes: usize,
     k: u32,
-    validity_fn: ValidityFn<String, TransactionValidationError>,
+    validity_fn: ValidityFn<String, test_utils::TransactionValidationError>,
     combine_fn: CombineFn<String>,
     logger: Logger,
 ) -> SCPNetwork {

--- a/consensus/scp/tests/test_mesh_networks.rs
+++ b/consensus/scp/tests/test_mesh_networks.rs
@@ -2,15 +2,14 @@
 
 mod mock_network;
 
-use mc_common::{
-    logger::{test_with_logger, Logger},
-};
+use mc_common::logger::{test_with_logger, Logger};
 
-use mc_consensus_scp::{core_types::{CombineFn, ValidityFn}, test_utils};
-use serial_test_derive::serial;
-use std::{
-    sync::Arc,
+use mc_consensus_scp::{
+    core_types::{CombineFn, ValidityFn},
+    test_utils,
 };
+use serial_test_derive::serial;
+use std::sync::Arc;
 
 /// Hack to skip certain tests (that are currently too slow) from running
 fn skip_slow_tests() -> bool {

--- a/consensus/scp/tests/test_metamesh_networks.rs
+++ b/consensus/scp/tests/test_metamesh_networks.rs
@@ -4,15 +4,16 @@ mod mock_network;
 
 use mc_common::{
     logger::{o, test_with_logger, Logger},
-    HashMap, HashSet,
-    NodeID
+    HashMap, HashSet, NodeID,
 };
 
-use mc_consensus_scp::{core_types::{CombineFn, ValidityFn}, quorum_set::QuorumSet, test_utils};
-use serial_test_derive::serial;
-use std::{
-    sync::{Arc, Mutex},
+use mc_consensus_scp::{
+    core_types::{CombineFn, ValidityFn},
+    quorum_set::QuorumSet,
+    test_utils,
 };
+use serial_test_derive::serial;
+use std::sync::{Arc, Mutex};
 
 /// Hack to skip certain tests (that are currently too slow) from running
 fn skip_slow_tests() -> bool {
@@ -69,11 +70,7 @@ fn new_meta_mesh(
             let other_servers_in_this_org = (0..num_servers_per_org)
                 .filter(|other_id| other_id != &server_id)
                 .map(|server_id| {
-                    meta_mesh_node_id(
-                        org_id as u32,
-                        num_servers_per_org as u32,
-                        server_id as u32,
-                    )
+                    meta_mesh_node_id(org_id as u32, num_servers_per_org as u32, server_id as u32)
                 })
                 .collect::<Vec<NodeID>>();
 
@@ -174,17 +171,17 @@ fn metamesh_test_helper(
 #[test_with_logger]
 #[serial]
 fn metamesh_2_3(logger: Logger) {
-    metamesh_test_helper(2,3,2,logger.clone(),);
+    metamesh_test_helper(2, 3, 2, logger.clone());
 }
 
 #[test_with_logger]
 #[serial]
 fn metamesh_3_3(logger: Logger) {
-    metamesh_test_helper(3,3,2,logger.clone(),);
+    metamesh_test_helper(3, 3, 2, logger.clone());
 }
 
 #[test_with_logger]
 #[serial]
 fn metamesh_3_4(logger: Logger) {
-    metamesh_test_helper(3,4,3,logger.clone(),);
+    metamesh_test_helper(3, 4, 3, logger.clone());
 }

--- a/consensus/scp/tests/test_metamesh_networks.rs
+++ b/consensus/scp/tests/test_metamesh_networks.rs
@@ -22,7 +22,7 @@ fn skip_slow_tests() -> bool {
 /// Creates NodeID from integer index for testing.
 fn meta_mesh_node_id(org_id: u32, num_servers_per_org: u32, server_id: u32) -> NodeID {
     let node_index = org_id * num_servers_per_org + server_id;
-    let (node_id, _signer) = test_node_id_and_signer(node_index);
+    let (node_id, _signer) = test_utils::test_node_id_and_signer(node_index);
     node_id
 }
 

--- a/consensus/scp/tests/test_metamesh_networks.rs
+++ b/consensus/scp/tests/test_metamesh_networks.rs
@@ -1,0 +1,185 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+mod mock_network;
+
+use mc_common::{
+    logger::{log, test_with_logger, Logger},
+    HashSet,
+};
+
+use mc_consensus_scp::{core_types::{CombineFn, ValidityFn}, quorum_set::QuorumSet, test_utils};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use serial_test_derive::serial;
+use std::{
+    sync::Arc,
+    thread::sleep,
+    time::{Duration, Instant},
+};
+
+/// Hack to skip certain tests (that are currently too slow) from running
+fn skip_slow_tests() -> bool {
+    std::env::var("SKIP_SLOW_TESTS") == Ok("1".to_string())
+}
+
+/// Constructs a meta-mesh network, in which organizations run clusters of redundant servers
+fn new_meta_mesh(
+    num_orgs: usize,
+    num_servers_per_org: usize,
+    k_servers_per_org: u32,
+    validity_fn: ValidityFn<String, TransactionValidationError>,
+    combine_fn: CombineFn<String>,
+    logger: Logger,
+) -> mock_network::SCPNetwork {
+    let mut network = mock_network::SCPNetwork {
+        nodes_map: Arc::new(Mutex::new(HashMap::default())),
+        thread_handles: HashMap::default(),
+        nodes_shared_data: HashMap::default(),
+        logger: logger.clone(),
+    };
+
+    let org_quorum_sets = (0..num_orgs)
+        .map(|org_id| {
+            QuorumSet::new_with_node_ids(
+                1,
+                (0..num_servers_per_org)
+                    .map(|server_id| {
+                        meta_mesh_node_id(
+                            org_id as u32,
+                            num_servers_per_org as u32,
+                            server_id as u32,
+                        )
+                    })
+                    .collect::<Vec<NodeID>>(),
+            )
+        })
+        .collect::<Vec<QuorumSet>>();
+
+    for org_id in 0..num_orgs {
+        for server_id in 0..num_servers_per_org {
+            let thread_name = format!(
+                "mm-{}-{}-{}-node{}-{}",
+                num_orgs, num_servers_per_org, k_servers_per_org, org_id, server_id
+            );
+
+            let other_servers_in_this_org = (0..num_servers_per_org)
+                .filter(|other_id| other_id != &server_id)
+                .map(|server_id| {
+                    meta_mesh_node_id(
+                        org_id as u32,
+                        num_servers_per_org as u32,
+                        server_id as u32,
+                    )
+                })
+                .collect::<Vec<NodeID>>();
+
+            let inner_quorum_set_for_our_org =
+                QuorumSet::new_with_node_ids(k_servers_per_org, other_servers_in_this_org);
+
+            let mut inner_quorum_sets_for_other_orgs = org_quorum_sets
+                .iter()
+                .enumerate()
+                .filter(|&(i, _)| i != org_id)
+                .map(|(_, e)| e)
+                .cloned()
+                .collect::<Vec<QuorumSet>>();
+
+            let mut inner_quorum_sets = Vec::<QuorumSet>::new();
+
+            inner_quorum_sets.push(inner_quorum_set_for_our_org);
+            inner_quorum_sets.append(&mut inner_quorum_sets_for_other_orgs);
+
+            let qs = QuorumSet::new_with_inner_sets(num_orgs as u32, inner_quorum_sets);
+
+            let node_id =
+                meta_mesh_node_id(org_id as u32, num_servers_per_org as u32, server_id as u32);
+
+            let peers: HashSet<NodeID> = org_quorum_sets
+                .iter()
+                .flat_map(|qs| {
+                    let mut other_nodes = qs.nodes();
+                    other_nodes.remove(&node_id);
+                    other_nodes
+                })
+                .collect::<HashSet<NodeID>>();
+
+            assert!(!peers.contains(&node_id));
+
+            let nodes_map_clone: Arc<Mutex<HashMap<NodeID, SCPNode>>> =
+                { Arc::clone(&network.nodes_map) };
+
+            let (node, thread_handle) = SCPNode::new(
+                thread_name,
+                node_id.clone(),
+                qs,
+                validity_fn.clone(),
+                combine_fn.clone(),
+                Arc::new(move |logger, msg| {
+                    mock_network::SCPNetwork::broadcast_msg(logger, &nodes_map_clone, &peers, msg)
+                }),
+                logger.new(o!("mc.local_node_id" => node_id.to_string())),
+            );
+
+            network
+                .thread_handles
+                .insert(node_id.clone(), thread_handle);
+            network
+                .nodes_shared_data
+                .insert(node_id.clone(), node.shared_data.clone());
+            network
+                .nodes_map
+                .lock()
+                .expect("lock failed on nodes_map inserting node")
+                .insert(node_id.clone(), node);
+        }
+    }
+    network
+}
+
+/// Performs a consensus test for a metamesh network of `num_orgs * num_servers_per_org` nodes.
+fn metamesh_test_helper(
+    num_orgs: usize,
+    num_servers_per_org: usize,
+    k_servers_per_org: u32,
+    logger: Logger,
+) {
+    if num_servers_per_org < 3 || num_servers_per_org as u64 <= k_servers_per_org as u64 {
+        return;
+    }
+    
+    if skip_slow_tests() {
+        return;
+    }
+    
+    let network = new_meta_mesh(
+        num_orgs,
+        num_servers_per_org,
+        k_servers_per_org,
+        Arc::new(test_utils::trivial_validity_fn::<String>),
+        Arc::new(test_utils::trivial_combine_fn::<String>),
+        logger.clone(),
+    );
+
+    let network_name = format!(
+        "mm{}-{}k{}",
+        num_orgs, num_servers_per_org, k_servers_per_org
+    );
+    mock_network::run_test(network, &network_name, logger.clone());
+}
+
+#[test_with_logger]
+#[serial]
+fn metamesh_2_3(logger: Logger) {
+    metamesh_test_helper(2,3,2,logger.clone(),);
+}
+
+#[test_with_logger]
+#[serial]
+fn metamesh_3_3(logger: Logger) {
+    metamesh_test_helper(3,3,2,logger.clone(),);
+}
+
+#[test_with_logger]
+#[serial]
+fn metamesh_3_4(logger: Logger) {
+    metamesh_test_helper(3,4,3,logger.clone(),);
+}

--- a/consensus/scp/tests/test_metamesh_networks.rs
+++ b/consensus/scp/tests/test_metamesh_networks.rs
@@ -3,8 +3,9 @@
 mod mock_network;
 
 use mc_common::{
-    logger::{log, o, test_with_logger, Logger},
+    logger::{o, test_with_logger, Logger},
     HashMap, HashSet,
+    NodeID
 };
 
 use mc_consensus_scp::{core_types::{CombineFn, ValidityFn}, quorum_set::QuorumSet, test_utils};


### PR DESCRIPTION
### Motivation

Simulating consensus networks using threads is an important complement to testing in deployed networks. This PR improves the scp integration tests.

### In this PR
- more testing parameters
- adds "metamesh' topology

This is a draft PR because it relies on `LruCache::resize()` which may or may not be incorporated into our library. After resolving #209 I will finish this up and mark as ready.

### Future Work
- allow for arbitrary quorum sets in `NodeOptions`
- simulate network timeouts and byzantine behavior
