### PR TITLE
Improve mc-uri error reporting and port to displaydoc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3243,8 +3243,8 @@ name = "mc-util-uri"
 version = "0.2.0"
 dependencies = [
  "base64 0.11.0",
+ "displaydoc",
  "ed25519",
- "failure",
  "hex 0.4.2",
  "mc-common",
  "mc-crypto-keys",

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -10,8 +10,8 @@ mc-util-host-cert = { path = "../../util/host-cert", default-features = false }
 mc-crypto-keys = { path = "../../crypto/keys" }
 
 base64 = "0.11"
+displaydoc = { version = "0.1", default-features = false }
 ed25519 = { version = "1.0.0-pre.1", default-features = false, features = ["serde"] }
-failure = "0.1.5"
 hex = "0.4"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 url = "2.1"

--- a/util/uri/src/traits.rs
+++ b/util/uri/src/traits.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use base64;
+use displaydoc::Display;
 use ed25519::signature::Error as SignatureError;
-use failure::Fail;
 use hex;
 use mc_common::{NodeID, ResponderId, ResponderIdParseError};
 use mc_crypto_keys::{DistinguishedEncoding, Ed25519Public, KeyError};
@@ -16,17 +16,17 @@ use core::{
     result::Result as StdResult,
 };
 
-#[derive(Debug, Fail, Ord, PartialOrd, Eq, PartialEq, Clone)]
+#[derive(Debug, Display, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub enum UriConversionError {
-    #[fail(display = "Error converting key {}", _0)]
+    /// Error converting key: {0}
     KeyConversion(KeyError),
-    #[fail(display = "Error with Ed25519 signature")]
+    /// Error with Ed25519 signature
     Signature,
-    #[fail(display = "Error decoding base64")]
+    /// Error decoding base64
     Base64Decode,
-    #[fail(display = "Error parsing ResponderId {} {}", _0, _1)]
+    /// Error parsing ResponderId {0}, {1}
     ResponderId(String, ResponderIdParseError),
-    #[fail(display = "No consensus-msg-key provided")]
+    /// No consensus-msg-key provided
     NoPubkey,
 }
 

--- a/util/uri/src/uri.rs
+++ b/util/uri/src/uri.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use crate::traits::{ConnectionUri, UriScheme};
-use failure::Fail;
+use displaydoc::Display;
 use std::{
     fmt::{Display, Formatter, Result as FmtResult},
     marker::PhantomData,
@@ -9,16 +9,14 @@ use std::{
 };
 use url::Url;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Display)]
 pub enum UriParseError {
-    #[fail(display = "Url parse error: {}", _0)]
+    /// Url parse error: {0}
     UrlParse(url::ParseError),
-
-    #[fail(display = "Missing host")]
+    /// Missing host
     MissingHost,
-
-    #[fail(display = "Unknown scheme")]
-    UnknownScheme,
+    /// Unknown scheme: Valid possibilities are `{0}`, `{1}`
+    UnknownScheme(&'static str, &'static str),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -91,7 +89,10 @@ impl<Scheme: UriScheme> FromStr for Uri<Scheme> {
         } else if url.scheme().starts_with(Scheme::SCHEME_INSECURE) {
             false
         } else {
-            return Err(UriParseError::UnknownScheme);
+            return Err(UriParseError::UnknownScheme(
+                &Scheme::SCHEME_SECURE,
+                &Scheme::SCHEME_INSECURE,
+            ));
         };
 
         let port = match (url.port(), use_tls) {


### PR DESCRIPTION
Soundtrack of this PR: https://www.youtube.com/watch?v=gjEqMt15MKc

### Motivation

The cause for this was, I get "unknown scheme" errors but I don't
know what the expected scheme was, so it makes it hard to debug.

### In this PR

I want it to hold &'static str and tell me what it wanted to see.
This retains the goal of keeping errors having the `'static` property.