### PR TITLE
New fields in account keys and public addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3025,6 +3025,7 @@ dependencies = [
  "mc-transaction-std",
  "mc-util-serial",
  "mc-util-test-helper",
+ "mc-util-uri",
  "rand 0.7.3",
 ]
 

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -53,31 +53,50 @@ message Ed25519Signature {
     bytes data = 1;
 }
 
-// Complete AccountKey, containing the pair of secret keys, which can be used
-// for spending, and optionally some Fog related info that can be used for spending.
-//
-// This matches the Rust `transaction::AccountKey` struct.
+/// Complete AccountKey, containing the pair of secret keys, which can be used
+/// for spending, and optionally some Fog related info that is used to form
+/// public addresses for accounts that sign up with Fog service.
+///
+/// This matches the Rust `transaction::AccountKey` struct.
 message AccountKey {
-    // Private key 'a' used for view-key matching.
+    /// Private key 'a' used for view-key matching.
     RistrettoPrivate view_private_key = 1;
 
-    // Private key `b` used for spending.
+    /// Private key `b` used for spending.
     RistrettoPrivate spend_private_key = 2;
-
-    // Optional url of fog server. Empty string when not in use.
-    string fog_url = 3;
-}
-
-// A public address, used to identify recipients.
-message PublicAddress {
-    /// View public key
-    RistrettoPublic view_public_key = 1;
-
-    /// Spend public key
-    RistrettoPublic spend_public_key = 2;
 
     /// Optional url of fog server. Empty string when not in use.
     string fog_url = 3;
+
+    /// Optional fingerprint of fog authority key.
+    /// Empty when not in use.
+    bytes fog_authority_key_fingerprint = 4;
+
+    /// Version number used to indicate breaking changes, so that old clients
+    /// fail fast on data they cannot handle, and prompt the user to upgrade.
+    uint32 version = 5;
+}
+
+/// A public address, used to identify recipients.
+message PublicAddress {
+    /// View public key
+    CompressedRistretto view_public_key = 1;
+
+    /// Spend public key
+    CompressedRistretto spend_public_key = 2;
+
+    /// Optional url of fog server. Empty string when not in use.
+    /// Indicates the place at which the fog report server should be contacted.
+    string fog_url = 3;
+
+    /// Signature of fog authority fingerprint using private key which
+    /// corresponds to view_public_key.
+    /// This should be a Schnorrkel signature.
+    bytes fog_authority_sig = 4;
+
+    /// Version number used to indicate breaking changes, so that old clients
+    /// fail fast on data they cannot handle, and prompt the user to upgrade.
+    uint32 version = 5;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -69,14 +69,14 @@ message AccountKey {
     /// Empty string when not in use, i.e. for accounts that don't have fog service.
     string fog_report_url = 3;
 
-    /// Optional fingerprint of fog authority key.
-    /// Empty when not in use.
-    bytes fog_authority_key_fingerprint = 4;
-
     /// Optional fog report key.
     /// The fog report server may serve multiple reports, this key disambiguates
     /// which one to use when sending to this account.
-    string fog_report_key = 5;
+    string fog_report_key = 4;
+
+    /// Optional fingerprint of fog authority key.
+    /// Empty when not in use.
+    bytes fog_authority_key_fingerprint = 5;
 }
 
 /// A public address, used to identify recipients.
@@ -92,15 +92,15 @@ message PublicAddress {
     /// Indicates the place at which the fog report server should be contacted.
     string fog_report_url = 3;
 
-    /// Signature of fog authority fingerprint using private key which
-    /// corresponds to view_public_key.
-    /// This should be a Schnorrkel signature.
-    bytes fog_authority_sig = 4;
-
     /// Optional fog report key.
     /// The fog report server may serve multiple reports, this key disambiguates
     /// which one to use when sending to this account.
-    string fog_report_key = 5;
+    string fog_report_key = 4;
+
+    /// Signature of fog authority fingerprint using private key which
+    /// corresponds to view_public_key.
+    /// This should be a Schnorrkel signature.
+    bytes fog_authority_sig = 5;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -67,7 +67,7 @@ message AccountKey {
 
     /// Optional url of fog report server.
     /// Empty string when not in use, i.e. for accounts that don't have fog service.
-    string fog_url = 3;
+    string fog_report_url = 3;
 
     /// Optional fingerprint of fog authority key.
     /// Empty when not in use.
@@ -90,7 +90,7 @@ message PublicAddress {
     /// Optional url of fog report server.
     /// Empty string when not in use, i.e. for accounts that don't have fog service.
     /// Indicates the place at which the fog report server should be contacted.
-    string fog_url = 3;
+    string fog_report_url = 3;
 
     /// Signature of fog authority fingerprint using private key which
     /// corresponds to view_public_key.

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -65,16 +65,18 @@ message AccountKey {
     /// Private key `b` used for spending.
     RistrettoPrivate spend_private_key = 2;
 
-    /// Optional url of fog server. Empty string when not in use.
+    /// Optional url of fog report server.
+    /// Empty string when not in use, i.e. for accounts that don't have fog service.
     string fog_url = 3;
 
     /// Optional fingerprint of fog authority key.
     /// Empty when not in use.
     bytes fog_authority_key_fingerprint = 4;
 
-    /// Version number used to indicate breaking changes, so that old clients
-    /// fail fast on data they cannot handle, and prompt the user to upgrade.
-    uint32 version = 5;
+    /// Optional fog report key.
+    /// The fog report server may serve multiple reports, this key disambiguates
+    /// which one to use when sending to this account.
+    string fog_report_key = 5;
 }
 
 /// A public address, used to identify recipients.
@@ -85,7 +87,8 @@ message PublicAddress {
     /// Spend public key
     CompressedRistretto spend_public_key = 2;
 
-    /// Optional url of fog server. Empty string when not in use.
+    /// Optional url of fog report server.
+    /// Empty string when not in use, i.e. for accounts that don't have fog service.
     /// Indicates the place at which the fog report server should be contacted.
     string fog_url = 3;
 
@@ -94,9 +97,10 @@ message PublicAddress {
     /// This should be a Schnorrkel signature.
     bytes fog_authority_sig = 4;
 
-    /// Version number used to indicate breaking changes, so that old clients
-    /// fail fast on data they cannot handle, and prompt the user to upgrade.
-    uint32 version = 5;
+    /// Optional fog report key.
+    /// The fog report server may serve multiple reports, this key disambiguates
+    /// which one to use when sending to this account.
+    string fog_report_key = 5;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -807,8 +807,14 @@ impl From<&AccountKey> for external::AccountKey {
 
         if let Some(url) = src.fog_report_url() {
             dst.set_fog_report_url(url.to_string());
-            dst.set_fog_authority_key_fingerprint(src.fog_authority_key_fingerprint.clone());
-            dst.set_fog_report_key(src.fog_report_key.clone());
+        }
+
+        if let Some(fingerprint) = src.fog_authority_key_fingerprint() {
+            dst.set_fog_authority_key_fingerprint(fingerprint.to_vec());
+        }
+
+        if let Some(key) = src.fog_report_key() {
+            dst.set_fog_report_key(key.to_string());
         }
 
         dst
@@ -854,8 +860,14 @@ impl From<&PublicAddress> for external::PublicAddress {
 
         if let Some(url) = src.fog_report_url() {
             dst.set_fog_report_url(url.to_string());
-            dst.set_fog_authority_sig(src.fog_authority_sig.to_vec());
-            dst.set_fog_report_key(src.fog_report_key.clone());
+        }
+
+        if let Some(sig) = src.fog_authority_sig() {
+            dst.set_fog_authority_sig(sig.to_vec());
+        }
+
+        if let Some(key) = src.fog_report_key() {
+            dst.set_fog_report_key(key.to_string());
         }
 
         dst

--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -844,8 +844,8 @@ impl TryFrom<&external::AccountKey> for AccountKey {
                 &spend_private_key,
                 &view_private_key,
                 &src.fog_report_url,
-                &src.fog_authority_key_fingerprint[..],
                 src.fog_report_key.clone(),
+                &src.fog_authority_key_fingerprint[..],
             ))
         }
     }
@@ -897,8 +897,8 @@ impl TryFrom<&external::PublicAddress> for PublicAddress {
                 &spend_public_key,
                 &view_public_key,
                 &src.fog_report_url,
-                src.fog_authority_sig.clone(),
                 src.fog_report_key.clone(),
+                src.fog_authority_sig.clone(),
             ))
         }
     }
@@ -1420,8 +1420,8 @@ mod conversion_tests {
                 tmp_account_key.spend_private_key(),
                 tmp_account_key.view_private_key(),
                 "fog://test.mobilecoin.com".to_string(),
-                vec![9, 9, 9, 9],
                 "99".to_string(),
+                vec![9, 9, 9, 9],
             );
 
             let proto_credentials = external::AccountKey::from(&account_key);
@@ -1488,8 +1488,8 @@ mod conversion_tests {
                 tmp_public_address.spend_public_key(),
                 tmp_public_address.view_public_key(),
                 "fog://test.mobilecoin.com".to_string(),
-                vec![9, 9, 9, 9],
                 "99".to_string(),
+                vec![9, 9, 9, 9],
             );
 
             let proto_credentials = external::PublicAddress::from(&public_address);

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -37,7 +37,7 @@ use mc_crypto_message_cipher::{AesMessageCipher, MessageCipher};
 use mc_crypto_rand::McRng;
 use mc_sgx_compat::sync::Mutex;
 use mc_transaction_core::{
-    account_keys::{PublicAddress, CURRENT_ACCOUNT_KEY_VERSION},
+    account_keys::PublicAddress,
     amount::Amount,
     blake2b_256::Blake2b256,
     constants::{FEE_SPEND_PUBLIC_KEY, FEE_VIEW_PUBLIC_KEY},
@@ -504,7 +504,6 @@ fn mint_aggregate_fee(tx_private_key: &RistrettoPrivate, total_fee: u64) -> Resu
     let fee_recipient = PublicAddress::new(
         &RistrettoPublic::try_from(&FEE_SPEND_PUBLIC_KEY).unwrap(),
         &RistrettoPublic::try_from(&FEE_VIEW_PUBLIC_KEY).unwrap(),
-        CURRENT_ACCOUNT_KEY_VERSION,
     );
 
     // Create a single TxOut
@@ -808,7 +807,6 @@ mod tests {
             let public_address = PublicAddress::new(
                 &RistrettoPublic::try_from(&FEE_SPEND_PUBLIC_KEY).unwrap(),
                 &RistrettoPublic::from(&view_secret_key),
-                CURRENT_ACCOUNT_KEY_VERSION,
             );
             ViewKey::new(view_secret_key, *public_address.spend_public_key())
         };

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -37,7 +37,7 @@ use mc_crypto_message_cipher::{AesMessageCipher, MessageCipher};
 use mc_crypto_rand::McRng;
 use mc_sgx_compat::sync::Mutex;
 use mc_transaction_core::{
-    account_keys::PublicAddress,
+    account_keys::{PublicAddress, CURRENT_ACCOUNT_KEY_VERSION},
     amount::Amount,
     blake2b_256::Blake2b256,
     constants::{FEE_SPEND_PUBLIC_KEY, FEE_VIEW_PUBLIC_KEY},
@@ -504,6 +504,7 @@ fn mint_aggregate_fee(tx_private_key: &RistrettoPrivate, total_fee: u64) -> Resu
     let fee_recipient = PublicAddress::new(
         &RistrettoPublic::try_from(&FEE_SPEND_PUBLIC_KEY).unwrap(),
         &RistrettoPublic::try_from(&FEE_VIEW_PUBLIC_KEY).unwrap(),
+        CURRENT_ACCOUNT_KEY_VERSION,
     );
 
     // Create a single TxOut
@@ -807,6 +808,7 @@ mod tests {
             let public_address = PublicAddress::new(
                 &RistrettoPublic::try_from(&FEE_SPEND_PUBLIC_KEY).unwrap(),
                 &RistrettoPublic::from(&view_secret_key),
+                CURRENT_ACCOUNT_KEY_VERSION,
             );
             ViewKey::new(view_secret_key, *public_address.spend_public_key())
         };

--- a/mobilecoind-json/src/main.rs
+++ b/mobilecoind-json/src/main.rs
@@ -3,7 +3,7 @@
 use grpcio::{ChannelBuilder, ChannelCredentialsBuilder};
 use protobuf::RepeatedField;
 
-use mc_api::external::{KeyImage, PublicAddress, RistrettoPublic};
+use mc_api::external::{CompressedRistretto, KeyImage, PublicAddress};
 use mc_common::logger::{create_app_logger, log, o};
 use mc_mobilecoind_api::mobilecoind_api_grpc::MobilecoindApiClient;
 use rocket::{get, post, routes};
@@ -312,12 +312,12 @@ fn transfer(
         hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
 
     // Decode the keys
-    let mut view_public_key = RistrettoPublic::new();
+    let mut view_public_key = CompressedRistretto::new();
     view_public_key.set_data(
         hex::decode(&transfer.receiver.view_public_key)
             .map_err(|err| format!("Failed to decode view key hex: {}", err))?,
     );
-    let mut spend_public_key = RistrettoPublic::new();
+    let mut spend_public_key = CompressedRistretto::new();
     spend_public_key.set_data(
         hex::decode(&transfer.receiver.spend_public_key)
             .map_err(|err| format!("Failed to decode spend key hex: {}", err))?,

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -133,7 +133,7 @@ impl<T: UserTxConnection + 'static> TransactionsManager<T> {
         // TODO fog service is currently unsupported.
         assert!(!outlays
             .iter()
-            .any(|outlay| outlay.receiver.fog_url().is_some()));
+            .any(|outlay| outlay.receiver.fog_report_url().is_some()));
 
         // Must have at least one output
         if outlays.is_empty() {

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -376,12 +376,13 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
 
         let view_key = receiver.view_public_key().to_bytes();
         let spend_key = receiver.spend_public_key().to_bytes();
-        let fog_url = receiver.fog_url().unwrap_or("");
 
         let payload = RequestPayload::new_v3(
             &view_key,
             &spend_key,
-            fog_url,
+            receiver.version,
+            &receiver.fog_url,
+            &receiver.fog_authority_sig,
             request.get_value(),
             request.get_memo(),
         )

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -380,7 +380,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         let payload = RequestPayload::new_v3(
             &view_key,
             &spend_key,
-            &receiver.fog_url,
+            &receiver.fog_report_url,
             &receiver.fog_authority_sig,
             &receiver.fog_report_key,
             request.get_value(),

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -380,9 +380,9 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         let payload = RequestPayload::new_v3(
             &view_key,
             &spend_key,
-            &receiver.fog_report_url,
-            &receiver.fog_authority_sig,
-            &receiver.fog_report_key,
+            receiver.fog_report_url().unwrap_or(&""),
+            receiver.fog_authority_sig().unwrap_or(&[]),
+            receiver.fog_report_key().unwrap_or(&""),
             request.get_value(),
             request.get_memo(),
         )

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -381,8 +381,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             &view_key,
             &spend_key,
             receiver.fog_report_url().unwrap_or(&""),
-            receiver.fog_authority_sig().unwrap_or(&[]),
             receiver.fog_report_key().unwrap_or(&""),
+            receiver.fog_authority_sig().unwrap_or(&[]),
             request.get_value(),
             request.get_memo(),
         )

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -380,9 +380,9 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         let payload = RequestPayload::new_v3(
             &view_key,
             &spend_key,
-            receiver.version,
             &receiver.fog_url,
             &receiver.fog_authority_sig,
+            &receiver.fog_report_key,
             request.get_value(),
             request.get_memo(),
         )

--- a/transaction/core/src/account_keys.rs
+++ b/transaction/core/src/account_keys.rs
@@ -42,28 +42,28 @@ pub const DEFAULT_SUBADDRESS_INDEX: u64 = 0;
 pub struct PublicAddress {
     /// The user's public subaddress view key 'C'.
     #[prost(message, required, tag = "1")]
-    pub view_public_key: RistrettoPublic,
+    view_public_key: RistrettoPublic,
 
     /// The user's public subaddress spend key `D`.
     #[prost(message, required, tag = "2")]
-    pub spend_public_key: RistrettoPublic,
+    spend_public_key: RistrettoPublic,
 
     /// This is the URL to talk to the fog report server, if the user has a fog service
     /// Empty if no fog for this public address
     /// Should be parseable as mc_util_uri::FogUri.
     #[prost(string, tag = "3")]
-    pub fog_report_url: String,
+    fog_report_url: String,
 
     /// A signature with the user's spend_private_key over the fog authority key fingerprint.
     /// Empty if no fog for this public address
     #[prost(bytes, tag = "4")]
-    pub fog_authority_sig: Vec<u8>,
+    fog_authority_sig: Vec<u8>,
 
     /// The fog report server potentially returns multiple reports when queried.
     /// This value is the key that indicates which of the reports to use.
     /// Empty if no fog for this public address.
     #[prost(string, tag = "5")]
-    pub fog_report_key: String,
+    fog_report_key: String,
 }
 
 impl fmt::Display for PublicAddress {
@@ -174,25 +174,25 @@ impl PublicAddress {
 pub struct AccountKey {
     /// Private key 'a' used for view-key matching.
     #[prost(message, required, tag = "1")]
-    pub view_private_key: RistrettoPrivate,
+    view_private_key: RistrettoPrivate,
 
     /// Private key `b` used for spending.
     #[prost(message, required, tag = "2")]
-    pub spend_private_key: RistrettoPrivate,
+    spend_private_key: RistrettoPrivate,
 
     /// Fog Report server url (if user has Fog service), empty string otherwise
     #[prost(string, tag = "3")]
-    pub fog_report_url: String,
+    fog_report_url: String,
 
     /// Fog Authority Key Fingerprint (if user has Fog service), empty otherwise
     #[prost(bytes, tag = "4")]
-    pub fog_authority_key_fingerprint: Vec<u8>,
+    fog_authority_key_fingerprint: Vec<u8>,
 
     /// Fog Report Key (if user has Fog service), empty otherwise
     /// The key labelling the report to use, from among the several reports
     /// which might be served by the fog report server.
     #[prost(string, tag = "5")]
-    pub fog_report_key: String,
+    fog_report_key: String,
 }
 
 // Note: Hash, Ord is implemented in terms of default_subaddress() because

--- a/transaction/core/src/account_keys.rs
+++ b/transaction/core/src/account_keys.rs
@@ -52,7 +52,7 @@ pub struct PublicAddress {
     /// Empty if no fog for this public address
     /// Should be parseable as mc_util_uri::FogUri.
     #[prost(string, tag = "3")]
-    pub fog_url: String,
+    pub fog_report_url: String,
 
     /// A signature with the user's spend_private_key over the fog authority key fingerprint.
     /// Empty if no fog for this public address
@@ -77,8 +77,8 @@ impl fmt::Display for PublicAddress {
         {
             write!(f, "{:02X}", byte)?;
         }
-        if !self.fog_url.is_empty() {
-            write!(f, ":'{}'", self.fog_url)?;
+        if !self.fog_report_url.is_empty() {
+            write!(f, ":'{}'", self.fog_report_url)?;
         }
         if !self.fog_report_key.is_empty() {
             write!(f, ":{}", self.fog_report_key)?;
@@ -98,7 +98,7 @@ impl PublicAddress {
         Self {
             view_public_key: *view_public_key,
             spend_public_key: *spend_public_key,
-            fog_url: Default::default(),
+            fog_report_url: Default::default(),
             fog_authority_sig: Default::default(),
             fog_report_key: Default::default(),
         }
@@ -109,21 +109,21 @@ impl PublicAddress {
     /// # Arguments
     /// `spend_public_key` - The user's public subaddress spend key `D`,
     /// `view_public_key` - The user's public subaddress view key `C`,
-    /// `fog_url` - User's fog report server url
+    /// `fog_report_url` - User's fog report server url
     /// `fog_authority_sig` - A signature over the fog authority fingerprint using the subaddress_spend_private_key
     /// `fog_report_key` - The key labelling the report to use, from among the several reports which might be served by the fog report server.
     #[inline]
     pub fn new_with_fog(
         spend_public_key: &RistrettoPublic,
         view_public_key: &RistrettoPublic,
-        fog_url: impl ToString,
+        fog_report_url: impl ToString,
         fog_authority_sig: Vec<u8>,
         fog_report_key: String,
     ) -> Self {
         Self {
             view_public_key: *view_public_key,
             spend_public_key: *spend_public_key,
-            fog_url: fog_url.to_string(),
+            fog_report_url: fog_report_url.to_string(),
             fog_authority_sig,
             fog_report_key,
         }
@@ -139,12 +139,12 @@ impl PublicAddress {
         &self.spend_public_key
     }
 
-    /// Get the optional fog url (if it exists / is not empty).
-    pub fn fog_url(&self) -> Option<&str> {
-        if self.fog_url.is_empty() {
+    /// Get the optional fog report url (if it exists / is not empty).
+    pub fn fog_report_url(&self) -> Option<&str> {
+        if self.fog_report_url.is_empty() {
             None
         } else {
-            Some(&self.fog_url)
+            Some(&self.fog_report_url)
         }
     }
 
@@ -182,7 +182,7 @@ pub struct AccountKey {
 
     /// Fog Report server url (if user has Fog service), empty string otherwise
     #[prost(string, tag = "3")]
-    pub fog_url: String,
+    pub fog_report_url: String,
 
     /// Fog Authority Key Fingerprint (if user has Fog service), empty otherwise
     #[prost(bytes, tag = "4")]
@@ -235,7 +235,7 @@ impl AccountKey {
         Self {
             spend_private_key: *spend_private_key,
             view_private_key: *view_private_key,
-            fog_url: Default::default(),
+            fog_report_url: Default::default(),
             fog_authority_key_fingerprint: Default::default(),
             fog_report_key: Default::default(),
         }
@@ -246,7 +246,7 @@ impl AccountKey {
     /// # Arguments
     /// * `spend_private_key` - The user's private spend key `b`.
     /// * `view_private_key` - The user's private view key `a`.
-    /// * `fog_url` - Url of fog report service
+    /// * `fog_report_url` - Url of fog report service
     /// * `fog_authority` - The fingerprint of the public key of the fog authority,
     ///                     which is signed by the user for the public address.
     /// * `fog_report_key` - The key labelling the report to use, from among the
@@ -254,14 +254,14 @@ impl AccountKey {
     pub fn new_with_fog(
         spend_private_key: &RistrettoPrivate,
         view_private_key: &RistrettoPrivate,
-        fog_url: impl ToString,
+        fog_report_url: impl ToString,
         fog_authority: impl AsRef<[u8]>,
         fog_report_key: String,
     ) -> Self {
         Self {
             spend_private_key: *spend_private_key,
             view_private_key: *view_private_key,
-            fog_url: fog_url.to_string(),
+            fog_report_url: fog_report_url.to_string(),
             fog_authority_key_fingerprint: fog_authority.as_ref().to_vec(),
             fog_report_key,
         }
@@ -278,11 +278,11 @@ impl AccountKey {
     }
 
     /// Access the fog url (if it exists).
-    pub fn fog_url(&self) -> Option<&str> {
-        if self.fog_url.is_empty() {
+    pub fn fog_report_url(&self) -> Option<&str> {
+        if self.fog_report_url.is_empty() {
             None
         } else {
-            Some(&self.fog_url)
+            Some(&self.fog_report_url)
         }
     }
 
@@ -355,13 +355,13 @@ impl AccountKey {
         let mut result = PublicAddress {
             view_public_key: subaddress_view_public,
             spend_public_key: subaddress_spend_public,
-            fog_url: self.fog_url.clone(),
+            fog_report_url: self.fog_report_url.clone(),
             fog_authority_sig: Default::default(),
             fog_report_key: self.fog_report_key.clone(),
         };
 
         // Compute fog_authority_sig as a signature over self.fog_authority_key_fingerprint
-        if !self.fog_url.is_empty() {
+        if !self.fog_report_url.is_empty() {
             // FIXME: FOG-106 fog_authority_sig should be a Schnorrkel sig using subaddress_view_private
             result.fog_authority_sig.extend(&[9u8, 9u8, 9u8, 9u8]);
         }

--- a/transaction/core/src/account_keys.rs
+++ b/transaction/core/src/account_keys.rs
@@ -54,16 +54,16 @@ pub struct PublicAddress {
     #[prost(string, tag = "3")]
     fog_report_url: String,
 
-    /// A signature with the user's spend_private_key over the fog authority key fingerprint.
-    /// Empty if no fog for this public address
-    #[prost(bytes, tag = "4")]
-    fog_authority_sig: Vec<u8>,
-
     /// The fog report server potentially returns multiple reports when queried.
     /// This value is the key that indicates which of the reports to use.
     /// Empty if no fog for this public address.
-    #[prost(string, tag = "5")]
+    #[prost(string, tag = "4")]
     fog_report_key: String,
+
+    /// A signature with the user's spend_private_key over the fog authority key fingerprint.
+    /// Empty if no fog for this public address
+    #[prost(bytes, tag = "5")]
+    fog_authority_sig: Vec<u8>,
 }
 
 impl fmt::Display for PublicAddress {
@@ -110,22 +110,22 @@ impl PublicAddress {
     /// `spend_public_key` - The user's public subaddress spend key `D`,
     /// `view_public_key` - The user's public subaddress view key `C`,
     /// `fog_report_url` - User's fog report server url
-    /// `fog_authority_sig` - A signature over the fog authority fingerprint using the subaddress_spend_private_key
     /// `fog_report_key` - The key labelling the report to use, from among the several reports which might be served by the fog report server.
+    /// `fog_authority_sig` - A signature over the fog authority fingerprint using the subaddress_spend_private_key
     #[inline]
     pub fn new_with_fog(
         spend_public_key: &RistrettoPublic,
         view_public_key: &RistrettoPublic,
         fog_report_url: impl ToString,
-        fog_authority_sig: Vec<u8>,
         fog_report_key: String,
+        fog_authority_sig: Vec<u8>,
     ) -> Self {
         Self {
             view_public_key: *view_public_key,
             spend_public_key: *spend_public_key,
             fog_report_url: fog_report_url.to_string(),
-            fog_authority_sig,
             fog_report_key,
+            fog_authority_sig,
         }
     }
 
@@ -184,15 +184,15 @@ pub struct AccountKey {
     #[prost(string, tag = "3")]
     fog_report_url: String,
 
-    /// Fog Authority Key Fingerprint (if user has Fog service), empty otherwise
-    #[prost(bytes, tag = "4")]
-    fog_authority_key_fingerprint: Vec<u8>,
-
     /// Fog Report Key (if user has Fog service), empty otherwise
     /// The key labelling the report to use, from among the several reports
     /// which might be served by the fog report server.
-    #[prost(string, tag = "5")]
+    #[prost(string, tag = "4")]
     fog_report_key: String,
+
+    /// Fog Authority Key Fingerprint (if user has Fog service), empty otherwise
+    #[prost(bytes, tag = "5")]
+    fog_authority_key_fingerprint: Vec<u8>,
 }
 
 // Note: Hash, Ord is implemented in terms of default_subaddress() because
@@ -236,8 +236,8 @@ impl AccountKey {
             spend_private_key: *spend_private_key,
             view_private_key: *view_private_key,
             fog_report_url: Default::default(),
-            fog_authority_key_fingerprint: Default::default(),
             fog_report_key: Default::default(),
+            fog_authority_key_fingerprint: Default::default(),
         }
     }
 
@@ -247,23 +247,23 @@ impl AccountKey {
     /// * `spend_private_key` - The user's private spend key `b`.
     /// * `view_private_key` - The user's private view key `a`.
     /// * `fog_report_url` - Url of fog report service
-    /// * `fog_authority` - The fingerprint of the public key of the fog authority,
-    ///                     which is signed by the user for the public address.
     /// * `fog_report_key` - The key labelling the report to use, from among the
     ///                     several reports which might be served by the fog report server.
+    /// * `fog_authority` - The fingerprint of the public key of the fog authority,
+    ///                     which is signed by the user for the public address.
     pub fn new_with_fog(
         spend_private_key: &RistrettoPrivate,
         view_private_key: &RistrettoPrivate,
         fog_report_url: impl ToString,
-        fog_authority: impl AsRef<[u8]>,
         fog_report_key: String,
+        fog_authority: impl AsRef<[u8]>,
     ) -> Self {
         Self {
             spend_private_key: *spend_private_key,
             view_private_key: *view_private_key,
             fog_report_url: fog_report_url.to_string(),
-            fog_authority_key_fingerprint: fog_authority.as_ref().to_vec(),
             fog_report_key,
+            fog_authority_key_fingerprint: fog_authority.as_ref().to_vec(),
         }
     }
 
@@ -329,8 +329,8 @@ impl AccountKey {
             &RistrettoPrivate::from_random(rng),
             &RistrettoPrivate::from_random(rng),
             "fog://example.com".to_string(),
-            <Vec<u8>>::default(),
             Default::default(),
+            <Vec<u8>>::default(),
         )
     }
 
@@ -356,8 +356,8 @@ impl AccountKey {
             view_public_key: subaddress_view_public,
             spend_public_key: subaddress_spend_public,
             fog_report_url: self.fog_report_url.clone(),
-            fog_authority_sig: Default::default(),
             fog_report_key: self.fog_report_key.clone(),
+            fog_authority_sig: Default::default(),
         };
 
         // Compute fog_authority_sig as a signature over self.fog_authority_key_fingerprint

--- a/transaction/core/src/account_keys.rs
+++ b/transaction/core/src/account_keys.rs
@@ -13,37 +13,59 @@
 #![allow(non_snake_case)]
 
 use crate::{domain_separators::SUBADDRESS_DOMAIN_TAG, view_key::ViewKey};
-use alloc::string::{String, ToString};
-use blake2::{Blake2b, Digest};
+
 use core::{
     cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
 };
-use curve25519_dalek::scalar::Scalar;
+
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use mc_crypto_digestible::Digestible;
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use mc_util_from_random::FromRandom;
+
+use blake2::{Blake2b, Digest};
+use curve25519_dalek::scalar::Scalar;
 use prost::Message;
 use rand_core::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
 
 /// An account's "default address" is its zero^th subaddress.
 pub const DEFAULT_SUBADDRESS_INDEX: u64 = 0;
 
+/// An account's version number. If breaking changes are made to the interpretation
+/// of account keys or public addresses, this should be incremented so that old clients
+/// will fail fast on data they shouldn't handle.
+pub const CURRENT_ACCOUNT_KEY_VERSION: u32 = 0;
+
 /// A MobileCoin user's public subaddress.
-#[derive(
-    PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug, Serialize, Deserialize, Clone, Digestible,
-)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Message, Clone, Digestible)]
 pub struct PublicAddress {
     /// The user's public subaddress view key 'C'.
-    view_public_key: RistrettoPublic,
+    #[prost(message, required, tag = "1")]
+    pub view_public_key: RistrettoPublic,
 
     /// The user's public subaddress spend key `D`.
-    spend_public_key: RistrettoPublic,
+    #[prost(message, required, tag = "2")]
+    pub spend_public_key: RistrettoPublic,
 
     /// Fog Url, if the user has a fog service
-    fog_url: Option<String>,
+    /// Should be parseable as mc_util_uri::FogUri.
+    #[prost(string, tag = "3")]
+    pub fog_url: String,
+
+    /// A signature with the user's view_private_key over the fog authority key fingerprint.
+    /// Empty if no fog for this address
+    #[prost(bytes, tag = "4")]
+    pub fog_authority_sig: Vec<u8>,
+
+    /// Version number of this data.
+    #[prost(uint32, tag = "5")]
+    pub version: u32,
 }
 
 impl fmt::Display for PublicAddress {
@@ -57,8 +79,8 @@ impl fmt::Display for PublicAddress {
         {
             write!(f, "{:02X}", byte)?;
         }
-        if let Some(ref name) = self.fog_url {
-            write!(f, ":'{}'", name)?;
+        if !self.fog_url.is_empty() {
+            write!(f, ":'{}'", self.fog_url)?;
         }
         Ok(())
     }
@@ -71,30 +93,41 @@ impl PublicAddress {
     /// `spend_public_key` - The user's public subaddress spend key `D`,
     /// `view_public_key` - The user's public subaddress view key  `C`,
     #[inline]
-    pub fn new(spend_public_key: &RistrettoPublic, view_public_key: &RistrettoPublic) -> Self {
+    pub fn new(
+        spend_public_key: &RistrettoPublic,
+        view_public_key: &RistrettoPublic,
+        version: u32,
+    ) -> Self {
         Self {
             view_public_key: *view_public_key,
             spend_public_key: *spend_public_key,
-            fog_url: None,
+            fog_url: Default::default(),
+            fog_authority_sig: Default::default(),
+            version,
         }
     }
 
-    /// Create a new public address from specific secret keys and account service name.
+    /// Create a new public address with specific public keys and account service name and authority sig.
     ///
     /// # Arguments
     /// `spend_public_key` - The user's public subaddress spend key `D`,
     /// `view_public_key` - The user's public subaddress view key `C`,
     /// `fog_url` - User's fog url
+    /// `
     #[inline]
     pub fn new_with_fog(
         spend_public_key: &RistrettoPublic,
         view_public_key: &RistrettoPublic,
         fog_url: impl ToString,
+        fog_authority_sig: Vec<u8>,
+        version: u32,
     ) -> Self {
         Self {
             view_public_key: *view_public_key,
             spend_public_key: *spend_public_key,
-            fog_url: Some(fog_url.to_string()),
+            fog_url: fog_url.to_string(),
+            fog_authority_sig,
+            version,
         }
     }
 
@@ -110,26 +143,38 @@ impl PublicAddress {
 
     /// Get the optional fog url.
     pub fn fog_url(&self) -> Option<&str> {
-        self.fog_url.as_deref()
+        if self.fog_url.is_empty() {
+            None
+        } else {
+            Some(&self.fog_url)
+        }
     }
 }
 
 /// Complete AccountKey, containing the pair of secret keys, which can be used
 /// for spending, and optionally some fog-related info,
 /// can be used for spending. This should only ever be present in client code.
-#[derive(Clone, Serialize, Deserialize, Message)]
+#[derive(Clone, Message)]
 pub struct AccountKey {
     /// Private key 'a' used for view-key matching.
     #[prost(message, required, tag = "1")]
-    view_private_key: RistrettoPrivate,
+    pub view_private_key: RistrettoPrivate,
 
     /// Private key `b` used for spending.
     #[prost(message, required, tag = "2")]
-    spend_private_key: RistrettoPrivate,
+    pub spend_private_key: RistrettoPrivate,
 
     /// Fog URL (if user has Fog service)
     #[prost(string, tag = "3")]
-    fog_url: String,
+    pub fog_url: String,
+
+    /// Fog Authority Key Fingerprint (if user has Fog service)
+    #[prost(bytes, tag = "4")]
+    pub fog_authority_key_fingerprint: Vec<u8>,
+
+    /// Version number of this data
+    #[prost(uint32, tag = "5")]
+    pub version: u32,
 }
 
 impl Hash for AccountKey {
@@ -166,11 +211,17 @@ impl AccountKey {
     /// * `spend_private_key` - The user's private spend key `b`.
     /// * `view_private_key` - The user's private view key `a`.
     #[inline]
-    pub fn new(spend_private_key: &RistrettoPrivate, view_private_key: &RistrettoPrivate) -> Self {
+    pub fn new(
+        spend_private_key: &RistrettoPrivate,
+        view_private_key: &RistrettoPrivate,
+        version: u32,
+    ) -> Self {
         Self {
             spend_private_key: *spend_private_key,
             view_private_key: *view_private_key,
             fog_url: "".to_string(),
+            fog_authority_key_fingerprint: Default::default(),
+            version,
         }
     }
 
@@ -184,11 +235,15 @@ impl AccountKey {
         spend_private_key: &RistrettoPrivate,
         view_private_key: &RistrettoPrivate,
         fog_url: impl ToString,
+        fog_authority: impl AsRef<[u8]>,
+        version: u32,
     ) -> Self {
         Self {
             spend_private_key: *spend_private_key,
             view_private_key: *view_private_key,
             fog_url: fog_url.to_string(),
+            fog_authority_key_fingerprint: fog_authority.as_ref().to_vec(),
+            version,
         }
     }
 
@@ -228,6 +283,7 @@ impl AccountKey {
         Self::new(
             &RistrettoPrivate::from_random(rng),
             &RistrettoPrivate::from_random(rng),
+            CURRENT_ACCOUNT_KEY_VERSION,
         )
     }
 
@@ -240,6 +296,8 @@ impl AccountKey {
             &RistrettoPrivate::from_random(rng),
             &RistrettoPrivate::from_random(rng),
             "example.com".to_string(),
+            <Vec<u8>>::default(),
+            CURRENT_ACCOUNT_KEY_VERSION,
         )
     }
 
@@ -261,14 +319,20 @@ impl AccountKey {
             RistrettoPublic::from(&subaddress_spend_private)
         };
 
-        match self.fog_url() {
-            None => PublicAddress::new(&subaddress_spend_public, &subaddress_view_public),
-            Some(fog_url) => PublicAddress::new_with_fog(
-                &subaddress_spend_public,
-                &subaddress_view_public,
-                fog_url,
-            ),
+        let mut result = PublicAddress {
+            view_public_key: subaddress_view_public,
+            spend_public_key: subaddress_spend_public,
+            fog_url: self.fog_url.clone(),
+            fog_authority_sig: Default::default(),
+            version: self.version,
+        };
+
+        if !self.fog_url.is_empty() {
+            // FIXME: fog_authority_sig should be a Schnorrkel sig using subaddress_view_private
+            result.fog_authority_sig.extend(&[9u8, 9u8, 9u8, 9u8]);
         }
+
+        result
     }
 
     /// The private spend key for the default subaddress.
@@ -326,19 +390,19 @@ mod account_key_tests {
     use rand_core::SeedableRng;
 
     #[test]
-    //Deserializing should recover a serialized a PublicAddress.
-    fn mc_util_serial_roundtrip_public_address() {
+    // Deserializing should recover a serialized a PublicAddress.
+    fn mc_util_serial_prost_roundtrip_public_address() {
         mc_util_test_helper::run_with_several_seeds(|mut rng| {
             {
                 let acct = AccountKey::random(&mut rng);
-                let ser = mc_util_serial::serialize(&acct.default_subaddress()).unwrap();
-                let result: PublicAddress = mc_util_serial::deserialize(&ser).unwrap();
+                let ser = mc_util_serial::encode(&acct.default_subaddress());
+                let result: PublicAddress = mc_util_serial::decode(&ser).unwrap();
                 assert_eq!(acct.default_subaddress(), result);
             }
             {
                 let acct = AccountKey::random_with_fog(&mut rng);
-                let ser = mc_util_serial::serialize(&acct.default_subaddress()).unwrap();
-                let result: PublicAddress = mc_util_serial::deserialize(&ser).unwrap();
+                let ser = mc_util_serial::encode(&acct.default_subaddress());
+                let result: PublicAddress = mc_util_serial::decode(&ser).unwrap();
                 assert_eq!(acct.default_subaddress(), result);
             }
         });
@@ -351,7 +415,7 @@ mod account_key_tests {
         let view_private = RistrettoPrivate::from_random(&mut rng);
         let spend_private = RistrettoPrivate::from_random(&mut rng);
 
-        let account_key = AccountKey::new(&spend_private, &view_private);
+        let account_key = AccountKey::new(&spend_private, &view_private, 0);
 
         let index = rng.next_u64();
         let subaddress = account_key.subaddress(index);

--- a/transaction/std/src/identity.rs
+++ b/transaction/std/src/identity.rs
@@ -17,7 +17,6 @@ use serde::{Deserialize, Serialize};
 use std::convert::From;
 
 pub const TEST_FOG_AUTHORITY_FINGERPRINT: [u8; 4] = [9, 9, 9, 9];
-
 pub const TEST_FOG_REPORT_KEY: &str = "";
 
 /// A RootIdentity is used to quickly derive an AccountKey from 32 bytes of entropy
@@ -56,8 +55,8 @@ impl From<&RootIdentity> for AccountKey {
                 &spend_private_key,
                 &view_private_key,
                 url.clone(),
-                TEST_FOG_AUTHORITY_FINGERPRINT,
                 TEST_FOG_REPORT_KEY.to_string(),
+                TEST_FOG_AUTHORITY_FINGERPRINT,
             ),
             None => AccountKey::new(&spend_private_key, &view_private_key),
         }

--- a/transaction/std/src/identity.rs
+++ b/transaction/std/src/identity.rs
@@ -11,15 +11,14 @@ use core::hash::Hash;
 use curve25519_dalek::scalar::Scalar;
 use hkdf::Hkdf;
 use mc_crypto_keys::RistrettoPrivate;
-use mc_transaction_core::{
-    account_keys::{AccountKey, CURRENT_ACCOUNT_KEY_VERSION},
-    blake2b_256::Blake2b256,
-};
+use mc_transaction_core::{account_keys::AccountKey, blake2b_256::Blake2b256};
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::convert::From;
 
 pub const TEST_FOG_AUTHORITY_FINGERPRINT: [u8; 4] = [9, 9, 9, 9];
+
+pub const TEST_FOG_REPORT_KEY: &str = "";
 
 /// A RootIdentity is used to quickly derive an AccountKey from 32 bytes of entropy
 /// for testing purposes. It should not be used to derive AccountKeys outside of a
@@ -58,13 +57,9 @@ impl From<&RootIdentity> for AccountKey {
                 &view_private_key,
                 url.clone(),
                 TEST_FOG_AUTHORITY_FINGERPRINT,
-                CURRENT_ACCOUNT_KEY_VERSION,
+                TEST_FOG_REPORT_KEY.to_string(),
             ),
-            None => AccountKey::new(
-                &spend_private_key,
-                &view_private_key,
-                CURRENT_ACCOUNT_KEY_VERSION,
-            ),
+            None => AccountKey::new(&spend_private_key, &view_private_key),
         }
     }
 }

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -221,13 +221,13 @@ fn create_fog_hint<RNG: CryptoRng + RngCore>(
 ) -> Result<EncryptedFogHint, TxBuilderError> {
     match maybe_ingest_pubkey {
         Some(ingest_pubkey) => {
-            if recipient.fog_url().is_none() {
+            if recipient.fog_report_url().is_none() {
                 return Err(TxBuilderError::IngestPubkeyUnexpectedlyProvided);
             }
             Ok(FogHint::from(recipient).encrypt(ingest_pubkey, rng))
         }
         None => {
-            if recipient.fog_url().is_some() {
+            if recipient.fog_report_url().is_some() {
                 return Err(TxBuilderError::IngestPubkeyNotProvided);
             }
             Ok(EncryptedFogHint::fake_onetime_hint(rng))

--- a/util/b58-payloads/Cargo.toml
+++ b/util/b58-payloads/Cargo.toml
@@ -12,9 +12,10 @@ crc = "1.8.1"
 
 # MobileCoin dependencies
 mc-crypto-keys = { path = "../../crypto/keys" }
-mc-util-serial = { path = "../../util/serial" }
 mc-transaction-core = { path = "../../transaction/core" }
 mc-transaction-std = { path = "../../transaction/std" }
+mc-util-uri = { path = "../../util/uri" }
+mc-util-serial = { path = "../../util/serial" }
 
 [dev-dependencies]
 rand = "0.7"

--- a/util/b58-payloads/src/error.rs
+++ b/util/b58-payloads/src/error.rs
@@ -2,6 +2,7 @@
 
 use failure::Fail;
 use mc_crypto_keys::KeyError;
+use mc_util_uri::UriParseError;
 use std::string::FromUtf8Error;
 
 #[derive(Clone, Debug, Eq, PartialEq, Fail)]
@@ -27,8 +28,8 @@ pub enum Error {
     Utf8ParsingError,
 
     /// Unable to convert string to a URL.
-    #[fail(display = "Invalid fog service URL")]
-    FogUrlParsingError,
+    #[fail(display = "Invalid fog service URL: {}", _0)]
+    FogUrlParsingError(UriParseError),
 
     /// A public key is not a valid Ristretto point.
     #[fail(display = "Invalid public key: {:?}", _0)]

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -5,12 +5,11 @@ use crate::error::Error;
 use core::{convert::TryFrom, fmt};
 use std::str::FromStr;
 
+use crc::crc32;
 use mc_crypto_keys::{KeyError, RistrettoPublic};
 use mc_transaction_core::account_keys::{AccountKey, PublicAddress};
 use mc_transaction_std::identity::RootIdentity;
 use mc_util_uri::FogUri;
-
-use crc::crc32;
 
 /// Type of payload standard encoding.
 #[repr(u8)] // we don't expect to ever need more than 255 payload types

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -332,8 +332,8 @@ impl TryFrom<&RequestPayload> for PublicAddress {
                 &spend_key,
                 &view_key,
                 &src.fog_report_url,
-                src.fog_authority_sig.clone(),
                 src.fog_report_key.clone(),
+                src.fog_authority_sig.clone(),
             )
         })
     }
@@ -610,8 +610,8 @@ mod testing {
             &RistrettoPublic::try_from(&alice_spend).unwrap(),
             &RistrettoPublic::try_from(&alice_view).unwrap(),
             alice_fog_url,
-            alice_fog_sig,
             "".to_string(),
+            alice_fog_sig,
         );
         let alice_request_payload = RequestPayload::try_from(&alice_public).unwrap();
         let alice_b58_str = alice_request_payload.encode();
@@ -636,8 +636,8 @@ mod testing {
             &RistrettoPublic::try_from(&bob_spend).unwrap(),
             &RistrettoPublic::try_from(&bob_view).unwrap(),
             bob_fog_url,
-            bob_fog_sig,
             99.to_string(),
+            bob_fog_sig,
         );
         let bob_request_payload = RequestPayload::try_from(&bob_public).unwrap();
         let bob_b58_str = bob_request_payload.encode();

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -210,8 +210,8 @@ impl RequestPayload {
             view_public_key: *view_key,
             spend_public_key: *spend_key,
             fog_report_url: "".to_owned(),
-            fog_authority_sig: Default::default(),
             fog_report_key: Default::default(),
+            fog_authority_sig: Default::default(),
             value: 0,
             memo: "".to_owned(),
         })
@@ -222,14 +222,14 @@ impl RequestPayload {
         view_key: &[u8; 32],
         spend_key: &[u8; 32],
         fog_report_url: &str,
-        fog_authority_sig: &[u8],
         fog_report_key: &str,
+        fog_authority_sig: &[u8],
     ) -> Result<Self, Error> {
         let mut result = RequestPayload::new_v0(view_key, spend_key)?;
         validate_fog_report_url(fog_report_url)?;
         result.fog_report_url = fog_report_url.to_owned();
-        result.fog_authority_sig = fog_authority_sig.to_vec();
         result.fog_report_key = fog_report_key.to_owned();
+        result.fog_authority_sig = fog_authority_sig.to_vec();
         result.version = 1;
         Ok(result)
     }
@@ -239,16 +239,16 @@ impl RequestPayload {
         view_key: &[u8; 32],
         spend_key: &[u8; 32],
         fog_report_url: &str,
-        fog_authority_sig: &[u8],
         fog_report_key: &str,
+        fog_authority_sig: &[u8],
         value: u64,
     ) -> Result<Self, Error> {
         let mut result = RequestPayload::new_v1(
             view_key,
             spend_key,
             fog_report_url,
-            fog_authority_sig,
             fog_report_key,
+            fog_authority_sig,
         )?;
         result.value = value;
         result.version = 2;
@@ -260,8 +260,8 @@ impl RequestPayload {
         view_key: &[u8; 32],
         spend_key: &[u8; 32],
         fog_report_url: &str,
-        fog_authority_sig: &[u8],
         fog_report_key: &str,
+        fog_authority_sig: &[u8],
         value: u64,
         memo: &str,
     ) -> Result<Self, Error> {
@@ -269,8 +269,8 @@ impl RequestPayload {
             view_key,
             spend_key,
             fog_report_url,
-            fog_authority_sig,
             fog_report_key,
+            fog_authority_sig,
             value,
         )?;
         validate_memo(memo)?;

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -349,8 +349,12 @@ impl TryFrom<&PublicAddress> for RequestPayload {
         if let Some(fog_report_url_string) = src.fog_report_url() {
             payload.version = 1;
             payload.fog_report_url = fog_report_url_string.to_string();
-            payload.fog_authority_sig = src.fog_authority_sig.clone();
-            payload.fog_report_key = src.fog_report_key.clone();
+            if let Some(sig) = src.fog_authority_sig() {
+                payload.fog_authority_sig = sig.to_vec();
+            }
+            if let Some(key) = src.fog_report_key() {
+                payload.fog_report_key = key.to_string();
+            }
         }
         Ok(payload)
     }

--- a/util/test-helper/src/known_accounts.rs
+++ b/util/test-helper/src/known_accounts.rs
@@ -2,7 +2,7 @@
 
 //! This module provides a consistent set of AccountKeys for use in testing
 
-use crate::{AccountKey, PublicAddress};
+use mc_transaction_core::account_keys::{AccountKey, PublicAddress, CURRENT_ACCOUNT_KEY_VERSION};
 use mc_transaction_std::identity::RootIdentity;
 use rand::rngs::StdRng;
 use rand_core::SeedableRng;
@@ -79,6 +79,7 @@ macro_rules! build_derived_account_keys {
                     keys.push(AccountKey::new(
                         acct.spend_private_key(),
                         acct.view_private_key(),
+                        CURRENT_ACCOUNT_KEY_VERSION,
                     ));
                 )+
                 keys

--- a/util/test-helper/src/known_accounts.rs
+++ b/util/test-helper/src/known_accounts.rs
@@ -2,7 +2,7 @@
 
 //! This module provides a consistent set of AccountKeys for use in testing
 
-use mc_transaction_core::account_keys::{AccountKey, PublicAddress, CURRENT_ACCOUNT_KEY_VERSION};
+use mc_transaction_core::account_keys::{AccountKey, PublicAddress};
 use mc_transaction_std::identity::RootIdentity;
 use rand::rngs::StdRng;
 use rand_core::SeedableRng;
@@ -79,7 +79,6 @@ macro_rules! build_derived_account_keys {
                     keys.push(AccountKey::new(
                         acct.spend_private_key(),
                         acct.view_private_key(),
-                        CURRENT_ACCOUNT_KEY_VERSION,
                     ));
                 )+
                 keys

--- a/util/uri/src/uri.rs
+++ b/util/uri/src/uri.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use url::Url;
 
-#[derive(Debug, Display)]
+#[derive(Clone, Eq, PartialEq, Debug, Display)]
 pub enum UriParseError {
     /// Url parse error: {0}
     UrlParse(url::ParseError),


### PR DESCRIPTION
Soundtrack of this PR: https://www.youtube.com/watch?v=gHUBYt1oPio

### Motivation

We must make some changes where we add some fields to account key and public address.
We need to incorporate the fog authority key fingerprint and the user's signature over that fingerprint,
in order to establish a complete chain of trust back to Bob whenever Alice wants to use a fog report
to send money to Bob.
In earlier discussion we considered encoding this as query parameters in fog-url, but that was only
to avoid making any changes to the b58-encoding. The b58-encoding has changed a lot since then
and has become much simpler to update.
We also should add version numbers to account keys / public addresses soon if we want to have that
for release. Otherwise it will be difficult or impossible to change the meaning of any of the fields. 

### In this PR

 Add fog_authority_key_fingerprint to AccountKey, sig to PublicAddress

This just adds fields to the structures, it doesn't actually compute
signatures or give them the right values, or check the signatures.

It also adds version numbers to both structs. This gives us an
escape if we have to make backwards incompatible changes to the way
that public addresses are handled, fog reports are looked up, change
the interpretations of some of these fields, etc.

This also removes Serde serialization of public address, which was
only being used in the keyfile. It makes public address implement
prost instead.

This also removes external.RistrettoPublic from the proto for
public address. It replaces it with CompressedRistretto and adds
some more missing conversions. This leads to small changes in mobilecoind.

This also updates the b58-payloads format to include the version number
and the fog authority sig. I believe that this change is backwards
compatible for any payload not containing fog data.

We should possible delete RistrettoPublic message in external.proto,
I believe that it should never be used.

### Future Work

- Remove RistrettoPublic from external.proto
- Remove serialization traits for RistrettoPublic rust type
- Consider making a simpler URL encoding of Public Address using query parameters to encode different optional components. - While the b58 encoding is very small on the wire, it is hard to create without having libmobilecoin. A version using query parameters may be easier for a human to inspect, and easy to create and destructure in javascript even without having libmobilecoin, i.e. having only a standard url lib and protobufs. (this is https://github.com/mobilecoinofficial/mobilecoin/pull/242)

### TODO

Try to ensure that this will not break testnet, or accept that users may have to download mobilecoind again, and learn from what happened.