### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -24,13 +24,6 @@ intellectual property in MobileCoin, along with the licensing terms that pertain
 to those sources of IP. This list is for informational purposes only and is not
 intended to represent an exhaustive list of third party contributions to MobileCoin.
 
-  * **lru-rs** (https://raw.githubusercontent.com/jeromefroe/lru-rs/master/src/lib.rs
-    @ a11d47ddc7ab86ff07e2308e96fa0a03bcc3f385) MobileCoin makes use of this LRU
-    because our no_std builds require the hashbrown without ahash. Without
-    introducing all of hashbrown's features into the lru crate, there is no way
-    to include hashbrown in our desired configuration. It is distributed with
-    MobileCoin under the terms of the MIT license below.
-
   * **rjson tests** (https://github.com/yw662/rjson) MobileCoin makes use of these
     tests. It is distributed with MobileCoin under the terms of the MIT license below.
 
@@ -47,34 +40,6 @@ intended to represent an exhaustive list of third party contributions to MobileC
     MobileCoin makes use of the Apache (formerly Baidu) rust-sgx-sdk for handling
     sgx types. It is distributed with MobileCoin under the terms of the Apache 2.0
     license below.
-
-
-lru-rs MIT License
--------------------------
-
-<https://github.com/jeromefroe/lru-rs>
-
-MIT License
-
-Copyright (c) 2016 Jerome Froelich
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 
 rjson MIT License

--- a/LICENSE
+++ b/LICENSE
@@ -24,6 +24,11 @@ intellectual property in MobileCoin, along with the licensing terms that pertain
 to those sources of IP. This list is for informational purposes only and is not
 intended to represent an exhaustive list of third party contributions to MobileCoin.
 
+  * **lru-rs** (https://raw.githubusercontent.com/jeromefroe/lru-rs/master/src/lib.rs
+    @ a11d47ddc7ab86ff07e2308e96fa0a03bcc3f385) MobileCoin makes use of the tests
+    from this lru implementation for our no_std, safe LRU implementation.
+    It is distributed with MobileCoin under the terms of the MIT license below.
+
   * **rjson tests** (https://github.com/yw662/rjson) MobileCoin makes use of these
     tests. It is distributed with MobileCoin under the terms of the MIT license below.
 
@@ -40,6 +45,34 @@ intended to represent an exhaustive list of third party contributions to MobileC
     MobileCoin makes use of the Apache (formerly Baidu) rust-sgx-sdk for handling
     sgx types. It is distributed with MobileCoin under the terms of the Apache 2.0
     license below.
+
+
+lru-rs MIT License
+-------------------------
+
+<https://github.com/jeromefroe/lru-rs>
+
+MIT License
+
+Copyright (c) 2016 Jerome Froelich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 rjson MIT License


### PR DESCRIPTION
### Motivation

Previously, we used the lru implementation from https://raw.githubusercontent.com/jeromefroe/lru-rs/master/src/lib.rs, but we have replaced this.

### In this PR
* Updates license

