### PR TITLE
QuorumSetMember ordering should not matter

### DIFF
--- a/consensus/scp/src/core_types.rs
+++ b/consensus/scp/src/core_types.rs
@@ -14,9 +14,22 @@ use std::{
 };
 
 /// A generic node identifier.
-pub trait GenericNodeId: Clone + Debug + Display + Eq + PartialEq + Hash + Digestible {}
+pub trait GenericNodeId:
+    Clone + Debug + Display + Eq + PartialEq + Ord + PartialOrd + Hash + Digestible
+{
+}
 impl<T> GenericNodeId for T where
-    T: Clone + Debug + Display + Serialize + DeserializeOwned + Eq + PartialEq + Hash + Digestible
+    T: Clone
+        + Debug
+        + Display
+        + Serialize
+        + DeserializeOwned
+        + Eq
+        + PartialEq
+        + Ord
+        + PartialOrd
+        + Hash
+        + Digestible
 {
 }
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -406,7 +406,11 @@ impl<ID: GenericNodeId + AsRef<ResponderId>> From<&QuorumSet<ID>> for QuorumSet<
 #[cfg(test)]
 mod quorum_set_tests {
     use super::*;
-    use crate::{core_types::*, msg::*, predicates::*, test_utils::test_node_id};
+    use crate::{
+        core_types::*,
+        msg::*, predicates::*,
+        test_utils::{quorum_set_to_string, test_node_id}
+    };
     use mc_common::ResponderId;
 
     #[test]

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -396,15 +396,15 @@ mod quorum_set_tests {
             2,
             vec![test_node_id(3), test_node_id(4)],
         );
-        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__3_4));
+        quorum_set_1.members.push(QuorumSetMember::<NodeID>(qs_2__3_4));
         let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(6), test_node_id(7)],
         );
-        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__5_6_7));
+        quorum_set_1.members.push(QuorumSetMember::<NodeID>(qs_2__5_6_7));
 
         // let quorum_set_2 = quorum_set_from_str("([2], 1, 0, ([2],4,3), ([2],5,7,6))");
-        let mut quorum_set_1 = QuorumSet::new_with_node_ids(
+        let mut quorum_set_2 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(1), test_node_id(0)],
         );
@@ -412,12 +412,12 @@ mod quorum_set_tests {
             2,
             vec![test_node_id(4), test_node_id(3)],
         );
-        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__3_4));
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>(qs_2__3_4));
         let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(6), test_node_id(7)],
         );
-        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__5_6_7));
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>(qs_2__5_6_7));
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 
@@ -433,15 +433,15 @@ mod quorum_set_tests {
             2,
             vec![test_node_id(3), test_node_id(4)],
         );
-        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__3_4));
+        quorum_set_1.members.push(QuorumSetMember::<NodeID>(qs_2__3_4));
         let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(6), test_node_id(7)],
         );
-        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__5_6_7));
+        quorum_set_1.members.push(QuorumSetMember::<NodeID>(qs_2__5_6_7));
 
         // let quorum_set_2 = quorum_set_from_str("([2], 1, ([2],3,4), 0, ([2],5,6,7))");
-        let mut quorum_set_1 = QuorumSet::new_with_node_ids(
+        let mut quorum_set_2 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(1)],
         );
@@ -449,16 +449,16 @@ mod quorum_set_tests {
             2,
             vec![test_node_id(4), test_node_id(3)],
         );
-        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__3_4));
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>(qs_2__3_4));
 
         let node_0 = test_node_id(0);
-        quorum_set_1.members.push(QuorumSetMember<NodeID>(node_0));
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>(node_0));
 
         let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(6), test_node_id(7)],
         );
