### PR TITLE
watcher bugfix: properly keep track of last synced block indexes (and some other bugfixes)

### DIFF
--- a/mobilecoind/clients/python/blockchain_explorer/blockchain_explorer.py
+++ b/mobilecoind/clients/python/blockchain_explorer/blockchain_explorer.py
@@ -6,7 +6,7 @@ from flask import Flask, render_template
 sys.path.append('../mob_client')
 from mob_client import mob_client
 
-client = mob_client('localhost:4444', False)
+client = None  # client is initialized at the bottom of this file
 app = Flask(__name__)
 
 def command_args():

--- a/tools/local-network/local-network.py
+++ b/tools/local-network/local-network.py
@@ -236,7 +236,12 @@ class Node:
 
         self.consensus_process = subprocess.Popen(cmd, shell=True)
 
-        time.sleep(2)
+        # Wait for ledger db to become available
+        ledger_db = os.path.join(self.ledger_dir, 'data.mdb')
+        while not os.path.exists(ledger_db):
+            time.sleep(1)
+            print(f'Waiting for {ledger_db}')
+
         cmd = ' '.join([
             f'cd {PROJECT_DIR} && exec {TARGET_DIR}/ledger-distribution',
             f'--ledger-path {self.ledger_dir}',


### PR DESCRIPTION
### Motivation

While working on block timestamps I discovered a few issues:
1) The `watcher` crate was keeping track of last synced block indexes, but defaulting to zero - which is incorrect since block index 0 also needs to be synced. Without the fixes here, the watcher was taking 100% CPU attempting to constantly get new blocks even if everything was synced.
2) `local-network` had a small bug that caused it to fail if nodes take a bit too long to copy the ledger database from the bootstrap one.
3) `block_explorer.py` had a confusing line at the top that caused me to waste some time trying to figure out why changing it is not getting the desired effect.

### In this PR
Fixes for the above issues. Issues 2 and 3 are trivial. For the `watcher` bug I opted to change how `watcher` stores its state. The `last_synced` database now only contains URL -> block indices of successfully synced blocks. The method `last_synced_blocks` was changed to return a map of URL -> `Option<u64>` for each URL known to the `watcher`. A value of `None` means no blocks were synced.
