### PR TITLE
Adds address request code to mobilecoind and REST API

### DIFF
--- a/mobilecoind-json/src/main.rs
+++ b/mobilecoind-json/src/main.rs
@@ -483,6 +483,39 @@ fn block_details(
     }))
 }
 
+#[derive(Deserialize)]
+struct JsonAddressRequestCodeRequest {
+    url: String,
+}
+
+#[derive(Serialize, Default)]
+struct JsonAddressRequestCodeResponse {
+    request_code: String,
+}
+
+/// Generates a request code with an optional value and memo
+#[post(
+    "/address-request",
+    format = "json",
+    data = "<address_request>",
+)]
+fn address_request_code(
+    state: rocket::State<State>,
+    address_request: Json<JsonAddressRequestCodeRequest>,
+) -> Result<Json<JsonAddressRequestCodeResponse>, String> {
+    let mut req = mc_mobilecoind_api::GetAddressRequestCodeRequest::new();
+    req.set_url(address_request.url.clone());
+
+    let resp = state
+        .mobilecoind_api_client
+        .get_address_request_code(&req)
+        .map_err(|err| format!("Failed address code: {}", err))?;
+
+    Ok(Json(JsonAddressRequestCodeResponse {
+        request_code: String::from(resp.get_b58_code()),
+    }))
+}
+
 fn main() {
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
@@ -534,6 +567,7 @@ fn main() {
                 ledger_info,
                 block_info,
                 block_details,
+                address_request_code,
             ],
         )
         .manage(State {

--- a/mobilecoind-json/src/main.rs
+++ b/mobilecoind-json/src/main.rs
@@ -493,7 +493,7 @@ struct JsonAddressRequestCodeResponse {
     request_code: String,
 }
 
-/// Generates a request code with an optional value and memo
+/// Generates an AddressRequest code with a URL for the client to POST payment instructions
 #[post("/address-request", format = "json", data = "<address_request>")]
 fn address_request_code(
     state: rocket::State<State>,

--- a/mobilecoind-json/src/main.rs
+++ b/mobilecoind-json/src/main.rs
@@ -494,11 +494,7 @@ struct JsonAddressRequestCodeResponse {
 }
 
 /// Generates a request code with an optional value and memo
-#[post(
-    "/address-request",
-    format = "json",
-    data = "<address_request>",
-)]
+#[post("/address-request", format = "json", data = "<address_request>")]
 fn address_request_code(
     state: rocket::State<State>,
     address_request: Json<JsonAddressRequestCodeRequest>,

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -32,6 +32,7 @@ service MobilecoindAPI {
     rpc GetRequestCode (GetRequestCodeRequest) returns (GetRequestCodeResponse) {}
     rpc ReadTransferCode (ReadTransferCodeRequest) returns (ReadTransferCodeResponse) {}
     rpc GetTransferCode (GetTransferCodeRequest) returns (GetTransferCodeResponse) {}
+    rpc GetAddressRequestCode (GetAddressRequestCodeRequest) returns (GetAddressRequestCodeResponse) {}
 
     // Txs
     rpc GenerateTx (GenerateTxRequest) returns (GenerateTxResponse) {}
@@ -330,6 +331,15 @@ message GetTransferCodeRequest {
     string memo = 3;
 }
 message GetTransferCodeResponse {
+    string b58_code = 1;
+}
+
+// Encode a URL into a base-58 "MobileCoin Address Request Code".
+message GetAddressRequestCodeRequest {
+    string url = 1;
+}
+
+message GetAddressRequestCodeResponse {
     string b58_code = 1;
 }
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -31,7 +31,7 @@ use mc_transaction_core::{
     ring_signature::KeyImage,
 };
 use mc_transaction_std::identity::RootIdentity;
-use mc_util_b58_payloads::payloads::{RequestPayload, TransferPayload};
+use mc_util_b58_payloads::payloads::{AddressRequestPayload, RequestPayload, TransferPayload};
 use mc_util_grpc::{rpc_internal_error, rpc_logger, send_result, BuildInfoService};
 use mc_watcher::watcher_db::WatcherDB;
 use protobuf::RepeatedField;
@@ -433,6 +433,18 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         let b58_code = payload.encode();
 
         let mut response = mc_mobilecoind_api::GetTransferCodeResponse::new();
+        response.set_b58_code(b58_code);
+        Ok(response)
+    }
+
+    fn get_address_request_code_impl(
+        &mut self,
+        request: mc_mobilecoind_api::GetAddressRequestCodeRequest,
+    ) -> Result<mc_mobilecoind_api::GetAddressRequestCodeResponse, RpcStatus> {
+        let payload = AddressRequestPayload::new_v0(request.get_url().to_string())
+            .map_err(|err| rpc_internal_error("AddressRequestPayload.new_v0", err, &self.logger))?;
+        let b58_code = payload.encode();
+        let mut response = mc_mobilecoind_api::GetAddressRequestCodeResponse::new();
         response.set_b58_code(b58_code);
         Ok(response)
     }
@@ -1142,6 +1154,7 @@ build_api! {
     get_request_code GetRequestCodeRequest GetRequestCodeResponse get_request_code_impl,
     read_transfer_code ReadTransferCodeRequest ReadTransferCodeResponse read_transfer_code_impl,
     get_transfer_code GetTransferCodeRequest GetTransferCodeResponse get_transfer_code_impl,
+    get_address_request_code GetAddressRequestCodeRequest GetAddressRequestCodeResponse get_address_request_code_impl,
     generate_tx GenerateTxRequest GenerateTxResponse generate_tx_impl,
     generate_optimization_tx GenerateOptimizationTxRequest GenerateOptimizationTxResponse generate_optimization_tx_impl,
     generate_transfer_code_tx GenerateTransferCodeTxRequest GenerateTransferCodeTxResponse generate_transfer_code_tx_impl,

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2816,4 +2816,22 @@ mod test {
             ledger_db.num_blocks().unwrap() - 1
         );
     }
+
+    #[test_with_logger]
+    fn test_address_request_code(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([23u8; 32]);
+
+        let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
+            get_testing_environment(3, &vec![], &vec![], logger.clone(), &mut rng);
+
+        let mut request = mc_mobilecoind_api::GetAddressRequestCodeRequest::new();
+        request.set_url("https://example.com".to_string());
+
+        let address_b58 = client.get_address_request_code(&request).unwrap();
+
+        assert_eq!(
+            address_b58.get_b58_code(),
+            "4mppAGCtx4xn42C36Ck7gGnAoGbdJceYBH6k",
+        );
+    }
 }


### PR DESCRIPTION
Soundtrack of this PR: [Postal Service -- Such Great Heights](https://www.youtube.com/watch?v=0wrsZog8qXg)

### Motivation

Previously we added the address request payload, this adds it to mobilecoind and the REST API

### In this PR
* adds a gRPC call to generate a b58 code for an address request
* adds a REST call to wrap the gRPC call 

```
$ curl localhost:9090/address-request -X POST -d '{"url": "https://example.com"}' -H 'Content-Type: application/json'
{"request_code":"4mppAGCtx4xn42C36Ck7gGnAoGbdJceYBH6k"}
```