-        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__5_6_7));
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>(qs_2__5_6_7));
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -85,7 +85,7 @@ impl<ID: GenericNodeId> Hash for QuorumSet<ID> {
         // sort before hashing
         let mut self_members: Vec<QuorumSetMember<ID>> = self.members.clone();
         self_members.sort();
-        for m in self.members.iter() {
+        for m in self_members.iter() {
             m.hash(state);
         }
     }

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -428,19 +428,19 @@ mod quorum_set_tests {
         let quorum_set_1 = QuorumSet::new(
             2,
             vec![
-                test_node_id(0),
-                test_node_id(1),
-                test_node_id(2),
-                test_node_id(3),
+                QuorumSetMember::Node(test_node_id(0)),
+                QuorumSetMember::Node(test_node_id(1)),
+                QuorumSetMember::Node(test_node_id(2)),
+                QuorumSetMember::Node(test_node_id(3)),
             ],
         );
         let quorum_set_2 = QuorumSet::new(
             2,
             vec![
-                test_node_id(3),
-                test_node_id(1),
-                test_node_id(2),
-                test_node_id(0),
+                QuorumSetMember::Node(test_node_id(3)),
+                QuorumSetMember::Node(test_node_id(1)),
+                QuorumSetMember::Node(test_node_id(2)),
+                QuorumSetMember::Node(test_node_id(0)),
             ],
         );
 
@@ -449,10 +449,10 @@ mod quorum_set_tests {
         // qs1 == qs2 must imply hash(qs1)==hash(qs2)
         let mut quorum_set_1_hash = DefaultHasher::new();
         quorum_set_1.hash(&mut quorum_set_1_hash);
-        quorum_set_1.finish()
+        quorum_set_1.finish();
         let mut quorum_set_2_hash = DefaultHasher::new();
         quorum_set_2.hash(&mut quorum_set_2_hash);
-        quorum_set_2.finish()
+        quorum_set_2.finish();
         assert_eq!(quorum_set_1_hash, quorum_set_2_hash);
     }
 
@@ -508,10 +508,10 @@ mod quorum_set_tests {
         // qs1 == qs2 must imply hash(qs1)==hash(qs2)
         let mut quorum_set_1_hash = DefaultHasher::new();
         quorum_set_1.hash(&mut quorum_set_1_hash);
-        quorum_set_1.finish()
+        quorum_set_1.finish();
         let mut quorum_set_2_hash = DefaultHasher::new();
         quorum_set_2.hash(&mut quorum_set_2_hash);
-        quorum_set_2.finish()
+        quorum_set_2.finish();
         assert_eq!(quorum_set_1_hash, quorum_set_2_hash);
     }
 
@@ -567,10 +567,10 @@ mod quorum_set_tests {
         // qs1 == qs2 must imply hash(qs1)==hash(qs2)
         let mut quorum_set_1_hash = DefaultHasher::new();
         quorum_set_1.hash(&mut quorum_set_1_hash);
-        quorum_set_1.finish()
+        quorum_set_1.finish();
         let mut quorum_set_2_hash = DefaultHasher::new();
         quorum_set_2.hash(&mut quorum_set_2_hash);
-        quorum_set_2.finish()
+        quorum_set_2.finish();
         assert_eq!(quorum_set_1_hash, quorum_set_2_hash);
     }
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -449,8 +449,10 @@ mod quorum_set_tests {
         // qs1 == qs2 must imply hash(qs1)==hash(qs2)
         let mut quorum_set_1_hash = DefaultHasher::new();
         quorum_set_1.hash(&mut quorum_set_1_hash);
+        quorum_set_1.finish()
         let mut quorum_set_2_hash = DefaultHasher::new();
         quorum_set_2.hash(&mut quorum_set_2_hash);
+        quorum_set_2.finish()
         assert_eq!(quorum_set_1_hash, quorum_set_2_hash);
     }
 
@@ -506,8 +508,10 @@ mod quorum_set_tests {
         // qs1 == qs2 must imply hash(qs1)==hash(qs2)
         let mut quorum_set_1_hash = DefaultHasher::new();
         quorum_set_1.hash(&mut quorum_set_1_hash);
+        quorum_set_1.finish()
         let mut quorum_set_2_hash = DefaultHasher::new();
         quorum_set_2.hash(&mut quorum_set_2_hash);
+        quorum_set_2.finish()
         assert_eq!(quorum_set_1_hash, quorum_set_2_hash);
     }
 
@@ -563,8 +567,10 @@ mod quorum_set_tests {
         // qs1 == qs2 must imply hash(qs1)==hash(qs2)
         let mut quorum_set_1_hash = DefaultHasher::new();
         quorum_set_1.hash(&mut quorum_set_1_hash);
+        quorum_set_1.finish()
         let mut quorum_set_2_hash = DefaultHasher::new();
         quorum_set_2.hash(&mut quorum_set_2_hash);
+        quorum_set_2.finish()
         assert_eq!(quorum_set_1_hash, quorum_set_2_hash);
     }
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -417,7 +417,7 @@ mod quorum_set_tests {
                 2,
                 vec![test_node_id(5), test_node_id(6), test_node_id(7)],
             );
-            QuorumSet::new_with_inner_sets(2, vec![test_node_id(1), inner_quorum_set_one, inner_quorum_set_two])
+            QuorumSet::new_with_inner_sets(2, vec![inner_quorum_set_one, inner_quorum_set_two])
         };
         let quorum_set_2: QuorumSet = {
             let inner_quorum_set_one = QuorumSet::new_with_node_ids(
@@ -428,7 +428,7 @@ mod quorum_set_tests {
                 2,
                 vec![test_node_id(5), test_node_id(7), test_node_id(6)],
             );
-            QuorumSet::new_with_inner_sets(2, vec![inner_quorum_set_two, test_node_id(1), inner_quorum_set_one])
+            QuorumSet::new_with_inner_sets(2, vec![inner_quorum_set_two, inner_quorum_set_one])
         };
         assert_eq!(quorum_set_1, quorum_set_2);
     }

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -97,7 +97,7 @@ impl<ID: GenericNodeId> QuorumSet<ID> {
     }
 
     /// Recursively sort the qs and all inner sets
-    pub fn sort(&mut self) -> {
+    pub fn sort(&mut self) {
         self.members.sort();
         for member in self.members.iter() {
             match member {
@@ -105,6 +105,7 @@ impl<ID: GenericNodeId> QuorumSet<ID> {
                 _ => {},
             }
         }
+
     }
 
     /// Returns a flattened set of all nodes contained in q and its nested QSets.

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -449,10 +449,10 @@ mod quorum_set_tests {
         // qs1 == qs2 must imply hash(qs1)==hash(qs2)
         let mut quorum_set_1_hash = DefaultHasher::new();
         quorum_set_1.hash(&mut quorum_set_1_hash);
-        quorum_set_1.finish();
+        quorum_set_1_hash.finish();
         let mut quorum_set_2_hash = DefaultHasher::new();
         quorum_set_2.hash(&mut quorum_set_2_hash);
-        quorum_set_2.finish();
+        quorum_set_2_hash.finish();
         assert_eq!(quorum_set_1_hash, quorum_set_2_hash);
     }
 
@@ -508,10 +508,10 @@ mod quorum_set_tests {
         // qs1 == qs2 must imply hash(qs1)==hash(qs2)
         let mut quorum_set_1_hash = DefaultHasher::new();
         quorum_set_1.hash(&mut quorum_set_1_hash);
-        quorum_set_1.finish();
+        quorum_set_1_hash.finish();
         let mut quorum_set_2_hash = DefaultHasher::new();
         quorum_set_2.hash(&mut quorum_set_2_hash);
-        quorum_set_2.finish();
+        quorum_set_2_hash.finish();
         assert_eq!(quorum_set_1_hash, quorum_set_2_hash);
     }
 
@@ -567,10 +567,10 @@ mod quorum_set_tests {
         // qs1 == qs2 must imply hash(qs1)==hash(qs2)
         let mut quorum_set_1_hash = DefaultHasher::new();
         quorum_set_1.hash(&mut quorum_set_1_hash);
-        quorum_set_1.finish();
+        quorum_set_1_hash.finish();
         let mut quorum_set_2_hash = DefaultHasher::new();
         quorum_set_2.hash(&mut quorum_set_2_hash);
-        quorum_set_2.finish();
+        quorum_set_2_hash.finish();
         assert_eq!(quorum_set_1_hash, quorum_set_2_hash);
     }
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -424,6 +424,10 @@ mod quorum_set_tests {
             2,
             vec![test_node_id(3), test_node_id(1), test_node_id(2), test_node_id(0)],
         );
+
+        println!("qs1: {}", quorum_set_to_string(&quorum_set_1));
+        println!("qs2: {}", quorum_set_to_string(&quorum_set_2));
+
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 
@@ -466,6 +470,9 @@ mod quorum_set_tests {
         );
         quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
 
+        println!("qs1: {}", quorum_set_to_string(&quorum_set_1));
+        println!("qs2: {}", quorum_set_to_string(&quorum_set_2));
+
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 
@@ -500,7 +507,7 @@ mod quorum_set_tests {
         quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__4_3));
         let qs_2__5_7_6 = QuorumSet::new_with_node_ids(
             2,
-            vec![test_node_id(5), test_node_id(6), test_node_id(7)],
+            vec![test_node_id(5), test_node_id(7), test_node_id(6)],
         );
         quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -60,9 +60,7 @@ impl<ID: GenericNodeId> Hash for QuorumSet<ID> {
         let mut qs_clone = self.clone();
         qs_clone.sort();
         qs_clone.threshold.hash(state);
-        for m in qs_clone.members.iter() {
-            m.hash(state);
-        }
+        qs_clone.members.hash(state);
     }
 }
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -393,6 +393,7 @@ mod quorum_set_tests {
     use super::*;
     use crate::{core_types::*, msg::*, predicates::*, test_utils::test_node_id};
     use mc_common::ResponderId;
+    use std::collections::hash_map::DefaultHasher;
 
     #[test]
     // quorum sets should sort recursively

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use std::{
     fmt::Debug,
     hash::{Hash, Hasher},
-    iter::FromIterator};
-}
+    iter::FromIterator,
+};
 
 use crate::{
     core_types::{GenericNodeId, Value},

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -43,11 +43,11 @@ impl<ID: GenericNodeId> PartialEq for QuorumSet<ID> {
     fn eq(&self, other: &QuorumSet<ID>) -> bool {
         if self.threshold == other.threshold && self.members.len() == other.members.len() {
             // sort before comparing
-            let mut self_members: Vec<QuorumSetMember<ID>> = self.members.clone();
-            let mut other_members: Vec<QuorumSetMember<ID>> = other.members.clone();
-            self_members.sort();
-            other_members.sort();
-            return self_members == other_members;
+            let mut self_clone = self.clone();
+            let mut other_clone = other.clone();
+            self_clone.sort();
+            other_clone.sort();
+            return self_clone.members == other_clone.members;
         }
         false
     }

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -98,14 +98,14 @@ impl<ID: GenericNodeId> QuorumSet<ID> {
 
     /// Recursively sort the qs and all inner sets
     pub fn sort(&mut self) {
-        self.members.sort();
         for member in self.members.iter_mut() {
             match member {
                 QuorumSetMember::InnerSet(qs) => qs.sort(),
                 _ => {},
             }
         }
-
+        // sort the members after any internal reordering!
+        self.members.sort();
     }
 
     /// Returns a flattened set of all nodes contained in q and its nested QSets.

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -397,14 +397,13 @@ mod quorum_set_tests {
     use crate::{
         core_types::*,
         msg::*, predicates::*,
-        test_utils::{quorum_set_to_string, test_node_id}
+        test_utils::test_node_id,
     };
     use mc_common::ResponderId;
 
     #[test]
     // quorum sets should sort recursively
     fn test_quorum_set_sorting() {
-        // let qs = quorum_set_from_str("([2], 1, ([2], 3, 2, [2],5,7,6))");
         let mut qs = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(1)],
@@ -427,9 +426,6 @@ mod quorum_set_tests {
         let mut qs_sorted = qs.clone();
         qs_sorted.sort();
 
-        println!("unsorted: {}", quorum_set_to_string(&qs));
-        println!("  sorted: {}", quorum_set_to_string(&qs_sorted));
-
         assert_eq!(qs, qs_sorted);
     }
 
@@ -445,16 +441,12 @@ mod quorum_set_tests {
             vec![test_node_id(3), test_node_id(1), test_node_id(2), test_node_id(0)],
         );
 
-        println!("qs1: {}", quorum_set_to_string(&quorum_set_1));
-        println!("qs2: {}", quorum_set_to_string(&quorum_set_2));
-
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 
     #[test]
     // ordering of members should not matter wrt member Enum type
     fn test_quorum_set_equality_2() {
-        // let quorum_set_1 = quorum_set_from_str("([2], 0, 1, ([2],3,4), ([2],5,6,7))");
         let mut quorum_set_1 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(0), test_node_id(1)],
@@ -470,7 +462,6 @@ mod quorum_set_tests {
         );
         quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
 
-        // let quorum_set_2 = quorum_set_from_str("([2], 1, ([2],3,4), 0, ([2],5,6,7))");
         let mut quorum_set_2 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(1)],
@@ -490,16 +481,12 @@ mod quorum_set_tests {
         );
         quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
 
-        println!("qs1: {}", quorum_set_to_string(&quorum_set_1));
-        println!("qs2: {}", quorum_set_to_string(&quorum_set_2));
-
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 
     #[test]
     // ordering of members inside inner sets should not matter
     fn test_quorum_set_equality_3() {
-        // let quorum_set_1 = quorum_set_from_str("([2], 0, 1, ([2],3,4), ([2],5,6,7))");
         let mut quorum_set_1 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(0), test_node_id(1)],
@@ -515,7 +502,6 @@ mod quorum_set_tests {
         );
         quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
 
-        // let quorum_set_2 = quorum_set_from_str("([2], 1, 0, ([2],4,3), ([2],5,7,6))");
         let mut quorum_set_2 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(1), test_node_id(0)],
@@ -530,9 +516,6 @@ mod quorum_set_tests {
             vec![test_node_id(5), test_node_id(7), test_node_id(6)],
         );
         quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
-
-        println!("qs1: {}", quorum_set_to_string(&quorum_set_1));
-        println!("qs2: {}", quorum_set_to_string(&quorum_set_2));
 
         assert_eq!(quorum_set_1, quorum_set_2);
     }

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// A member in a QuorumSet. Can be either a Node or another QuorumSet.
-#[derive(Clone, Debug, Ord, PartialOrd, Serialize, Deserialize, Digestible)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Digestible)]
 #[serde(tag = "type", content = "args")]
 pub enum QuorumSetMember<ID: GenericNodeId> {
     /// A single trusted entity with an identity.
@@ -27,31 +27,6 @@ pub enum QuorumSetMember<ID: GenericNodeId> {
 
     /// A quorum set can also be a member of a quorum set.
     InnerSet(QuorumSet<ID>),
-}
-
-impl<ID: GenericNodeId> PartialEq for QuorumSetMember<ID> {
-    fn eq(&self, other: &QuorumSetMember<ID>) -> bool {
-        match self {
-            QuorumSetMember::Node(self_node) => match other {
-                QuorumSetMember::Node(other_node) => self_node == other_node,
-                _ => false,
-            },
-            QuorumSetMember::InnerSet(self_qs) => match other {
-                QuorumSetMember::InnerSet(other_qs) => self_qs == other_qs,
-                _ => false,
-            },
-        }
-    }
-}
-impl<ID: GenericNodeId> Eq for QuorumSetMember<ID> {}
-
-impl<ID: GenericNodeId> Hash for QuorumSetMember<ID> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match self {
-            QuorumSetMember::Node(self_node) => self_node.hash(state),
-            QuorumSetMember::InnerSet(self_qs) => self_qs.hash(state),
-        }
-    }
 }
 
 /// The quorum set defining the trusted set of peers.

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -387,38 +387,14 @@ mod quorum_set_tests {
     #[test]
     // ordering of members should not matter
     fn test_quorum_set_equality_1() {
-        // let quorum_set_1 = quorum_set_from_str("([2], 0, 1, ([2],3,4), ([2],5,6,7))");
-        let mut quorum_set_1 = QuorumSet::new_with_node_ids(
+        let quorum_set_1 = QuorumSet::new_with_node_ids(
             2,
-            vec![test_node_id(0), test_node_id(1)],
+            vec![test_node_id(0), test_node_id(1), test_node_id(2), test_node_id(3)],
         );
-        let qs_2__3_4 = QuorumSet::new_with_node_ids(
+        let quorum_set_2 = QuorumSet::new_with_node_ids(
             2,
-            vec![test_node_id(3), test_node_id(4)],
+            vec![test_node_id(3), test_node_id(1), test_node_id(2), test_node_id(0)],
         );
-        quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
-        let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(5), test_node_id(6), test_node_id(7)],
-        );
-        quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
-
-        // let quorum_set_2 = quorum_set_from_str("([2], 1, 0, ([2],4,3), ([2],5,7,6))");
-        let mut quorum_set_2 = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(1), test_node_id(0)],
-        );
-        let qs_2__4_3 = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(4), test_node_id(3)],
-        );
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__4_3));
-        let qs_2__5_7_6 = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(5), test_node_id(6), test_node_id(7)],
-        );
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
-
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 
@@ -464,60 +440,41 @@ mod quorum_set_tests {
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 
-
     #[test]
-    // ordering of QuorumSetMembers should not matter
-    fn test_quorum_set_equality_with_reordering() {
-        let quorum_set_1: QuorumSet = {
-            let inner_quorum_set_one = QuorumSet::new_with_node_ids(
-                2,
-                vec![test_node_id(2), test_node_id(3), test_node_id(4)],
-            );
-            let inner_quorum_set_two = QuorumSet::new_with_node_ids(
-                2,
-                vec![test_node_id(5), test_node_id(6), test_node_id(7)],
-            );
-            QuorumSet::new_with_inner_sets(2, vec![inner_quorum_set_one, inner_quorum_set_two])
-        };
-        let quorum_set_2: QuorumSet = {
-            let inner_quorum_set_one = QuorumSet::new_with_node_ids(
-                2,
-                vec![test_node_id(2), test_node_id(3), test_node_id(4)],
-            );
-            let inner_quorum_set_two = QuorumSet::new_with_node_ids(
-                2,
-                vec![test_node_id(5), test_node_id(7), test_node_id(6)],
-            );
-            QuorumSet::new_with_inner_sets(2, vec![inner_quorum_set_two, inner_quorum_set_one])
-        };
-        assert_eq!(quorum_set_1, quorum_set_2);
-    }
+    // ordering of members inside inner sets should not matter
+    fn test_quorum_set_equality_3() {
+        // let quorum_set_1 = quorum_set_from_str("([2], 0, 1, ([2],3,4), ([2],5,6,7))");
+        let mut quorum_set_1 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(0), test_node_id(1)],
+        );
+        let qs_2__3_4 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(3), test_node_id(4)],
+        );
+        quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
+        let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(5), test_node_id(6), test_node_id(7)],
+        );
+        quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
 
