### PR TITLE
Adds additional REST functions for monitor list and block details

### DIFF
--- a/mobilecoind-json/src/main.rs
+++ b/mobilecoind-json/src/main.rs
@@ -475,7 +475,7 @@ fn block_details(
     let resp = state
         .mobilecoind_api_client
         .get_block(&req)
-        .map_err(|err| format!("Failed getting ledger info: {}", err))?;
+        .map_err(|err| format!("Failed getting block details: {}", err))?;
     let block = resp.get_block();
     Ok(Json(JsonBlockDetailsResponse {
         block_id: hex::encode(&block.get_id().get_data()),

--- a/mobilecoind-json/src/main.rs
+++ b/mobilecoind-json/src/main.rs
@@ -463,7 +463,7 @@ struct JsonBlockDetailsResponse {
     contents_hash: String,
 }
 
-/// Retrieves the data in a request code
+/// Retrieves the details for a given block.
 #[get("/block-details/<block_num>")]
 fn block_details(
     state: rocket::State<State>,

--- a/mobilecoind-json/src/main.rs
+++ b/mobilecoind-json/src/main.rs
@@ -104,6 +104,27 @@ fn create_monitor(
 }
 
 #[derive(Serialize, Default)]
+struct JsonMonitorListResponse {
+    monitor_id: Vec<String>,
+}
+
+/// Gets a list of existing monitors
+#[get("/monitors")]
+fn monitors(state: rocket::State<State>) -> Result<Json<JsonMonitorListResponse>, String> {
+    let resp = state
+        .mobilecoind_api_client
+        .get_monitor_list(&mc_mobilecoind_api::Empty::new())
+        .map_err(|err| format!("Failed getting monitor list: {}", err))?;
+    Ok(Json(JsonMonitorListResponse {
+        monitor_id: resp
+        .get_monitor_id_list()
+        .iter()
+        .map(|monitor_id| hex::encode(monitor_id))
+        .collect()
+    }))
+}
+
+#[derive(Serialize, Default)]
 struct JsonMonitorStatusResponse {
     first_subaddress: u64,
     num_subaddresses: u64,
@@ -432,6 +453,40 @@ fn block_info(
     }))
 }
 
+#[derive(Serialize, Default)]
+struct JsonBlockDetailsResponse {
+    block_id: String,
+    version: u32,
+    parent_id: String,
+    index: String,
+    cumulative_txo_count: String,
+    contents_hash: String,
+}
+
+/// Retrieves the data in a request code
+#[get("/block-details/<block_num>")]
+fn block_details(
+    state: rocket::State<State>,
+    block_num: u64,
+) -> Result<Json<JsonBlockDetailsResponse>, String> {
+    let mut req = mc_mobilecoind_api::GetBlockRequest::new();
+    req.set_block(block_num);
+
+    let resp = state
+        .mobilecoind_api_client
+        .get_block(&req)
+        .map_err(|err| format!("Failed getting ledger info: {}", err))?;
+    let block = resp.get_block();
+    Ok(Json(JsonBlockDetailsResponse {
+        block_id: hex::encode(&block.get_id().get_data()),
+        version: block.get_version(),
+        parent_id: hex::encode(&block.get_parent_id().get_data()),
+        index: block.get_index().to_string(),
+        cumulative_txo_count: block.get_cumulative_txo_count().to_string(),
+        contents_hash: hex::encode(&block.get_contents_hash().get_data()),
+    }))
+}
+
 fn main() {
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
@@ -473,6 +528,7 @@ fn main() {
             routes![
                 entropy,
                 create_monitor,
+                monitors,
                 monitor_status,
                 balance,
                 request_code,
@@ -481,6 +537,7 @@ fn main() {
                 check_transfer_status,
                 ledger_info,
                 block_info,
+                block_details,
             ],
         )
         .manage(State {

--- a/mobilecoind-json/src/main.rs
+++ b/mobilecoind-json/src/main.rs
@@ -117,10 +117,10 @@ fn monitors(state: rocket::State<State>) -> Result<Json<JsonMonitorListResponse>
         .map_err(|err| format!("Failed getting monitor list: {}", err))?;
     Ok(Json(JsonMonitorListResponse {
         monitor_id: resp
-        .get_monitor_id_list()
-        .iter()
-        .map(|monitor_id| hex::encode(monitor_id))
-        .collect()
+            .get_monitor_id_list()
+            .iter()
+            .map(hex::encode)
+            .collect(),
     }))
 }
 

--- a/mobilecoind-json/src/main.rs
+++ b/mobilecoind-json/src/main.rs
@@ -116,11 +116,7 @@ fn monitors(state: rocket::State<State>) -> Result<Json<JsonMonitorListResponse>
         .get_monitor_list(&mc_mobilecoind_api::Empty::new())
         .map_err(|err| format!("Failed getting monitor list: {}", err))?;
     Ok(Json(JsonMonitorListResponse {
-        monitor_id: resp
-            .get_monitor_id_list()
-            .iter()
-            .map(hex::encode)
-            .collect(),
+        monitor_id: resp.get_monitor_id_list().iter().map(hex::encode).collect(),
     }))
 }
 


### PR DESCRIPTION
Soundtrack of this PR: [Get Back](https://www.youtube.com/watch?v=IKJqecxswCA)

### Motivation

A couple of outstanding requests from our partners for the REST API 

### In this PR
* GET for the list of current monitors
* GET for details about a block 

```
$ curl localhost:9090/monitors -d '{"entropy": "706db549844bc7b5c8328368d4b8276e9aa03a26ac02474d54aa99b7c3369e2e", "first_subaddress": 0, "num_subaddresses": 10}' -X POST -H 'Content-Type: application/json'

{"monitor_id":"5bb9c1a387029f16ded2c8c2f5a942c6ccb1a70f822684372b6b95a8c26750c7"}

$ curl localhost:9090/monitors

{"monitor_id":["5bb9c1a387029f16ded2c8c2f5a942c6ccb1a70f822684372b6b95a8c26750c7"]}

$ curl localhost:9090/block-details/5

{"block_id":"e5f20951896206e88e3df25bf4191381ac197f756ef4fcc713686b5644c87476","version":0,"parent_id":"fe6f53c07aa35c051a40c8afd8e49332ac6d11de6ada169ca6d4c0cdb1f73319","index":"5","cumulative_txo_count":"10015","contents_hash":"f3a384fb8eb55da2a0dc95754fc4f9c1db609b05a5d9e8741ad4eeb89737dc91"}
```