### PR TITLE
Disallow duplicate TxOut public keys

### DIFF
--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -56,14 +56,16 @@ enum ProposeTxResult {
     UnsortedKeyImages = 26;
     ContainsSpentKeyImage = 27;
     DuplicateKeyImages = 28;
-    MissingTxOutMembershipProof = 29;
-    InvalidTxOutMembershipProof = 30;
-    InvalidRistrettoPublicKey = 31;
-    InvalidLedgerContext = 32;
-    Ledger = 33;
-    MembershipProofValidationError = 34;
-    TxFeeError = 35;
-    KeyError = 36;
+    DuplicateOutputPublicKey = 29;
+    ContainsExistingOutputPublicKey = 30;
+    MissingTxOutMembershipProof = 31;
+    InvalidTxOutMembershipProof = 32;
+    InvalidRistrettoPublicKey = 33;
+    InvalidLedgerContext = 34;
+    Ledger = 35;
+    MembershipProofValidationError = 36;
+    TxFeeError = 37;
+    KeyError = 38;
 }
 
 /// Response from TxPropose RPC call.

--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -40,6 +40,10 @@ impl From<TransactionValidationError> for ProposeTxResult {
             TransactionValidationError::UnsortedKeyImages => Self::UnsortedKeyImages,
             TransactionValidationError::ContainsSpentKeyImage => Self::ContainsSpentKeyImage,
             TransactionValidationError::DuplicateKeyImages => Self::DuplicateKeyImages,
+            TransactionValidationError::DuplicateOutputPublicKey => Self::DuplicateOutputPublicKey,
+            TransactionValidationError::ContainsExistingOutputPublicKey => {
+                Self::ContainsExistingOutputPublicKey
+            }
             TransactionValidationError::MissingTxOutMembershipProof => {
                 Self::MissingTxOutMembershipProof
             }
@@ -94,6 +98,12 @@ impl TryInto<TransactionValidationError> for ProposeTxResult {
             Self::UnsortedKeyImages => Ok(TransactionValidationError::UnsortedKeyImages),
             Self::ContainsSpentKeyImage => Ok(TransactionValidationError::ContainsSpentKeyImage),
             Self::DuplicateKeyImages => Ok(TransactionValidationError::DuplicateKeyImages),
+            Self::DuplicateOutputPublicKey => {
+                Ok(TransactionValidationError::DuplicateOutputPublicKey)
+            }
+            Self::ContainsExistingOutputPublicKey => {
+                Ok(TransactionValidationError::ContainsExistingOutputPublicKey)
+            }
             Self::MissingTxOutMembershipProof => {
                 Ok(TransactionValidationError::MissingTxOutMembershipProof)
             }

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -19,7 +19,7 @@ use mc_attest_enclave_api::{
     PeerAuthResponse, PeerSession,
 };
 use mc_common::ResponderId;
-use mc_crypto_keys::{Ed25519Public, X25519Public};
+use mc_crypto_keys::{CompressedRistrettoPublic, Ed25519Public, X25519Public};
 use mc_transaction_core::{
     ring_signature::KeyImage,
     tx::{Tx, TxHash, TxOutMembershipProof},
@@ -56,6 +56,9 @@ pub struct WellFormedTxContext {
 
     /// Highest membership proofs indices.
     highest_indices: Vec<u64>,
+
+    /// Output public keys.
+    output_public_keys: Vec<CompressedRistrettoPublic>,
 }
 
 impl WellFormedTxContext {
@@ -78,6 +81,10 @@ impl WellFormedTxContext {
     pub fn highest_indices(&self) -> &Vec<u64> {
         &self.highest_indices
     }
+
+    pub fn output_public_keys(&self) -> &Vec<CompressedRistrettoPublic> {
+        &self.output_public_keys
+    }
 }
 
 impl From<&Tx> for WellFormedTxContext {
@@ -88,6 +95,7 @@ impl From<&Tx> for WellFormedTxContext {
             tombstone_block: tx.prefix.tombstone_block,
             key_images: tx.key_images(),
             highest_indices: tx.get_membership_proof_highest_indices(),
+            output_public_keys: tx.output_public_keys(),
         }
     }
 }
@@ -101,6 +109,7 @@ pub struct TxContext {
     pub tx_hash: TxHash,
     pub highest_indices: Vec<u64>,
     pub key_images: Vec<KeyImage>,
+    pub output_public_keys: Vec<CompressedRistrettoPublic>,
 }
 
 pub type SealedBlockSigningKey = Vec<u8>;

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -231,12 +231,14 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         let tx_hash = tx.tx_hash();
         let highest_indices = tx.get_membership_proof_highest_indices();
         let key_images: Vec<KeyImage> = tx.key_images();
+        let output_public_keys = tx.output_public_keys();
 
         Ok(TxContext {
             locally_encrypted_tx,
             tx_hash,
             highest_indices,
             key_images,
+            output_public_keys,
         })
     }
 
@@ -261,12 +263,14 @@ impl ConsensusEnclave for SgxConsensusEnclave {
                 let tx_hash = tx.tx_hash();
                 let highest_indices = tx.get_membership_proof_highest_indices();
                 let key_images: Vec<KeyImage> = tx.key_images();
+                let output_public_keys = tx.output_public_keys();
 
                 Ok(TxContext {
                     locally_encrypted_tx,
                     tx_hash,
                     highest_indices,
                     key_images,
+                    output_public_keys,
                 })
             })
             .collect()
@@ -419,6 +423,20 @@ impl ConsensusEnclave for SgxConsensusEnclave {
                     )));
                 }
                 used_key_images.insert(key_image);