-    #[test]
-    // ordering within inner QuorumSetMembers should not matter
-    fn test_quorum_set_equality_with_inner_set_reordering() {
-        let quorum_set_1: QuorumSet = {
-            let inner_quorum_set_one = QuorumSet::new_with_node_ids(
-                2,
-                vec![test_node_id(2), test_node_id(3), test_node_id(4)],
-            );
-            let inner_quorum_set_two = QuorumSet::new_with_node_ids(
-                2,
-                vec![test_node_id(6), test_node_id(5), test_node_id(7)],
-            );
-            QuorumSet::new_with_inner_sets(2, vec![inner_quorum_set_one, inner_quorum_set_two])
-        };
-        let quorum_set_2: QuorumSet = {
-            let inner_quorum_set_one = QuorumSet::new_with_node_ids(
-                2,
-                vec![test_node_id(2), test_node_id(3), test_node_id(4)],
-            );
-            let inner_quorum_set_two = QuorumSet::new_with_node_ids(
-                2,
-                vec![test_node_id(5), test_node_id(7), test_node_id(6)],
-            );
-            QuorumSet::new_with_inner_sets(2, vec![inner_quorum_set_two, inner_quorum_set_one])
-        };
+        // let quorum_set_2 = quorum_set_from_str("([2], 1, 0, ([2],4,3), ([2],5,7,6))");
+        let mut quorum_set_2 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(1), test_node_id(0)],
+        );
+        let qs_2__4_3 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(4), test_node_id(3)],
+        );
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__4_3));
+        let qs_2__5_7_6 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(5), test_node_id(6), test_node_id(7)],
+        );
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
+
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -531,9 +531,6 @@ mod quorum_set_tests {
         );
         quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
 
