### PR TITLE
Implement confirmation number

### DIFF
--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -658,7 +658,7 @@ impl<T: UserTxConnection + 'static> TransactionsManager<T> {
         let mut total_value = 0;
         let mut tx_out_to_outlay_index = HashMap::default();
         for (i, outlay) in destinations.iter().enumerate() {
-            let tx_out = tx_builder
+            let (tx_out, _) = tx_builder
                 .add_output(outlay.value, &outlay.receiver, None, rng)
                 .map_err(|err| Error::TxBuildError(format!("failed adding output: {}", err)))?;
 

--- a/transaction/core/src/domain_separators.rs
+++ b/transaction/core/src/domain_separators.rs
@@ -41,3 +41,6 @@ pub const TXOUT_MERKLE_NIL_DOMAIN_TAG: &str = "mc_tx_out_merkle_nil";
 
 /// Domain separator for RingMLSAG's challenges.
 pub const RING_MLSAG_CHALLENGE_DOMAIN_TAG: &str = "mc_ring_mlsag_challenge";
+
+/// Domain separator for hashing the confirmation number
+pub const TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG: &str = "mc_tx_out_confirmation_number";

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -22,7 +22,7 @@ mod blockchain;
 mod commitment;
 mod compressed_commitment;
 pub mod constants;
-mod domain_separators;
+pub mod domain_separators;
 pub mod encrypted_fog_hint;
 pub mod fog_hint;
 pub mod membership_proofs;

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -22,7 +22,7 @@ mod blockchain;
 mod commitment;
 mod compressed_commitment;
 pub mod constants;
-pub mod domain_separators;
+mod domain_separators;
 pub mod encrypted_fog_hint;
 pub mod fog_hint;
 pub mod membership_proofs;

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use alloc::vec::Vec;
+use blake2::digest::Input;
 use core::{
     convert::{TryFrom, TryInto},
     fmt,
@@ -8,7 +9,7 @@ use core::{
 
 use mc_common::{Hash, HashMap};
 use mc_crypto_digestible::Digestible;
-use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate};
+use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
 use mc_util_repr_bytes::{
     derive_prost_message_from_repr_bytes, typenum::U32, GenericArray, ReprBytes,
 };
@@ -20,6 +21,7 @@ use crate::{
     account_keys::PublicAddress,
     amount::{Amount, AmountError},
     blake2b_256::Blake2b256,
+    domain_separators::TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG,
     encrypted_fog_hint::EncryptedFogHint,
     onetime_keys::{compute_shared_secret, compute_tx_pubkey, create_onetime_public_key},
     range::Range,
@@ -401,6 +403,14 @@ derive_prost_message_from_repr_bytes!(TxOutMembershipHash);
 pub struct TxOutConfirmationNumber([u8; 32]);
 
 impl TxOutConfirmationNumber {
+    pub fn new(shared_secret: RistrettoPublic) -> Self {
+        let mut hasher = Blake2b256::new();
+        hasher.input(&TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG);
+        hasher.input(&shared_secret.to_bytes());
+
+        let result: [u8; 32] = hasher.result().into();
+        Self(result)
+    }
     /// Copies self into a new Vec.
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -394,6 +394,53 @@ impl ReprBytes for TxOutMembershipHash {
 
 derive_prost_message_from_repr_bytes!(TxOutMembershipHash);
 
+/// A hash of the shared secret used to confirm tx was sent
+#[derive(
+    Clone, Deserialize, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Debug, Digestible,
+)]
+pub struct TxOutConfirmationNumber([u8; 32]);
+
+impl TxOutConfirmationNumber {
+    /// Copies self into a new Vec.
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}
+
+impl core::convert::AsRef<[u8; 32]> for TxOutConfirmationNumber {
+    #[inline]
+    fn as_ref(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl core::convert::From<&[u8; 32]> for TxOutConfirmationNumber {
+    #[inline]
+    fn from(src: &[u8; 32]) -> Self {
+        Self(*src)
+    }
+}
+
+impl core::convert::From<[u8; 32]> for TxOutConfirmationNumber {
+    #[inline]
+    fn from(src: [u8; 32]) -> Self {
+        Self(src)
+    }
+}
+
+impl ReprBytes for TxOutConfirmationNumber {
+    type Error = &'static str;
+    type Size = U32;
+    fn from_bytes(src: &GenericArray<u8, U32>) -> Result<Self, &'static str> {
+        Ok(Self((*src).into()))
+    }
+    fn to_bytes(&self) -> GenericArray<u8, U32> {
+        self.0.into()
+    }
+}
+
+derive_prost_message_from_repr_bytes!(TxOutConfirmationNumber);
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -5,14 +5,11 @@
 //! See https://cryptonote.org/img/cryptonote_transaction.png
 
 use crate::{InputCredentials, TxBuilderError};
-use blake2::digest::Input;
 use curve25519_dalek::scalar::Scalar;
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
 use mc_transaction_core::{
     account_keys::PublicAddress,
-    blake2b_256::Blake2b256,
     constants::BASE_FEE,
-    domain_separators::TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG,
     encrypted_fog_hint::EncryptedFogHint,
     fog_hint::FogHint,
     onetime_keys::compute_shared_secret,
@@ -73,12 +70,7 @@ impl TransactionBuilder {
         self.outputs_and_shared_secrets
             .push((tx_out.clone(), shared_secret));
 
-        let mut hasher = Blake2b256::new();
-        hasher.input(&TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG);
-        hasher.input(&shared_secret.to_bytes());
-
-        let result: [u8; 32] = hasher.result().into();
-        let confirmation = TxOutConfirmationNumber::from(result);
+        let confirmation = TxOutConfirmationNumber::new(shared_secret);
 
         Ok((tx_out, confirmation))
     }

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -5,16 +5,19 @@
 //! See https://cryptonote.org/img/cryptonote_transaction.png
 
 use crate::{InputCredentials, TxBuilderError};
+use blake2::digest::Input;
 use curve25519_dalek::scalar::Scalar;
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
 use mc_transaction_core::{
     account_keys::PublicAddress,
+    blake2b_256::Blake2b256,
     constants::BASE_FEE,
+    domain_separators::{TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG},
     encrypted_fog_hint::EncryptedFogHint,
     fog_hint::FogHint,
     onetime_keys::compute_shared_secret,
     ring_signature::SignatureRctBulletproofs,
-    tx::{Tx, TxIn, TxOut, TxPrefix},
+    tx::{Tx, TxIn, TxOut, TxOutConfirmationNumber, TxPrefix},
     CompressedCommitment,
 };
 use mc_util_from_random::FromRandom;
@@ -63,13 +66,21 @@ impl TransactionBuilder {
         recipient: &PublicAddress,
         recipient_fog_ingest_key: Option<&RistrettoPublic>,
         rng: &mut RNG,
-    ) -> Result<TxOut, TxBuilderError> {
+    ) -> Result<(TxOut, TxOutConfirmationNumber), TxBuilderError> {
         let (tx_out, shared_secret) =
             create_output(value, recipient, recipient_fog_ingest_key, rng)?;
 
         self.outputs_and_shared_secrets
             .push((tx_out.clone(), shared_secret));
-        Ok(tx_out)
+
+        let mut hasher = Blake2b256::new();
+        hasher.input(&TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG);
+        hasher.input(&shared_secret.to_bytes());
+
+        let result: [u8; 32] = hasher.result().into();
+        let confirmation = TxOutConfirmationNumber::from(result);
+        
+        Ok((tx_out, confirmation))
     }
 
     /// Sets the tombstone block.

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -12,7 +12,7 @@ use mc_transaction_core::{
     account_keys::PublicAddress,
     blake2b_256::Blake2b256,
     constants::BASE_FEE,
-    domain_separators::{TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG},
+    domain_separators::TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG,
     encrypted_fog_hint::EncryptedFogHint,
     fog_hint::FogHint,
     onetime_keys::compute_shared_secret,
@@ -79,7 +79,7 @@ impl TransactionBuilder {
 
         let result: [u8; 32] = hasher.result().into();
         let confirmation = TxOutConfirmationNumber::from(result);
-        
+
         Ok((tx_out, confirmation))
     }
 


### PR DESCRIPTION
Soundtrack of this PR: [https://www.youtube.com/watch?v=Clo0U1BMR5I](My God by Pusha T)

### Motivation

We want to be able to send something to a transaction recipient that demonstrates that we have some secret knowledge that only the creator of the transaction would know.  It doesn't actually prove that we created the transaction, but its close enough for our use case.

### In this PR
* Add TxOutConfirmationNumber and corresponding domain separator
* Create and return it from TransactionBuilder::add_output

fixes #FOG-98

### Future Work
* Integrate confirmation number into sdk and mobilecoind

