### PR TITLE
Enable mc-common/std for mc-common/loggers

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,7 +9,6 @@ default = []
 std = [
     "failure/std",
     "mc-util-serial/std",
-    "serde/std",
 ]
 log = [
     "backtrace",
@@ -19,7 +18,11 @@ log = [
     "slog-scope",
 ]
 loggers = [
+    # Features
     "log",
+    "std",
+
+    # Dependencies
     "hostname",
     "lazy_static",
     "mc-util-build-info",


### PR DESCRIPTION
Soundtrack of this PR: [Sahalé - Nlreb Mra Alrrih (Playing With The Wind)](https://soundcloud.com/sahaleprods/sahale-nlreb-mra-alrrih-playing-with-the-wind)

### Motivation

`mc-util-serial/std` must be enabled whenever `serde/std` is enabled, even if `serde/std` is enabled by a third-party dependency. Currently `mc-common/loggers` enables multiple dependencies (`sentry`, `slog-gelf`, and `slog-json`) that all enable `serde/std`. This causes a compile error for any crate that depends on `mc-common/loggers` without something in the dependency tree also enabling `mc-util-serial/std`. Since `mc-common/loggers` is the crate that introduces these dependencies, it should also enable `mc-util-serial/std` for correctness.

### In this PR
* Enables `mc-util-serial/std` for `mc-common/loggers`
* Removes redundant `serde/std` from `mc-common/std`