-        quorum_set_1.sort();
-        quorum_set_2.sort();
-
         println!("qs1: {}", quorum_set_to_string(&quorum_set_1));
         println!("qs2: {}", quorum_set_to_string(&quorum_set_2));
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -424,7 +424,8 @@ mod quorum_set_tests {
         let node_0 = test_node_id(0);
         qs.members.push(QuorumSetMember::<NodeID>::Node(node_0));
 
-        let qs_sorted = qs.clone().sort();
+        let mut qs_sorted = qs.clone();
+        qs_sorted.sort();
 
         println!("unsorted: {}", quorum_set_to_string(&qs));
         println!("  sorted: {}", quorum_set_to_string(&qs_sorted));

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -6,7 +6,11 @@
 use mc_common::{HashMap, HashSet, NodeID, ResponderId};
 use mc_crypto_digestible::Digestible;
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, hash::{Hash, Hasher}, iter::FromIterator};
+use std::{
+    fmt::Debug,
+    hash::{Hash, Hasher},
+    iter::FromIterator};
+}
 
 use crate::{
     core_types::{GenericNodeId, Value},

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -504,8 +504,8 @@ mod quorum_set_tests {
         );
         quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
 
-        println!("qs1: {}", quorum_set_to_string(quorum_set_1));
-        println!("qs2: {}", quorum_set_to_string(quorum_set_2));
+        println!("qs1: {}", quorum_set_to_string(&quorum_set_1));
+        println!("qs2: {}", quorum_set_to_string(&quorum_set_2));
 
         assert_eq!(quorum_set_1, quorum_set_2);
     }

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -396,12 +396,12 @@ mod quorum_set_tests {
             2,
             vec![test_node_id(3), test_node_id(4)],
         );
-        quorum_set_1.members.push(QuorumSetMember::<NodeID>(qs_2__3_4));
+        quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
         let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(6), test_node_id(7)],
         );
-        quorum_set_1.members.push(QuorumSetMember::<NodeID>(qs_2__5_6_7));
+        quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
 
         // let quorum_set_2 = quorum_set_from_str("([2], 1, 0, ([2],4,3), ([2],5,7,6))");
         let mut quorum_set_2 = QuorumSet::new_with_node_ids(
@@ -412,12 +412,12 @@ mod quorum_set_tests {
             2,
             vec![test_node_id(4), test_node_id(3)],
         );
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>(qs_2__3_4));
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
         let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(6), test_node_id(7)],
         );
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>(qs_2__5_6_7));
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 
@@ -433,12 +433,12 @@ mod quorum_set_tests {
             2,
             vec![test_node_id(3), test_node_id(4)],
         );
-        quorum_set_1.members.push(QuorumSetMember::<NodeID>(qs_2__3_4));
+        quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
         let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(6), test_node_id(7)],
         );
