### PR TITLE
MC-1567: include approximate signing time in BlockSignature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ dist/
 # Per-crate lock files
 Cargo.lock
 !/Cargo.lock
+
+# Python stuff
+__pycache__/
+mobilecoind/clients/python/blockchain_explorer/latest.tar.gz
+mobilecoind/clients/python/env/
+mobilecoind/clients/python/mob_client/blockchain_pb2.py

--- a/api/proto/blockchain.proto
+++ b/api/proto/blockchain.proto
@@ -51,8 +51,15 @@ message BlockContents {
 }
 
 message BlockSignature {
+    // The signature of the block.
     external.Ed25519Signature signature = 1;
+
+    // The signer that generated the above signature.
     external.Ed25519Public signer = 2;
+
+    // An approximate time in which the block was signed.
+    // Represented as seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z.
+    uint64 signed_at = 3;
 }
 
 // Version 1 of an archived block.

--- a/consensus/service/src/tx_manager.rs
+++ b/consensus/service/src/tx_manager.rs
@@ -318,9 +318,12 @@ impl<E: ConsensusEnclaveProxy, L: Ledger, UI: UntrustedInterfaces> TxManager<E, 
 
         let num_blocks = self.ledger.num_blocks()?;
         let parent_block = self.ledger.get_block(num_blocks - 1)?;
-        let (block, block_contents, signature) = self
+        let (block, block_contents, mut signature) = self
             .enclave
             .form_block(&parent_block, &encrypted_txs_with_proofs)?;
+
+        // The enclave cannot provide a timestamp, so this happens in untrusted.
+        signature.set_signed_at(chrono::Utc::now().timestamp() as u64);
 
         Ok((block, block_contents, signature))
     }

--- a/mobilecoind/clients/python/blockchain_explorer/blockchain_explorer.py
+++ b/mobilecoind/clients/python/blockchain_explorer/blockchain_explorer.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2018-2020 MobileCoin Inc.
 
-import argparse, sys
+import argparse, datetime, sys
 from flask import Flask, render_template
 
 sys.path.append('../mob_client')
@@ -72,6 +72,12 @@ def render_ledger_range(start, count):
                            num_blocks=num_blocks,
                            num_transactions=num_transactions,
                            signers=signers)
+
+@app.template_filter('datetime')
+def format_datetime(value):
+    if not value:
+        return 'N/A'
+    return datetime.datetime.fromtimestamp(value).isoformat()
 
 @app.route('/')
 def index():

--- a/mobilecoind/clients/python/blockchain_explorer/static/css/lofi.css
+++ b/mobilecoind/clients/python/blockchain_explorer/static/css/lofi.css
@@ -68,6 +68,14 @@ a {
   width: 16ch;
 }
 
+.col_19 {
+  width: 19ch;
+}
+
+.col_30 {
+  width: 30ch;
+}
+
 .col_34 {
   width: 34ch;
 }

--- a/mobilecoind/clients/python/blockchain_explorer/templates/block.html
+++ b/mobilecoind/clients/python/blockchain_explorer/templates/block.html
@@ -43,21 +43,24 @@
 <div class="row">********************************************************************************</div>
 <div class="row">&nbsp;</div>
 <div class="row">
-    <div class="col_40">Url</div>
+    <div class="col_30">Url</div>
     <div class="col_15">Signer</div>
     <div class="col_15">Signature</div>
+    <div class="col_19">Signed at</div>
 </div>
 <div class="row">
-    <div class="col_40">---</div>
+    <div class="col_30">---</div>
     <div class="col_15">------</div>
     <div class="col_15">---------</div>
+    <div class="col_19">---------</div>
 </div>
 <div class="row">&nbsp;</div>
 {%- for signature in signatures %}
     <div class="row">
-      <div class="col_40">{{ signature.src_url }}</div>
+      <div class="col_30">{{ signature.src_url }}</div>
       <div class="col_15">{{ signature.signature.signer.data.hex()[:5] }}...</div>
       <div class="col_15">{{ signature.signature.signature.data.hex()[:9] }}...</div>
+      <div class="col_19">{{ signature.signature.signed_at|datetime }}</div>
     </div>
 {%- endfor %}
 <div class="row">&nbsp;</div>

--- a/transaction/core/src/blockchain/block_signature.rs
+++ b/transaction/core/src/blockchain/block_signature.rs
@@ -34,6 +34,8 @@ impl BlockSignature {
     /// # Arguments
     /// * `signature` - A block signature.
     /// * `signer` - The signer of the signature.
+    /// * `signed_at` - The approximate time in which the block was signed, represented at seconds
+    ///                 of UTC time since Unix epoch 1970-01-01T00:00:00Z.
     pub fn new(signature: Ed25519Signature, signer: Ed25519Public, signed_at: u64) -> Self {
         Self {
             signature,

--- a/transaction/core/src/blockchain/block_signature.rs
+++ b/transaction/core/src/blockchain/block_signature.rs
@@ -21,6 +21,11 @@ pub struct BlockSignature {
     /// The public key of the keypair used to generate the signature.
     #[prost(message, required, tag = "2")]
     signer: Ed25519Public,
+
+    /// An approximate time in which the block was signed.
+    /// Represented as seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z.
+    #[prost(uint64, tag = "3")]
+    signed_at: u64,
 }
 
 impl BlockSignature {
@@ -29,11 +34,17 @@ impl BlockSignature {
     /// # Arguments
     /// * `signature` - A block signature.
     /// * `signer` - The signer of the signature.
-    pub fn new(signature: Ed25519Signature, signer: Ed25519Public) -> Self {
-        Self { signature, signer }
+    pub fn new(signature: Ed25519Signature, signer: Ed25519Public, signed_at: u64) -> Self {
+        Self {
+            signature,
+            signer,
+            signed_at,
+        }
     }
 
     /// Create a new BlockSignature by signing a block.
+    /// Since is generally done inside an enclave, time is not available. As such, `signed_at` is
+    /// being initialized to zero. It can then be set by calling `set_signed_at`.
     pub fn from_block_and_keypair(
         block: &Block,
         keypair: &Ed25519Pair,
@@ -45,7 +56,16 @@ impl BlockSignature {
 
         let signer = keypair.public_key();
 
-        Ok(Self { signature, signer })
+        Ok(Self {
+            signature,
+            signer,
+            signed_at: 0,
+        })
+    }
+
+    /// Set the value of `signed_at`.
+    pub fn set_signed_at(&mut self, signed_at: u64) {
+        self.signed_at = signed_at;
     }
 
     /// Get the signature.
@@ -56,6 +76,11 @@ impl BlockSignature {
     /// Get the signer.
     pub fn signer(&self) -> &Ed25519Public {
         &self.signer
+    }
+
+    /// Get the signed at timestamp.
+    pub fn signed_at(&self) -> u64 {
+        self.signed_at
     }
 
     /// Verify that this signature is over a given block.


### PR DESCRIPTION
Soundtrack of this PR: [Techno](https://soundcloud.com/adambeyer/dcr515-drumcode-radio-live-adam-beyer-studio-mix-recorded-in-ibiza)

### Motivation

We want to have an approximate estimation for when blocks were formed. This PR adds that.

### In this PR
* Change to `BlockSignature` to also include an optional timestamp, represented as seconds since unix epoch that is filled in by untrusted consensus service immediately after forming a block. This change is backwards compatible.
* A change to the block explorer that shows the timestamps on a block page:
![image](https://user-images.githubusercontent.com/1485066/85340399-e0574380-b49a-11ea-8237-7d830ae68525.png)
* A fix to `watcher` to use constant-size keys. This fix is not backwards compatible. 