+            }
+        }
+
+        // Duplicate output public keys are not allowed.
+        let mut seen_output_public_keys = BTreeSet::default();
+        for tx in &transactions {
+            for public_key in tx.output_public_keys() {
+                if seen_output_public_keys.contains(&public_key) {
+                    return Err(Error::FormBlock(format!(
+                        "Duplicate output public key: {:?}",
+                        public_key
+                    )));
+                }
+                seen_output_public_keys.insert(public_key);
             }
         }
 
@@ -884,6 +902,98 @@ mod tests {
         let expected = Err(Error::FormBlock(format!(
             "Duplicate key image: {:?}",
             expected_duplicate_key_image
+        )));
+
+        assert_eq!(form_block_result, expected);
+    }
+
+    #[test]
+    /// form_block should return an error if the input transactions contain a duplicate output
+    /// public key.
+    fn test_form_block_prevents_duplicate_output_public_key() {
+        let enclave = SgxConsensusEnclave::default();
+        let mut rng = Hc128Rng::from_seed([77u8; 32]);
+
+        // Initialize a ledger. `sender` is the owner of all outputs in the initial ledger.
+        let sender = AccountKey::random(&mut rng);
+        let mut ledger = create_ledger();
+        let n_blocks = 3;
+        initialize_ledger(&mut ledger, n_blocks, &sender, &mut rng);
+
+        // Create a few transactions from `sender` to `recipient`.
+        let num_transactions = 5;
+        let recipient = AccountKey::random(&mut rng);
+
+        // The first block contains RING_SIZE outputs.
+        let block_zero_contents = ledger.get_block_contents(0).unwrap();
+
+        // Re-create the rng so that we could more easily generate a duplicate output public key.
+        let mut rng = Hc128Rng::from_seed([77u8; 32]);
+
+        let mut new_transactions = Vec::new();
+        for i in 0..num_transactions - 1 {
+            let tx_out = &block_zero_contents.outputs[i];
+
+            let tx = create_transaction(
+                &mut ledger,
+                tx_out,
+                &sender,
+                &recipient.default_subaddress(),
+                n_blocks + 1,
+                &mut rng,
+            );
+            new_transactions.push(tx);
+        }
+
+        // Re-creating the rng here would result in a duplicate output public key.
+        {
+            let mut rng = Hc128Rng::from_seed([77u8; 32]);
+            let tx_out = &block_zero_contents.outputs[num_transactions - 1];
+
+            let tx = create_transaction(
+                &mut ledger,
+                tx_out,
+                &sender,
+                &recipient.default_subaddress(),
+                n_blocks + 1,
+                &mut rng,
+            );
+            new_transactions.push(tx);
+
+            assert_eq!(
+                new_transactions[0].prefix.outputs[0].public_key,
+                new_transactions[num_transactions - 1].prefix.outputs[0].public_key,
+            );
+        }
+
+        // Create WellFormedEncryptedTxs + proofs
+        let well_formed_encrypted_txs_with_proofs: Vec<_> = new_transactions
+            .iter()
+            .map(|tx| {
+                let well_formed_tx = WellFormedTx::from(tx.clone());
+                let encrypted_tx = enclave
+                    .encrypt_well_formed_tx(&well_formed_tx, &mut rng)
+                    .unwrap();
+
+                let highest_indices = well_formed_tx.tx.get_membership_proof_highest_indices();
+                let membership_proofs = ledger
+                    .get_tx_out_proof_of_memberships(&highest_indices)
+                    .expect("failed getting proof");
+                (encrypted_tx, membership_proofs)
+            })
+            .collect();
+
+        // Form block
+        let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+
+        let form_block_result =
+            enclave.form_block(&parent_block, &well_formed_encrypted_txs_with_proofs);
+        let expected_duplicate_output_public_key = new_transactions[0].output_public_keys()[0];
+
+        // Check
+        let expected = Err(Error::FormBlock(format!(
+            "Duplicate output public key: {:?}",
+            expected_duplicate_output_public_key
         )));
 
         assert_eq!(form_block_result, expected);

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -49,6 +49,9 @@ use mc_transaction_core::{
 use prost::Message;
 use rand_core::{CryptoRng, RngCore};
 
+/// Domain seperator for unified fees transaction private key.
+pub const FEES_OUTPUT_PRIVATE_KEY_DOMAIN_TAG: &str = "mc_fees_output_private_key";
+
 /// A well-formed transaction.
 #[derive(Clone, Eq, PartialEq, Message)]
 pub struct WellFormedTx {
@@ -444,7 +447,8 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         let fee_tx_private_key = {
             let hash_value: [u8; 32] = {
                 let mut hasher = Blake2b256::new();
-                // TODO: domain separator.
+                FEES_OUTPUT_PRIVATE_KEY_DOMAIN_TAG.digest(&mut hasher);
+                parent_block.id.digest(&mut hasher);
                 transactions.digest(&mut hasher);
                 hasher
                     .result()

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -45,12 +45,14 @@ impl ConsensusServiceMockEnclave {
         let tx_hash = tx.tx_hash();
         let highest_indices = tx.get_membership_proof_highest_indices();
         let key_images: Vec<KeyImage> = tx.key_images();
+        let output_public_keys = tx.output_public_keys();
 
         TxContext {
             locally_encrypted_tx,
             tx_hash,
             highest_indices,
             key_images,
+            output_public_keys,
         }
     }
 }

--- a/consensus/service/src/client_api_service.rs
+++ b/consensus/service/src/client_api_service.rs
@@ -99,6 +99,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger + Clone> ClientApiService<E, L> {
                 // These errors are common, so only trace them
                 if err == TransactionValidationError::TombstoneBlockExceeded
                     || err == TransactionValidationError::ContainsSpentKeyImage
+                    || err == TransactionValidationError::ContainsExistingOutputPublicKey
                 {
                     log::trace!(
                         logger,

--- a/consensus/service/src/test_utils/mod.rs
+++ b/consensus/service/src/test_utils/mod.rs
@@ -2,6 +2,7 @@
 
 use crate::tx_manager::UntrustedInterfaces;
 use mc_consensus_enclave::WellFormedTxContext;
+use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
     ring_signature::KeyImage,
     tx::{TxHash, TxOutMembershipProof},
@@ -17,6 +18,7 @@ impl UntrustedInterfaces for TrivialTxManagerUntrustedInterfaces {
         &self,
         _highest_indices: &[u64],
         _key_images: &[KeyImage],
+        _output_public_keys: &[CompressedRistrettoPublic],
     ) -> TransactionValidationResult<(u64, Vec<TxOutMembershipProof>)> {
         Ok((1, Vec::new()))
     }

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -61,11 +61,12 @@ impl<L: Ledger> TxManagerUntrustedInterfaces for DefaultTxManagerUntrustedInterf
         }
 
         // Output public keys should not exist in the ledger.
-        if output_public_keys.iter().any(|public_key| {
+        let contains_existing_public_key = output_public_keys.iter().any(|public_key| {
             self.ledger
                 .contains_tx_out_public_key(public_key)
                 .unwrap_or(true)
-        }) {
+        });
+        if contains_existing_public_key {
             // At least one public key is already in the ledger, or the ledger returned an error.
             return Err(TransactionValidationError::ContainsExistingOutputPublicKey);
         }
@@ -110,11 +111,12 @@ impl<L: Ledger> TxManagerUntrustedInterfaces for DefaultTxManagerUntrustedInterf
         }
 
         // The `output_public_keys` must not appear in the ledger.
-        if context.output_public_keys().iter().any(|public_key| {
+        let contains_existing_public_key = context.output_public_keys().iter().any(|public_key| {
             self.ledger
                 .contains_tx_out_public_key(public_key)
                 .unwrap_or(true)
-        }) {
+        });
+        if contains_existing_public_key {
             // At least one public key is already in the ledger, or the ledger returned an error.
             return Err(TransactionValidationError::ContainsExistingOutputPublicKey);
         }

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["MobileCoin"]
 edition = "2018"
 
 [features]
-test_utils = ["rand", "mc-crypto-keys"]
+test_utils = ["rand"]
 
 [dependencies]
 mc-common = { path = "../../common", features = ["log"] }
-mc-crypto-keys = { path = "../../crypto/keys", optional = true }
+mc-crypto-keys = { path = "../../crypto/keys" }
 mc-transaction-core = { path = "../../transaction/core" }
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-serial = { path = "../../util/serial", features = ["std"] }

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
     #[fail(display = "KeyImageAlreadySpent")]
     KeyImageAlreadySpent,
 
+    #[fail(display = "DuplicateOutputPublicKey")]
+    DuplicateOutputPublicKey,
+
     #[fail(display = "InvalidBlockContents")]
     InvalidBlockContents,
 

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -2,6 +2,7 @@
 
 use crate::Error;
 use mc_common::Hash;
+use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipProof},
@@ -34,6 +35,12 @@ pub trait Ledger: Clone + Send {
 
     /// Returns the index of the TxOut with the given hash.
     fn get_tx_out_index_by_hash(&self, tx_out_hash: &Hash) -> Result<u64, Error>;
+
+    /// Returns the index of the TxOut with the given public key.
+    fn get_tx_out_index_by_public_key(
+        &self,
+        tx_out_public_key: &CompressedRistrettoPublic,
+    ) -> Result<u64, Error>;
 
     /// Gets a TxOut by its index in the ledger.
     fn get_tx_out_by_index(&self, index: u64) -> Result<TxOut, Error>;

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -51,6 +51,12 @@ pub trait Ledger: Clone + Send {
         indexes: &[u64],
     ) -> Result<Vec<TxOutMembershipProof>, Error>;
 
+    /// Returns true if the Ledger contains the given TxOut public key.
+    fn contains_tx_out_public_key(
+        &self,
+        public_key: &CompressedRistrettoPublic,
+    ) -> Result<bool, Error>;
+
     /// Returns true if the Ledger contains the given key image.
     fn contains_key_image(&self, key_image: &KeyImage) -> Result<bool, Error> {
         self.check_key_image(key_image).map(|x| x.is_some())

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -12,6 +12,7 @@ use lmdb::{
     Database, DatabaseFlags, Environment, EnvironmentFlags, RoTransaction, RwTransaction,
     Transaction, WriteFlags,
 };
+use mc_common::logger::global_log;
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
     ring_signature::KeyImage,
@@ -283,6 +284,34 @@ impl LedgerDB {
             .set_flags(EnvironmentFlags::NO_SYNC)
             .open(&path)?;
 
+        // Check if the database we opened is compatible with the current implementation.
+        let metadata_store = MetadataStore::new(&env)?;
+        let db_txn = env.begin_ro_txn()?;
+        let version = metadata_store.get_version(&db_txn)?;
+        global_log::info!("Ledger db is currently at version: {:?}", version);
+        db_txn.commit()?;
+
+        match version.is_compatible_with_latest() {
+            Ok(_) => {}
+            // Version 20200610 introduced the TxOut public key -> index store.
+            Err(Error::VersionIncompatible(20200427, 20200610)) => {
+                global_log::info!("Ledger db migrating from version 20200427 to 20200610, this might take awhile...");
+
+                TxOutStore::construct_tx_out_index_by_public_key_from_existing_data(&env)?;
+
+                let mut db_txn = env.begin_rw_txn()?;
+                metadata_store.set_version_to_latest(&mut db_txn)?;
+                global_log::info!(
+                    "Ledger db migration complete, now at version: {:?}",
+                    metadata_store.get_version(&db_txn),
+                );
+                db_txn.commit()?;
+            }
+            Err(err) => {
+                return Err(err);
+            }
+        };
+
         let counts = env.open_db(Some(COUNTS_DB_NAME))?;
         let blocks = env.open_db(Some(BLOCKS_DB_NAME))?;
         let block_signatures = env.open_db(Some(BLOCK_SIGNATURES_DB_NAME))?;
@@ -290,14 +319,7 @@ impl LedgerDB {
         let key_images_by_block = env.open_db(Some(KEY_IMAGES_BY_BLOCK_DB_NAME))?;
         let tx_outs_by_block = env.open_db(Some(TX_OUTS_BY_BLOCK_DB_NAME))?;
 
-        let metadata_store = MetadataStore::new(&env)?;
         let tx_out_store = TxOutStore::new(&env)?;
-
-        // Check if the database we opened is compatible with the current implementation.
-        let db_txn = env.begin_ro_txn()?;
-        let version = metadata_store.get_version(&db_txn)?;
-        version.is_compatible_with_latest()?;
-        db_txn.commit()?;
 
         Ok(LedgerDB {
             env: Arc::new(env),

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -250,7 +250,7 @@ impl LedgerDB {
     /// Opens an existing Ledger Database in the given path.
     pub fn open(path: PathBuf) -> Result<LedgerDB, Error> {
         let env = Environment::new()
-            .set_max_dbs(20)
+            .set_max_dbs(21)
             .set_map_size(MAX_LMDB_FILE_SIZE)
             // TODO - needed because currently our test cloud machines have slow disks.
             .set_flags(EnvironmentFlags::NO_SYNC)

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -276,6 +276,7 @@ impl Ledger for LedgerDB {
 
 impl LedgerDB {
     /// Opens an existing Ledger Database in the given path.
+    #[allow(clippy::unreadable_literal)]
     pub fn open(path: PathBuf) -> Result<LedgerDB, Error> {
         let env = Environment::new()
             .set_max_dbs(21)

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, Ledger};
 use mc_common::{HashMap, HashSet};
-use mc_crypto_keys::RistrettoPrivate;
+use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate};
 use mc_transaction_core::{
     account_keys::AccountKey,
     ring_signature::KeyImage,
@@ -133,6 +133,13 @@ impl Ledger for MockLedger {
     fn get_tx_out_by_index(&self, _: u64) -> Result<TxOut, Error> {
         // Unused for these tests.
         unimplemented!()
+    }
+
+    fn get_tx_out_index_by_public_key(
+        &self,
+        _tx_out_public_key: &CompressedRistrettoPublic,
+    ) -> Result<u64, Error> {
+        unimplemented!();
     }
 
     fn check_key_image(&self, key_image: &KeyImage) -> Result<Option<u64>, Error> {

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -142,6 +142,13 @@ impl Ledger for MockLedger {
         unimplemented!();
     }
 
+    fn contains_tx_out_public_key(
+        &self,
+        _public_key: &CompressedRistrettoPublic,
+    ) -> Result<bool, Error> {
+        unimplemented!();
+    }
+
     fn check_key_image(&self, key_image: &KeyImage) -> Result<Option<u64>, Error> {
         // Unused for these tests.
         Ok(self.lock().key_images.get(key_image).cloned())

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -140,7 +140,7 @@ impl Tx {
         self.prefix
             .outputs
             .iter()
-            .map(|tx_out| tx_out.public_key.clone())
+            .map(|tx_out| tx_out.public_key)
             .collect()
     }
 }

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -134,6 +134,15 @@ impl Tx {
     pub fn get_membership_proof_highest_indices(&self) -> Vec<u64> {
         self.prefix.get_membership_proof_highest_indices()
     }
+
+    /// Output public keys contained in this transaction.
+    pub fn output_public_keys(&self) -> Vec<CompressedRistrettoPublic> {
+        self.prefix
+            .outputs
+            .iter()
+            .map(|tx_out| tx_out.public_key.clone())
+            .collect()
+    }
 }
 
 /// TxPrefix is the Tx struct without the signature.  It is used to

--- a/transaction/core/src/validation/error.rs
+++ b/transaction/core/src/validation/error.rs
@@ -87,6 +87,10 @@ pub enum TransactionValidationError {
     #[fail(display = "DuplicateKeyImages")]
     DuplicateKeyImages,
 
+    /// Output public keys in the transaction must be unique.
+    #[fail(display = "DuplicateOutputPublicKey")]
+    DuplicateOutputPublicKey,
+
     /// Each ring element must have a corresponding proof of membership.
     #[fail(display = "MissingTxOutMembershipProof")]
     MissingTxOutMembershipProof,

--- a/transaction/core/src/validation/error.rs
+++ b/transaction/core/src/validation/error.rs
@@ -91,6 +91,10 @@ pub enum TransactionValidationError {
     #[fail(display = "DuplicateOutputPublicKey")]
     DuplicateOutputPublicKey,
 
+    /// Contains an output public key that has previously appeared in the ledger.
+    #[fail(display = "ContainsExistingOutputPublicKey")]
+    ContainsExistingOutputPublicKey,
+
     /// Each ring element must have a corresponding proof of membership.
     #[fail(display = "MissingTxOutMembershipProof")]
     MissingTxOutMembershipProof,


### PR DESCRIPTION
Soundtrack of this PR: [whats currently playing in my room](https://soundcloud.com/doobdoob/doob-moloch-du-sollst-nicht-gehen-310318?in=doobdoob/sets/doob-slow)

### Motivation

We use a TxOut's public key as a unique identifier for the TxOut in numerous places, but up until now have not enforced its uniqueness. Well-behaved clients should never generate the same key twice, but it is a good idea to enforce this behavior in consensus.

### In this PR
* Adding a new TxOut-by-public-key LMDB store
* Changing validation logic across ledger db and consensus to deny having duplicate TxOut public keys.
* For the first time, adding code to gracefully migrate existing LedgerDBs so that this update is painless for live networks.

This has been deployed and slammed successfully with no noticeable performance implications. This does make the LedgerDB bigger, but thats the cost of doing business.