### PR TITLE
remove unused dependency on byteorder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,7 +2591,6 @@ dependencies = [
 name = "mc-mobilecoind"
 version = "0.4.0"
 dependencies = [
- "byteorder",
  "crossbeam-channel 0.3.9",
  "failure",
  "futures",
@@ -2942,7 +2941,6 @@ dependencies = [
  "blake2",
  "bs58",
  "bulletproofs",
- "byteorder",
  "cfg-if",
  "crc",
  "criterion",

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -1004,7 +1004,6 @@ dependencies = [
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bulletproofs 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -30,7 +30,6 @@ mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }
 mc-watcher = { path = "../watcher" }
 
-byteorder = "1.3.4"
 crossbeam-channel = "0.3"
 failure = "0.1.5"
 futures = "0.1"

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -16,7 +16,6 @@ test-net-fee-keys = []
 aead = "0.2"
 bs58 = { version = "0.3.0", default-features = false, features = ["alloc"] }
 blake2 = { version = "0.8.1", default-features = false, features = ["simd"] }
-byteorder = { version = "1.3.4", default-features = false }
 crc = { version = "1.8.1", default-features = false }
 cfg-if = "0.1"
 digest = { version = "0.8.1", default-features = false }


### PR DESCRIPTION
Soundtrack of this PR: https://soundcloud.com/johnny-blue/johnny-blue-anthropos-stream-2020

### Motivation

`byteorder` was replaced by builtin functionality, and there is a lingering unused dependency on it.

### In this PR
Removing said dependency.