-        quorum_set_1.members.push(QuorumSetMember::<NodeID>(qs_2__5_6_7));
+        quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
 
         // let quorum_set_2 = quorum_set_from_str("([2], 1, ([2],3,4), 0, ([2],5,6,7))");
         let mut quorum_set_2 = QuorumSet::new_with_node_ids(
@@ -449,16 +449,16 @@ mod quorum_set_tests {
             2,
             vec![test_node_id(4), test_node_id(3)],
         );
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>(qs_2__3_4));
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
 
         let node_0 = test_node_id(0);
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>(node_0));
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>::Node(node_0));
 
         let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(6), test_node_id(7)],
         );
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>(qs_2__5_6_7));
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -386,7 +386,7 @@ mod quorum_set_tests {
 
     #[test]
     // ordering of QuorumSetMembers should not matter
-    fn test_quorum_set_equality() {
+    fn test_quorum_set_equality_with_reordering() {
         let quorum_set_1: QuorumSet = {
             let inner_quorum_set_one = QuorumSet::new_with_node_ids(
                 2,
@@ -395,6 +395,34 @@ mod quorum_set_tests {
             let inner_quorum_set_two = QuorumSet::new_with_node_ids(
                 2,
                 vec![test_node_id(5), test_node_id(6), test_node_id(7)],
+            );
+            QuorumSet::new_with_inner_sets(2, vec![inner_quorum_set_one, inner_quorum_set_two])
+        };
+        let quorum_set_2: QuorumSet = {
+            let inner_quorum_set_one = QuorumSet::new_with_node_ids(
+                2,
+                vec![test_node_id(2), test_node_id(3), test_node_id(4)],
+            );
+            let inner_quorum_set_two = QuorumSet::new_with_node_ids(
+                2,
+                vec![test_node_id(5), test_node_id(7), test_node_id(6)],
+            );
+            QuorumSet::new_with_inner_sets(2, vec![inner_quorum_set_two, inner_quorum_set_one])
+        };
+        assert_eq!(quorum_set_1, quorum_set_2);
+    }
+    
+    #[test]
+    // ordering within inner QuorumSetMembers should not matter
+    fn test_quorum_set_equality_with_inner_set_reordering() {
+        let quorum_set_1: QuorumSet = {
+            let inner_quorum_set_one = QuorumSet::new_with_node_ids(
+                2,
+                vec![test_node_id(2), test_node_id(3), test_node_id(4)],
+            );
+            let inner_quorum_set_two = QuorumSet::new_with_node_ids(
+                2,
+                vec![test_node_id(6), test_node_id(5), test_node_id(7)],
             );
             QuorumSet::new_with_inner_sets(2, vec![inner_quorum_set_one, inner_quorum_set_two])
         };

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -60,7 +60,7 @@ impl<ID: GenericNodeId> Hash for QuorumSet<ID> {
         let mut qs_clone = self.clone();
         qs_clone.sort();
         qs_clone.threshold.hash(state);
-        for m in qs_clone.drain() {
+        for m in qs_clone.members.iter() {
             m.hash(state);
         }
     }

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -531,6 +531,9 @@ mod quorum_set_tests {
         );
         quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
 
+        quorum_set_1.sort();
+        quorum_set_2.sort();
+
         println!("qs1: {}", quorum_set_to_string(&quorum_set_1));
         println!("qs2: {}", quorum_set_to_string(&quorum_set_2));
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -99,10 +99,7 @@ impl<ID: GenericNodeId> QuorumSet<ID> {
     /// Recursively sort the qs and all inner sets
     pub fn sort(&mut self) {
         for member in self.members.iter_mut() {
-            match member {
-                QuorumSetMember::InnerSet(qs) => qs.sort(),
-                _ => {}
-            }
+            if let QuorumSetMember::InnerSet(qs) = member { qs.sort() };
         }
         // sort the members after any internal reordering!
         self.members.sort();

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -402,6 +402,37 @@ mod quorum_set_tests {
     use mc_common::ResponderId;
 
     #[test]
+    // quorum sets should sort recursively
+    fn test_quorum_set_sorting() {
+        // let qs = quorum_set_from_str("([2], 1, ([2], 3, 2, [2],5,7,6))");
+        let mut qs = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(1)],
+        );
+        let mut inner_qs = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(3), test_node_id(2)],
+        );
+        let qs_2__5_7_6 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(5), test_node_id(7), test_node_id(6)],
+        );
+        inner_qs.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
+
+        qs.members.push(QuorumSetMember::<NodeID>::InnerSet(inner_qs));
+
+        let node_0 = test_node_id(0);
+        qs.members.push(QuorumSetMember::<NodeID>::Node(node_0));
+
+        let qs_sorted = qs.clone().sort();
+
+        println!("unsorted: {}", quorum_set_to_string(&qs));
+        println!("  sorted: {}", quorum_set_to_string(&qs_sorted));
+
+        assert_eq!(qs, qs_sorted);
+    }
+
+    #[test]
     // ordering of members should not matter
     fn test_quorum_set_equality_1() {
         let quorum_set_1 = QuorumSet::new_with_node_ids(

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -500,6 +500,9 @@ mod quorum_set_tests {
         );
         quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
 
+        println!("qs1: {}", quorum_set_to_string(quorum_set_1));
+        println!("qs2: {}", quorum_set_to_string(quorum_set_2));
+
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -392,7 +392,7 @@ mod quorum_set_tests {
             2,
             vec![test_node_id(0), test_node_id(1)],
         );
-                let qs_2__3_4 = QuorumSet::new_with_node_ids(
+        let qs_2__3_4 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(3), test_node_id(4)],
         );
@@ -408,16 +408,17 @@ mod quorum_set_tests {
             2,
             vec![test_node_id(1), test_node_id(0)],
         );
-                let qs_2__3_4 = QuorumSet::new_with_node_ids(
+        let qs_2__4_3 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(4), test_node_id(3)],
         );
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
-        let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__4_3));
+        let qs_2__5_7_6 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(6), test_node_id(7)],
         );
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
+        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
+
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 
@@ -447,7 +448,7 @@ mod quorum_set_tests {
         );
         let qs_2__3_4 = QuorumSet::new_with_node_ids(
             2,
-            vec![test_node_id(4), test_node_id(3)],
+            vec![test_node_id(3), test_node_id(4)],
         );
         quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
 
@@ -459,6 +460,7 @@ mod quorum_set_tests {
             vec![test_node_id(5), test_node_id(6), test_node_id(7)],
         );
         quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
