### PR TITLE
MC-1335: LedgerDB should reject non-origin blocks that do not contain key images

### DIFF
--- a/consensus/service/src/blockchain_api_service.rs
+++ b/consensus/service/src/blockchain_api_service.rs
@@ -142,92 +142,17 @@ impl<L: Ledger + Clone> BlockchainApi for BlockchainApiService<L> {
 mod tests {
     use super::*;
     use mc_common::logger::test_with_logger;
-    use mc_crypto_keys::RistrettoPrivate;
-    use mc_ledger_db::LedgerDB;
-    use mc_transaction_core::{
-        account_keys::AccountKey, tx::TxOut, Block, BlockContents, BLOCK_VERSION,
-    };
-    use mc_util_from_random::FromRandom;
+    use mc_transaction_core::account_keys::AccountKey;
+    use mc_transaction_core_test_utils::{create_ledger, initialize_ledger};
     use rand::{rngs::StdRng, SeedableRng};
-    use tempdir::TempDir;
-
-    /// Creates a LedgerDB instance.
-    fn create_db() -> LedgerDB {
-        let temp_dir = TempDir::new("test").unwrap();
-        let path = temp_dir.path().to_path_buf();
-        LedgerDB::create(path.clone()).unwrap();
-        LedgerDB::open(path).unwrap()
-    }
-
-    /// Populates the LedgerDB with initial data, and returns the Block entities that were written.
-    ///
-    /// # Arguments
-    /// * `n_blocks` - number of blocks of transactions to write to `db`.
-    ///
-    fn populate_db(db: &mut LedgerDB, n_blocks: u64) -> Vec<Block> {
-        let initial_amount: u64 = 5_000 * 1_000_000_000_000;
-        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-
-        // Generate 1 public / private addresses and create transactions.
-        let account_key = AccountKey::random(&mut rng);
-
-        let mut parent_block: Option<Block> = None;
-        let mut blocks: Vec<Block> = Vec::new();
-
-        for block_index in 0..n_blocks {
-            let tx_out = TxOut::new(
-                initial_amount,
-                &account_key.default_subaddress(),
-                &RistrettoPrivate::from_random(&mut rng),
-                Default::default(),
-                &mut rng,
-            )
-            .unwrap();
-
-            let outputs = vec![tx_out];
-            let block_contents = BlockContents::new(vec![], outputs.clone());
-
-            let block = match parent_block {
-                None => Block::new_origin_block(&outputs),
-                Some(parent) => Block::new_with_parent(
-                    BLOCK_VERSION,
-                    &parent,
-                    &Default::default(),
-                    &block_contents,
-                ),
-            };
-            assert_eq!(block_index, block.index);
-
-            db.append_block(&block, &block_contents, None)
-                .expect("failed writing initial transactions");
-            blocks.push(block.clone());
-            parent_block = Some(block);
-        }
-
-        // Verify that db now contains n transactions.
-        assert_eq!(db.num_blocks().unwrap(), n_blocks as u64);
-
-        blocks
-    }
-
-    #[test]
-    // Quick sanity test of the `populate_db` test fixture.
-    fn test_populate_db() {
-        let mut ledger_db = create_db();
-        let n_transactions: u64 = 7;
-        let blocks = populate_db(&mut ledger_db, n_transactions);
-        for block in &blocks {
-            println!("{:?}", block);
-        }
-
-        assert_eq!(blocks.len(), n_transactions as usize);
-    }
 
     #[test_with_logger]
     // `get_last_block_info` should returns the last block.
     fn test_get_last_block_info(logger: Logger) {
-        let mut ledger_db = create_db();
-        let block_entities = populate_db(&mut ledger_db, 200);
+        let mut ledger_db = create_ledger();
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let account_key = AccountKey::random(&mut rng);
+        let block_entities = initialize_ledger(&mut ledger_db, 10, &account_key, &mut rng);
 
         let mut expected_response = LastBlockInfoResponse::new();
         expected_response.set_index(block_entities.last().unwrap().index);
@@ -245,8 +170,11 @@ mod tests {
     #[test_with_logger]
     // `get_blocks` should returns the correct range of blocks.
     fn test_get_blocks_response_range(logger: Logger) {
-        let mut ledger_db = create_db();
-        let block_entities = populate_db(&mut ledger_db, 200);
+        let mut ledger_db = create_ledger();
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let account_key = AccountKey::random(&mut rng);
+        let block_entities = initialize_ledger(&mut ledger_db, 10, &account_key, &mut rng);
+
         let expected_blocks: Vec<blockchain::Block> = block_entities
             .into_iter()
             .map(|block_entity| blockchain::Block::from(&block_entity))
@@ -269,13 +197,13 @@ mod tests {
         }
 
         {
-            // The range [0,100) should return 100 Blocks.
-            let block_response = blockchain_api_service.get_blocks_helper(0, 100).unwrap();
+            // The range [0,10) should return 10 Blocks.
+            let block_response = blockchain_api_service.get_blocks_helper(0, 10).unwrap();
             let blocks = block_response.blocks;
-            assert_eq!(100, blocks.len());
+            assert_eq!(10, blocks.len());
             assert_eq!(expected_blocks.get(0).unwrap(), blocks.get(0).unwrap());
-            assert_eq!(expected_blocks.get(77).unwrap(), blocks.get(77).unwrap());
-            assert_eq!(expected_blocks.get(99).unwrap(), blocks.get(99).unwrap());
+            assert_eq!(expected_blocks.get(7).unwrap(), blocks.get(7).unwrap());
+            assert_eq!(expected_blocks.get(9).unwrap(), blocks.get(9).unwrap());
         }
     }
 
@@ -283,22 +211,28 @@ mod tests {
     // `get_blocks` should return the intersection of the request with the available data
     // if a client requests data that does not exist.
     fn test_get_blocks_request_out_of_bounds(logger: Logger) {
-        let mut ledger_db = create_db();
-        let _blocks = populate_db(&mut ledger_db, 200);
+        let mut ledger_db = create_ledger();
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let account_key = AccountKey::random(&mut rng);
+        let _blocks = initialize_ledger(&mut ledger_db, 10, &account_key, &mut rng);
+
         let mut blockchain_api_service = BlockchainApiService::new(ledger_db, logger);
 
         {
-            // The range [0, 1000) requests values that don't exist. The response should contain [0,200).
+            // The range [0, 1000) requests values that don't exist. The response should contain [0,10).
             let block_response = blockchain_api_service.get_blocks_helper(0, 1000).unwrap();
-            assert_eq!(200, block_response.blocks.len());
+            assert_eq!(10, block_response.blocks.len());
         }
     }
 
     #[test_with_logger]
     // `get_blocks` should only return the "maximum" number of items if the requested range is larger.
     fn test_get_blocks_max_size(logger: Logger) {
-        let mut ledger_db = create_db();
-        let block_entities = populate_db(&mut ledger_db, 200);
+        let mut ledger_db = create_ledger();
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let account_key = AccountKey::random(&mut rng);
+        let block_entities = initialize_ledger(&mut ledger_db, 10, &account_key, &mut rng);
+
         let expected_blocks: Vec<blockchain::Block> = block_entities
             .into_iter()
             .map(|block_entity| blockchain::Block::from(&block_entity))

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -491,11 +491,10 @@ impl LedgerDB {
             return Err(Error::NoOutputs);
         }
 
-        // TODO: enable this.
-        // // Non-origin blocks must have key images.
-        // if block.index == 0 && block_contents.key_images.is_empty() {
-        //     return Err(Error::InvalidBlock);
-        // }
+        // Non-origin blocks must have key images.
+        if block.index != 0 && block_contents.key_images.is_empty() {
+            return Err(Error::InvalidBlock);
+        }
 
         // Check if block is being appended at the correct place.
         let num_blocks = self.num_blocks()?;
@@ -609,7 +608,12 @@ mod ledger_db_test {
                 })
                 .collect();
 
-            let key_images: Vec<KeyImage> = Vec::new();
+            // Non-origin blocks must have at least one key image.
+            let key_images: Vec<KeyImage> = if block_index > 0 {
+                vec![KeyImage::from(block_index)]
+            } else {
+                vec![]
+            };
             let block_contents = BlockContents::new(key_images, outputs.clone());
 
             let block = match parent_block {

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -758,6 +758,55 @@ mod ledger_db_test {
     }
 
     #[test]
+    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: InvalidBlock")]
+    // Appending a non-origin block should fail if the block contains no key images.
+    fn test_append_block_fails_for_non_origin_blocks_without_key_images() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let mut ledger_db = create_db();
+
+        // === Create and append the origin block. ===
+        // The origin block contains a single output belonging to the `origin_account_key`.
+
+        let origin_account_key = AccountKey::random(&mut rng);
+        let (origin_block, origin_block_contents) =
+            get_origin_block_and_contents(&origin_account_key);
+
+        ledger_db
+            .append_block(&origin_block, &origin_block_contents, None)
+            .unwrap();
+
+        // === Attempt to append a block without key images ===
+        let recipient_account_key = AccountKey::random(&mut rng);
+        let outputs: Vec<TxOut> = (0..4)
+            .map(|_i| {
+                TxOut::new(
+                    1000,
+                    &recipient_account_key.default_subaddress(),
+                    &RistrettoPrivate::from_random(&mut rng),
+                    Default::default(),
+                    &mut rng,
+                )
+                .unwrap()
+            })
+            .collect();
+
+        let key_images = Vec::new();
+
+        let block_contents = BlockContents::new(key_images.clone(), outputs);
+        let block = Block::new_with_parent(
+            BLOCK_VERSION,
+            &origin_block,
+            &Default::default(),
+            &block_contents,
+        );
+
+        // This is expected to fail.
+        ledger_db
+            .append_block(&block, &block_contents, None)
+            .unwrap();
+    }
+
+    #[test]
     #[ignore]
     // A block that attempts a double spend should be rejected.
     fn test_reject_double_spend() {

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1168,6 +1168,7 @@ mod test {
         utxo_store::UnspentTxOut,
     };
     use mc_common::{logger::test_with_logger, HashSet};
+    use mc_crypto_rand::RngCore;
     use mc_transaction_core::{
         account_keys::{AccountKey, PublicAddress, DEFAULT_SUBADDRESS_INDEX},
         constants::{BASE_FEE, MAX_INPUTS, RING_SIZE},
@@ -2150,7 +2151,7 @@ mod test {
             let _ = add_block_to_ledger_db(
                 &mut ledger_db,
                 &[sender_default_subaddress.clone()],
-                &[],
+                &[KeyImage::from(rng.next_u64())],
                 &mut rng,
             );
         }

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -87,8 +87,14 @@ pub fn get_test_databases(
 
     let mut ledger_db = generate_ledger_db(&ledger_db_path);
 
-    for _i in 0..num_blocks {
-        let _new_block_height = add_block_to_ledger_db(&mut ledger_db, &public_addresses, &[], rng);
+    for block_index in 0..num_blocks {
+        let key_images = if block_index == 0 {
+            vec![]
+        } else {
+            vec![KeyImage::from(rng.next_u64())]
+        };
+        let _new_block_height =
+            add_block_to_ledger_db(&mut ledger_db, &public_addresses, &key_images, rng);
     }
 
     let mobilecoind_db = Database::new(mobilecoind_db_path.to_string(), logger)

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -10,6 +10,7 @@ pub use mc_transaction_core::{
     get_tx_out_shared_secret,
     onetime_keys::recover_onetime_private_key,
     range::Range,
+    ring_signature::KeyImage,
     tx::{Tx, TxOut, TxOutMembershipElement, TxOutMembershipHash},
     Block, BlockID, BlockIndex, BLOCK_VERSION,
 };
@@ -260,7 +261,10 @@ pub fn get_blocks<T: Rng + RngCore + CryptoRng>(
             .collect();
         let outputs = get_outputs(&recipient_and_amount, rng);
 
-        let block_contents = BlockContents::new(Vec::new(), outputs);
+        // Non-origin blocks must have at least one key image.
+        let key_images = vec![KeyImage::from(block_index as u64)];
+
+        let block_contents = BlockContents::new(key_images, outputs);
 
         // Fake proofs
         let root_element = TxOutMembershipElement {


### PR DESCRIPTION
### Motivation

LedgerDB should ensure only valid blocks are written, as an extra safety measurement. Non-origin blocks that lack key images are invalid and that should be enforced.

### In this PR
`append_block` enforces non-zero number of key images for non-origin blocks.

