### PR TITLE
Change confirmation ::new to ::from and add a unit test

### DIFF
--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -403,14 +403,6 @@ derive_prost_message_from_repr_bytes!(TxOutMembershipHash);
 pub struct TxOutConfirmationNumber([u8; 32]);
 
 impl TxOutConfirmationNumber {
-    pub fn new(shared_secret: RistrettoPublic) -> Self {
-        let mut hasher = Blake2b256::new();
-        hasher.input(&TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG);
-        hasher.input(&shared_secret.to_bytes());
-
-        let result: [u8; 32] = hasher.result().into();
-        Self(result)
-    }
     /// Copies self into a new Vec.
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()
@@ -435,6 +427,18 @@ impl core::convert::From<[u8; 32]> for TxOutConfirmationNumber {
     #[inline]
     fn from(src: [u8; 32]) -> Self {
         Self(src)
+    }
+}
+
+impl core::convert::From<RistrettoPublic> for TxOutConfirmationNumber {
+    #[inline]
+    fn from(shared_secret: RistrettoPublic) -> Self {
+        let mut hasher = Blake2b256::new();
+        hasher.input(&TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG);
+        hasher.input(&shared_secret.to_bytes());
+
+        let result: [u8; 32] = hasher.result().into();
+        Self(result)
     }
 }
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -430,12 +430,11 @@ impl core::convert::From<[u8; 32]> for TxOutConfirmationNumber {
     }
 }
 
-impl core::convert::From<RistrettoPublic> for TxOutConfirmationNumber {
-    #[inline]
-    fn from(shared_secret: RistrettoPublic) -> Self {
+impl core::convert::From<&RistrettoPublic> for TxOutConfirmationNumber {
+    fn from(shared_secret: &RistrettoPublic) -> Self {
         let mut hasher = Blake2b256::new();
         hasher.input(&TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG);
-        hasher.input(&shared_secret.to_bytes());
+        hasher.input(shared_secret.to_bytes());
 
         let result: [u8; 32] = hasher.result().into();
         Self(result)

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -70,7 +70,7 @@ impl TransactionBuilder {
         self.outputs_and_shared_secrets
             .push((tx_out.clone(), shared_secret));
 
-        let confirmation = TxOutConfirmationNumber::new(shared_secret);
+        let confirmation = TxOutConfirmationNumber::from(shared_secret);
 
         Ok((tx_out, confirmation))
     }
@@ -379,8 +379,9 @@ pub mod transaction_builder_tests {
         .unwrap();
 
         let mut transaction_builder = TransactionBuilder::new();
+
         transaction_builder.add_input(input_credentials);
-        transaction_builder
+        let (_txout, confirmation) = transaction_builder
             .add_output(
                 value - BASE_FEE,
                 &recipient.default_subaddress(),
@@ -413,12 +414,15 @@ pub mod transaction_builder_tests {
             ));
         }
 
-        // The output should have the correct value.
+        // The output should have the correct value and confirmation number
         {
             let public_key = RistrettoPublic::try_from(&output.public_key).unwrap();
             let shared_secret = get_tx_out_shared_secret(recipient.view_private_key(), &public_key);
             let (output_value, _blinding) = output.amount.get_value(&shared_secret).unwrap();
             assert_eq!(output_value, value - BASE_FEE);
+            let calculated_confirmation = TxOutConfirmationNumber::from(shared_secret);
+
+            assert_eq!(confirmation, calculated_confirmation);
         }
 
         // The transaction should have a valid signature.

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -70,7 +70,7 @@ impl TransactionBuilder {
         self.outputs_and_shared_secrets
             .push((tx_out.clone(), shared_secret));
 
-        let confirmation = TxOutConfirmationNumber::from(shared_secret);
+        let confirmation = TxOutConfirmationNumber::from(&shared_secret);
 
         Ok((tx_out, confirmation))
     }
@@ -420,7 +420,7 @@ pub mod transaction_builder_tests {
             let shared_secret = get_tx_out_shared_secret(recipient.view_private_key(), &public_key);
             let (output_value, _blinding) = output.amount.get_value(&shared_secret).unwrap();
             assert_eq!(output_value, value - BASE_FEE);
-            let calculated_confirmation = TxOutConfirmationNumber::from(shared_secret);
+            let calculated_confirmation = TxOutConfirmationNumber::from(&shared_secret);
 
             assert_eq!(confirmation, calculated_confirmation);
         }


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

The initial TxOutConfirmationNumber PR was pushed out quickly so that clients could start using it.  But there were a couple of small items in the review comments that were promised in an add-on PR.  This PR will satisfy those review comments.

### In this PR
* Change TxOutConfirmationNumber::new() to TxOutConfirmationNumber::from() since the latter is more canonical Rust
* Add a unit test that verifies the return from TxBuilder::add_output is the same as would be calculated from the shared_secret directly

This change completes FOG-98.

### Future Work
This is the final piece of this work.