+
         assert_eq!(quorum_set_1, quorum_set_2);
     }
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// A member in a QuorumSet. Can be either a Node or another QuorumSet.
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Digestible)]
+#[derive(Clone, Debug, Ord, PartialOrd, Serialize, Deserialize, Digestible)]
 #[serde(tag = "type", content = "args")]
 pub enum QuorumSetMember<ID: GenericNodeId> {
     /// A single trusted entity with an identity.
@@ -27,6 +27,31 @@ pub enum QuorumSetMember<ID: GenericNodeId> {
 
     /// A quorum set can also be a member of a quorum set.
     InnerSet(QuorumSet<ID>),
+}
+
+impl<ID: GenericNodeId> PartialEq for QuorumSetMember<ID> {
+    fn eq(&self, other: &QuorumSetMember<ID>) -> bool {
+        match self {
+            QuorumSetMember::Node(self_node) => match other {
+                QuorumSetMember::Node(other_node) => self_node == other_node,
+                _ => false,
+            },
+            QuorumSetMember::InnerSet(self_qs) => match other {
+                QuorumSetMember::InnerSet(other_qs) => self_qs == other_qs,
+                _ => false,
+            },
+        }
+    }
+}
+impl<ID: GenericNodeId> Eq for QuorumSetMember<ID> {}
+
+impl<ID: GenericNodeId> Hash for QuorumSetMember<ID> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            QuorumSetMember::Node(self_node) => self_node.hash(state),
+            QuorumSetMember::InnerSet(self_qs) => self_qs.hash(state),
+        }
+    }
 }
 
 /// The quorum set defining the trusted set of peers.

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -99,7 +99,7 @@ impl<ID: GenericNodeId> QuorumSet<ID> {
     /// Recursively sort the qs and all inner sets
     pub fn sort(&mut self) {
         self.members.sort();
-        for member in self.members.iter() {
+        for member in self.members.iter_mut() {
             match member {
                 QuorumSetMember::InnerSet(qs) => qs.sort(),
                 _ => {},

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -99,7 +99,9 @@ impl<ID: GenericNodeId> QuorumSet<ID> {
     /// Recursively sort the qs and all inner sets
     pub fn sort(&mut self) {
         for member in self.members.iter_mut() {
-            if let QuorumSetMember::InnerSet(qs) = member { qs.sort() };
+            if let QuorumSetMember::InnerSet(qs) = member {
+                qs.sort()
+            };
         }
         // sort the members after any internal reordering!
         self.members.sort();

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -406,6 +406,34 @@ mod quorum_set_tests {
     use mc_common::ResponderId;
 
     #[test]
+    // ordering of QuorumSetMembers should not matter
+    fn test_quorum_set_equality() {
+        let quorum_set_1: QuorumSet = {
+            let inner_quorum_set_one = QuorumSet::new_with_node_ids(
+                2,
+                vec![test_node_id(2), test_node_id(3), test_node_id(4)],
+            );
+            let inner_quorum_set_two = QuorumSet::new_with_node_ids(
+                2,
+                vec![test_node_id(5), test_node_id(6), test_node_id(7)],
+            );
+            QuorumSet::new_with_inner_sets(2, vec![test_node_id(1), inner_quorum_set_one, inner_quorum_set_two])
+        };
+        let quorum_set_2: QuorumSet = {
+            let inner_quorum_set_one = QuorumSet::new_with_node_ids(
+                2,
+                vec![test_node_id(2), test_node_id(3), test_node_id(4)],
+            );
+            let inner_quorum_set_two = QuorumSet::new_with_node_ids(
+                2,
+                vec![test_node_id(5), test_node_id(7), test_node_id(6)],
+            );
+            QuorumSet::new_with_inner_sets(2, vec![inner_quorum_set_two, test_node_id(1), inner_quorum_set_one])
+        };
+        assert_eq!(quorum_set_1, quorum_set_2);
+    }
+
+    #[test]
     // findBlockingSet returns an empty set when there is no blocking set
     fn test_no_blocking_set() {
         // Node 2 and 3 form a blocking set

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -549,7 +549,7 @@ mod quorum_set_tests {
             ],
         );
         let quorum_set_2 = QuorumSet::new(
-           2,
+            2,
             vec![
                 QuorumSetMember::Node(test_node_id(1)),
                 QuorumSetMember::Node(test_node_id(0)),

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -385,6 +385,85 @@ mod quorum_set_tests {
     use mc_common::ResponderId;
 
     #[test]
+    // ordering of members should not matter
+    fn test_quorum_set_equality_1() {
+        // let quorum_set_1 = quorum_set_from_str("([2], 0, 1, ([2],3,4), ([2],5,6,7))");
+        let mut quorum_set_1 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(0), test_node_id(1)],
+        );
+                let qs_2__3_4 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(3), test_node_id(4)],
+        );
+        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__3_4));
+        let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(5), test_node_id(6), test_node_id(7)],
+        );
+        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__5_6_7));
+
+        // let quorum_set_2 = quorum_set_from_str("([2], 1, 0, ([2],4,3), ([2],5,7,6))");
+        let mut quorum_set_1 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(1), test_node_id(0)],
+        );
+                let qs_2__3_4 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(4), test_node_id(3)],
+        );
+        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__3_4));
+        let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(5), test_node_id(6), test_node_id(7)],
+        );
+        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__5_6_7));
+        assert_eq!(quorum_set_1, quorum_set_2);
+    }
+
+    #[test]
+    // ordering of members should not matter wrt member Enum type
+    fn test_quorum_set_equality_2() {
+        // let quorum_set_1 = quorum_set_from_str("([2], 0, 1, ([2],3,4), ([2],5,6,7))");
+        let mut quorum_set_1 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(0), test_node_id(1)],
+        );
+        let qs_2__3_4 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(3), test_node_id(4)],
+        );
+        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__3_4));
+        let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(5), test_node_id(6), test_node_id(7)],
+        );
+        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__5_6_7));
+
+        // let quorum_set_2 = quorum_set_from_str("([2], 1, ([2],3,4), 0, ([2],5,6,7))");
+        let mut quorum_set_1 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(1)],
+        );
+        let qs_2__3_4 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(4), test_node_id(3)],
+        );
+        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__3_4));
+
+        let node_0 = test_node_id(0);
+        quorum_set_1.members.push(QuorumSetMember<NodeID>(node_0));
+
+        let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
+            2,
+            vec![test_node_id(5), test_node_id(6), test_node_id(7)],
+        );
+        quorum_set_1.members.push(QuorumSetMember<NodeID>(qs_2__5_6_7));
+        assert_eq!(quorum_set_1, quorum_set_2);
+    }
+
+
+    #[test]
     // ordering of QuorumSetMembers should not matter
     fn test_quorum_set_equality_with_reordering() {
         let quorum_set_1: QuorumSet = {
@@ -411,7 +490,7 @@ mod quorum_set_tests {
         };
         assert_eq!(quorum_set_1, quorum_set_2);
     }
-    
+
     #[test]
     // ordering within inner QuorumSetMembers should not matter
     fn test_quorum_set_equality_with_inner_set_reordering() {

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -459,7 +459,7 @@ mod quorum_set_tests {
         let quorum_set_1 = QuorumSet::new(
             2,
             vec![
-                QuorumSetMember::Node(test_node_id(0),
+                QuorumSetMember::Node(test_node_id(0)),
                 QuorumSetMember::Node(test_node_id(1)),
                 QuorumSetMember::InnerSet(QuorumSet::new(
                     2,
@@ -489,7 +489,7 @@ mod quorum_set_tests {
                         QuorumSetMember::Node(test_node_id(4)),
                     ],
                 )),
-                QuorumSetMember::Node(test_node_id(0),
+                QuorumSetMember::Node(test_node_id(0)),
                 QuorumSetMember::InnerSet(QuorumSet::new(
                     2,
                     vec![
@@ -516,7 +516,7 @@ mod quorum_set_tests {
         let quorum_set_1 = QuorumSet::new(
             2,
             vec![
-                QuorumSetMember::Node(test_node_id(0),
+                QuorumSetMember::Node(test_node_id(0)),
                 QuorumSetMember::Node(test_node_id(1)),
                 QuorumSetMember::InnerSet(QuorumSet::new(
                     2,
@@ -538,7 +538,7 @@ mod quorum_set_tests {
         let quorum_set_2 = QuorumSet::new(
            2,
             vec![
-                QuorumSetMember::Node(test_node_id(1),
+                QuorumSetMember::Node(test_node_id(1)),
                 QuorumSetMember::Node(test_node_id(0)),
                 QuorumSetMember::InnerSet(QuorumSet::new(
                     2,

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -447,12 +447,16 @@ mod quorum_set_tests {
         assert_eq!(quorum_set_1, quorum_set_2);
 
         // qs1 == qs2 must imply hash(qs1)==hash(qs2)
-        let mut quorum_set_1_hash = DefaultHasher::new();
-        quorum_set_1.hash(&mut quorum_set_1_hash);
-        quorum_set_1_hash.finish();
-        let mut quorum_set_2_hash = DefaultHasher::new();
-        quorum_set_2.hash(&mut quorum_set_2_hash);
-        quorum_set_2_hash.finish();
+        let quorum_set_1_hash = {
+            let mut hasher = DefaultHasher::new();
+            quorum_set_1.hash(&mut hasher);
+            hasher.finish()
+        };
+        let quorum_set_2_hash = {
+            let mut hasher = DefaultHasher::new();
+            quorum_set_2.hash(&mut hasher);
+            hasher.finish()
+        };
         assert_eq!(quorum_set_1_hash, quorum_set_2_hash);
     }
 
@@ -506,12 +510,16 @@ mod quorum_set_tests {
         assert_eq!(quorum_set_1, quorum_set_2);
 
         // qs1 == qs2 must imply hash(qs1)==hash(qs2)
-        let mut quorum_set_1_hash = DefaultHasher::new();
-        quorum_set_1.hash(&mut quorum_set_1_hash);
-        quorum_set_1_hash.finish();
-        let mut quorum_set_2_hash = DefaultHasher::new();
-        quorum_set_2.hash(&mut quorum_set_2_hash);
-        quorum_set_2_hash.finish();
+        let quorum_set_1_hash = {
+            let mut hasher = DefaultHasher::new();
+            quorum_set_1.hash(&mut hasher);
+            hasher.finish()
+        };
+        let quorum_set_2_hash = {
+            let mut hasher = DefaultHasher::new();
+            quorum_set_2.hash(&mut hasher);
+            hasher.finish()
+        };
         assert_eq!(quorum_set_1_hash, quorum_set_2_hash);
     }
 
@@ -565,12 +573,16 @@ mod quorum_set_tests {
         assert_eq!(quorum_set_1, quorum_set_2);
 
         // qs1 == qs2 must imply hash(qs1)==hash(qs2)
-        let mut quorum_set_1_hash = DefaultHasher::new();
-        quorum_set_1.hash(&mut quorum_set_1_hash);
-        quorum_set_1_hash.finish();
-        let mut quorum_set_2_hash = DefaultHasher::new();
-        quorum_set_2.hash(&mut quorum_set_2_hash);
-        quorum_set_2_hash.finish();
+        let quorum_set_1_hash = {
+            let mut hasher = DefaultHasher::new();
+            quorum_set_1.hash(&mut hasher);
+            hasher.finish()
+        };
+        let quorum_set_2_hash = {
+            let mut hasher = DefaultHasher::new();
+            quorum_set_2.hash(&mut hasher);
+            hasher.finish()
+        };
         assert_eq!(quorum_set_1_hash, quorum_set_2_hash);
     }
 

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -101,7 +101,7 @@ impl<ID: GenericNodeId> QuorumSet<ID> {
         for member in self.members.iter_mut() {
             match member {
                 QuorumSetMember::InnerSet(qs) => qs.sort(),
-                _ => {},
+                _ => {}
             }
         }
         // sort the members after any internal reordering!
@@ -394,31 +394,24 @@ impl<ID: GenericNodeId + AsRef<ResponderId>> From<&QuorumSet<ID>> for QuorumSet<
 #[cfg(test)]
 mod quorum_set_tests {
     use super::*;
-    use crate::{
-        core_types::*,
-        msg::*, predicates::*,
-        test_utils::test_node_id,
-    };
+    use crate::{core_types::*, msg::*, predicates::*, test_utils::test_node_id};
     use mc_common::ResponderId;
 
     #[test]
     // quorum sets should sort recursively
     fn test_quorum_set_sorting() {
-        let mut qs = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(1)],
-        );
-        let mut inner_qs = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(3), test_node_id(2)],
-        );
+        let mut qs = QuorumSet::new_with_node_ids(2, vec![test_node_id(1)]);
+        let mut inner_qs = QuorumSet::new_with_node_ids(2, vec![test_node_id(3), test_node_id(2)]);
         let qs_2__5_7_6 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(7), test_node_id(6)],
         );
-        inner_qs.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
+        inner_qs
+            .members
+            .push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
 
-        qs.members.push(QuorumSetMember::<NodeID>::InnerSet(inner_qs));
+        qs.members
+            .push(QuorumSetMember::<NodeID>::InnerSet(inner_qs));
 
         let node_0 = test_node_id(0);
         qs.members.push(QuorumSetMember::<NodeID>::Node(node_0));
@@ -434,11 +427,21 @@ mod quorum_set_tests {
     fn test_quorum_set_equality_1() {
         let quorum_set_1 = QuorumSet::new_with_node_ids(
             2,
-            vec![test_node_id(0), test_node_id(1), test_node_id(2), test_node_id(3)],
+            vec![
+                test_node_id(0),
+                test_node_id(1),
+                test_node_id(2),
+                test_node_id(3),
+            ],
         );
         let quorum_set_2 = QuorumSet::new_with_node_ids(
             2,
-            vec![test_node_id(3), test_node_id(1), test_node_id(2), test_node_id(0)],
+            vec![
+                test_node_id(3),
+                test_node_id(1),
+                test_node_id(2),
+                test_node_id(0),
+            ],
         );
 
         assert_eq!(quorum_set_1, quorum_set_2);
@@ -447,39 +450,38 @@ mod quorum_set_tests {
     #[test]
     // ordering of members should not matter wrt member Enum type
     fn test_quorum_set_equality_2() {
-        let mut quorum_set_1 = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(0), test_node_id(1)],
-        );
-        let qs_2__3_4 = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(3), test_node_id(4)],
-        );
-        quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
+        let mut quorum_set_1 =
+            QuorumSet::new_with_node_ids(2, vec![test_node_id(0), test_node_id(1)]);
+        let qs_2__3_4 = QuorumSet::new_with_node_ids(2, vec![test_node_id(3), test_node_id(4)]);
+        quorum_set_1
+            .members
+            .push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
         let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(6), test_node_id(7)],
         );
-        quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
+        quorum_set_1
+            .members
+            .push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
 
-        let mut quorum_set_2 = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(1)],
-        );
-        let qs_2__3_4 = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(3), test_node_id(4)],
-        );
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
+        let mut quorum_set_2 = QuorumSet::new_with_node_ids(2, vec![test_node_id(1)]);
+        let qs_2__3_4 = QuorumSet::new_with_node_ids(2, vec![test_node_id(3), test_node_id(4)]);
+        quorum_set_2
+            .members
+            .push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
 
         let node_0 = test_node_id(0);
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>::Node(node_0));
+        quorum_set_2
+            .members
+            .push(QuorumSetMember::<NodeID>::Node(node_0));
 
         let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(6), test_node_id(7)],
         );
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
+        quorum_set_2
+            .members
+            .push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
 
         assert_eq!(quorum_set_1, quorum_set_2);
     }
@@ -487,35 +489,33 @@ mod quorum_set_tests {
     #[test]
     // ordering of members inside inner sets should not matter
     fn test_quorum_set_equality_3() {
-        let mut quorum_set_1 = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(0), test_node_id(1)],
-        );
-        let qs_2__3_4 = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(3), test_node_id(4)],
-        );
-        quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
+        let mut quorum_set_1 =
+            QuorumSet::new_with_node_ids(2, vec![test_node_id(0), test_node_id(1)]);
+        let qs_2__3_4 = QuorumSet::new_with_node_ids(2, vec![test_node_id(3), test_node_id(4)]);
+        quorum_set_1
+            .members
+            .push(QuorumSetMember::<NodeID>::InnerSet(qs_2__3_4));
         let qs_2__5_6_7 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(6), test_node_id(7)],
         );
-        quorum_set_1.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
+        quorum_set_1
+            .members
+            .push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_6_7));
 
-        let mut quorum_set_2 = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(1), test_node_id(0)],
-        );
-        let qs_2__4_3 = QuorumSet::new_with_node_ids(
-            2,
-            vec![test_node_id(4), test_node_id(3)],
-        );
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__4_3));
+        let mut quorum_set_2 =
+            QuorumSet::new_with_node_ids(2, vec![test_node_id(1), test_node_id(0)]);
+        let qs_2__4_3 = QuorumSet::new_with_node_ids(2, vec![test_node_id(4), test_node_id(3)]);
+        quorum_set_2
+            .members
+            .push(QuorumSetMember::<NodeID>::InnerSet(qs_2__4_3));
         let qs_2__5_7_6 = QuorumSet::new_with_node_ids(
             2,
             vec![test_node_id(5), test_node_id(7), test_node_id(6)],
         );
