### PR TITLE
Encoding for address requests, right now just a URL to POST to

### DIFF
--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -14,6 +14,7 @@ enum PayloadType {
     Transfer = 1,
     // Wallet = 2,
     // Envelope = 3,
+    AddressRequest = 5,
 }
 
 /// A little-endian IEEE CRC32 checksum is prepended to payloads.
@@ -389,6 +390,66 @@ impl From<&TransferPayload> for AccountKey {
     }
 }
 
+/// AddressRequestPayload encodes a URL to which a user to send a public address
+#[derive(PartialEq, Eq, Clone)]
+pub struct AddressRequestPayload {
+    /// The payload version.
+    version: u8,
+
+    /// utf-8 encoded url
+    pub url: String,
+}
+
+impl AddressRequestPayload {
+    /// Creates a new AddressRequestPayload from an encoded string.
+    pub fn decode(encoded_string: &str) -> Result<Self, Error> {
+        let (version, mut buffer_bytes) = decode_payload(encoded_string, PayloadType::AddressRequest)?;
+
+        let url_size_byte = checked_split_off(&mut buffer_bytes, 1, "url_size_byte")?;
+        let url_size: usize = url_size_byte[0] as usize;
+        let url_bytes = checked_split_off(&mut buffer_bytes, url_size, "memo_bytes")?;
+
+        let mut payload = AddressRequestPayload::new_v0(String::from_utf8(url_bytes.to_vec())?)?;
+        payload.version = version;
+        Ok(payload)
+    }
+
+    pub fn new_v0(url: String) -> Result<Self, Error> {
+        Ok(AddressRequestPayload {
+            version: 0,
+            url: url,
+        })
+    }
+
+    /// Encodes this AddressRequestPayload to a string
+    /// [0..4]            checksum
+    /// [4]               PayloadType::AddressRequest
+    /// [5]               version (< 256)
+    /// [f]               length of URL
+    /// [6..(6+f)]        URL to POST address to
+    pub fn encode(&self) -> String {
+        let mut bytes_vec = Vec::new();
+        // Note that the checksum can't be calculated until all the other bytes are collected,
+        // and will be added in the call to `encode_payload` at the end of this function.
+        bytes_vec.push(PayloadType::AddressRequest as u8);
+        bytes_vec.push(self.version);
+        bytes_vec.push(self.url.len() as u8);
+        bytes_vec.extend_from_slice(&self.url.as_bytes());
+        encode_payload(bytes_vec)
+    }
+}
+
+impl fmt::Debug for AddressRequestPayload {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "version:{}, url:{}",
+            self.version,
+            self.url,
+        )
+    }
+}
+
 #[cfg(test)]
 mod testing {
     use super::*;
@@ -571,5 +632,22 @@ mod testing {
                 let _account_key = AccountKey::from(&payload);
             }
         });
+    }
+
+    /// Test that Address Requests successfully encode and decode
+    #[test_with_logger]
+    fn address_request_roundtrip(logger: Logger) {
+        let url = "https://example.com/address-endpoint/8473212-2812349".to_string();
+
+        let payload = AddressRequestPayload::new_v0(url.clone()).unwrap();
+        log::info!(logger, " payload  {:?}", payload);
+
+        let encoded_string = payload.encode();
+        log::info!(logger, "encoded {:?}", encoded_string);
+
+        let roundtrip_payload = AddressRequestPayload::decode(&encoded_string).unwrap();
+        log::info!(logger, "recovered {:?}", roundtrip_payload);
+
+        assert_eq!(url, roundtrip_payload.url);
     }
 }

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -403,7 +403,8 @@ pub struct AddressRequestPayload {
 impl AddressRequestPayload {
     /// Creates a new AddressRequestPayload from an encoded string.
     pub fn decode(encoded_string: &str) -> Result<Self, Error> {
-        let (version, mut buffer_bytes) = decode_payload(encoded_string, PayloadType::AddressRequest)?;
+        let (version, mut buffer_bytes) =
+            decode_payload(encoded_string, PayloadType::AddressRequest)?;
 
         let url_size_byte = checked_split_off(&mut buffer_bytes, 1, "url_size_byte")?;
         let url_size: usize = url_size_byte[0] as usize;
@@ -415,10 +416,7 @@ impl AddressRequestPayload {
     }
 
     pub fn new_v0(url: String) -> Result<Self, Error> {
-        Ok(AddressRequestPayload {
-            version: 0,
-            url: url,
-        })
+        Ok(AddressRequestPayload { version: 0, url })
     }
 
     /// Encodes this AddressRequestPayload to a string
@@ -441,12 +439,7 @@ impl AddressRequestPayload {
 
 impl fmt::Debug for AddressRequestPayload {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "version:{}, url:{}",
-            self.version,
-            self.url,
-        )
+        write!(f, "version:{}, url:{}", self.version, self.url,)
     }
 }
 


### PR DESCRIPTION
Soundtrack of this PR: [Mr Postman](https://www.youtube.com/watch?v=425GpjTSlS4)

### Motivation

For some potential workflows we'd like a way to specify a URL for a user to submit their public address 

### In this PR
* Defines a payload for a b58 encoding of an "address request" which is just URL
* Tests round-trip encoding and decoding

### Future Work
* Integrate into APIs
