### PR TITLE
rename local-network.py to local_network.py so that it could be imported as a python module

### DIFF
--- a/tools/local-network/README.md
+++ b/tools/local-network/README.md
@@ -12,7 +12,7 @@ need private master keys.
 
 This is a simple script to bootstrap a test ledger and keys to play with. The script writes the keys to `target/sample_data/keys` and the ledger to `target_sample_data/ledger`.
 
-## local-network.py
+## local_network.py
 
 This script starts a local mobilecoin consensus network by launching a separate process for each consensus validator and configuring them to communicate via a default set of ports. It takes the following parameters:
 
@@ -33,6 +33,6 @@ of the local drive.
 
 ## mobilecoind.sh
 
-This script starts mobilecoind and connects it to the nodes started by `local-network.py`.
+This script starts mobilecoind and connects it to the nodes started by `local_network.py`.
 
 It has sane defaults and requires no extra configuration.


### PR DESCRIPTION
Soundtrack of this PR: [generic house music](https://soundcloud.com/guy-j/guy-j-echos-12062020)

### Motivation

For some internal work we want to be able to reuse code inside the local network Python script. In order to be able to import it, it needs to match the Python naming conventions.

### In this PR
* Rename `local-network.py` to `local_network.py`
* Some minor structural changes to allow the entry point (`__main__` stuff) to be reused.