-        quorum_set_2.members.push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
+        quorum_set_2
+            .members
+            .push(QuorumSetMember::<NodeID>::InnerSet(qs_2__5_7_6));
 
         assert_eq!(quorum_set_1, quorum_set_2);
     }

--- a/consensus/scp/src/test_utils.rs
+++ b/consensus/scp/src/test_utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 //! Utilities for Stellar Consensus Protocol tests.
-use crate::{core_types::Value, slot::Slot, QuorumSet, QuorumSetMember, SlotIndex};
+use crate::{core_types::Value, slot::Slot, QuorumSet, SlotIndex};
 use mc_common::{logger::Logger, NodeID, ResponderId};
 use mc_crypto_keys::Ed25519Pair;
 use mc_util_from_random::FromRandom;
@@ -56,19 +56,6 @@ pub fn test_node_id_and_signer(node_id: u32) -> (NodeID, Ed25519Pair) {
         },
         signer_keypair,
     )
-}
-
-/// Recovers the u32 node_id value for a NodeID created using test_node_id_and_signer
-pub fn recover_test_node_index(node_id: &NodeID) -> u32 {
-    node_id
-        .responder_id
-        .0
-        .split('.')
-        .fuse()
-        .next()
-        .expect("unexpected responder_id")[4..]
-        .parse::<u32>()
-        .expect("unable to parse node index")
 }
 
 /// Creates a new slot.
@@ -165,25 +152,4 @@ pub fn three_node_dense_graph() -> (
         QuorumSet::new_with_node_ids(2, vec![test_node_id(1), test_node_id(2)]),
     );
     (node_1, node_2, node_3)
-}
-
-/// creates a easy-to-read string from a QuorumSet<NodeID>
-pub fn quorum_set_to_string(quorum_set: &QuorumSet<NodeID>) -> String {
-    let mut quorum_set_string = format!("([{}]", quorum_set.threshold);
-    for member in quorum_set.members.iter() {
-        match member {
-            QuorumSetMember::Node(node_id) => {
-                quorum_set_string.push_str(&format!(
-                    ",{}",
-                    recover_test_node_index(node_id)
-                ));
-            }
-            QuorumSetMember::InnerSet(inner_set) => {
-                quorum_set_string.push(',');
-                quorum_set_string.push_str(&quorum_set_to_string(inner_set));
-            }
-        }
-    }
-    quorum_set_string.push(')');
-    quorum_set_string
 }

--- a/consensus/scp/src/test_utils.rs
+++ b/consensus/scp/src/test_utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 //! Utilities for Stellar Consensus Protocol tests.
-use crate::{core_types::Value, slot::Slot, QuorumSet, SlotIndex};
+use crate::{core_types::Value, slot::Slot, QuorumSet, QuorumSetMember, SlotIndex};
 use mc_common::{logger::Logger, NodeID, ResponderId};
 use mc_crypto_keys::Ed25519Pair;
 use mc_util_from_random::FromRandom;

--- a/consensus/scp/src/test_utils.rs
+++ b/consensus/scp/src/test_utils.rs
@@ -58,6 +58,19 @@ pub fn test_node_id_and_signer(node_id: u32) -> (NodeID, Ed25519Pair) {
     )
 }
 
+/// Recovers the u32 node_id value for a NodeID created using test_node_id_and_signer
+pub fn recover_test_node_index(node_id: &NodeID) -> u32 {
+    node_id
+        .responder_id
+        .0
+        .split('.')
+        .fuse()
+        .next()
+        .expect("unexpected responder_id")[4..]
+        .parse::<u32>()
+        .expect("unable to parse node index")
+}
+
 /// Creates a new slot.
 pub fn get_slot(
     slot_index: SlotIndex,
@@ -152,4 +165,25 @@ pub fn three_node_dense_graph() -> (
         QuorumSet::new_with_node_ids(2, vec![test_node_id(1), test_node_id(2)]),
     );
     (node_1, node_2, node_3)
+}
+
+/// creates a easy-to-read string from a QuorumSet<NodeID>
+pub fn quorum_set_to_string(quorum_set: &QuorumSet<NodeID>) -> String {
+    let mut quorum_set_string = format!("([{}]", quorum_set.threshold);
+    for member in quorum_set.members.iter() {
+        match member {
+            QuorumSetMember::Node(node_id) => {
+                quorum_set_string.push_str(&format!(
+                    ",{}",
+                    recover_test_node_index(node_id)
+                ));
+            }
+            QuorumSetMember::InnerSet(inner_set) => {
+                quorum_set_string.push(',');
+                quorum_set_string.push_str(&quorum_set_to_string(inner_set));
+            }
+        }
+    }
+    quorum_set_string.push(')');
+    quorum_set_string
 }


### PR DESCRIPTION
### Motivation

QuorumSet equality is incorrect in existing code.

### In this PR
* Fix equality by comparing quorum set members in sorted order

