### PR TITLE
Mob url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,6 +3249,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-util-url-encoding"
+version = "0.4.0"
+dependencies = [
+ "base64 0.11.0",
+ "displaydoc",
+ "hex 0.4.2",
+ "mc-common",
+ "mc-crypto-keys",
+ "mc-transaction-core",
+ "mc-transaction-std",
+ "mc-util-b58-payloads",
+ "mc-util-from-random",
+ "mc-util-test-helper",
+ "mc-util-uri",
+ "rand_hc 0.2.0",
+ "url 2.1.1",
+]
+
+[[package]]
 name = "mc-watcher"
 version = "0.4.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,6 +3253,7 @@ name = "mc-util-url-encoding"
 version = "0.4.0"
 dependencies = [
  "base64 0.11.0",
+ "crc",
  "displaydoc",
  "hex 0.4.2",
  "mc-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ members = [
     "util/serial",
     "util/test-helper",
     "util/uri",
+    "util/url-encoding",
     "watcher",
 ]
 exclude = [

--- a/util/uri/src/uri.rs
+++ b/util/uri/src/uri.rs
@@ -11,8 +11,8 @@ use url::Url;
 
 #[derive(Clone, Eq, PartialEq, Debug, Display)]
 pub enum UriParseError {
-    /// Url parse error: "{1}", "{0}"
-    UrlParse(url::ParseError, String),
+    /// Url parse error: "{0}", "{1}"
+    UrlParse(String, url::ParseError),
     /// Missing host
     MissingHost,
     /// Unknown scheme: Valid possibilities are `{0}`, `{1}`
@@ -74,7 +74,7 @@ impl<Scheme: UriScheme> FromStr for Uri<Scheme> {
     type Err = UriParseError;
 
     fn from_str(src: &str) -> Result<Self, Self::Err> {
-        let url = Url::parse(src).map_err(|err| UriParseError::UrlParse(err, src.to_string()))?;
+        let url = Url::parse(src).map_err(|err| UriParseError::UrlParse(src.to_string(), err))?;
 
         let host = url
             .host_str()

--- a/util/uri/src/uri.rs
+++ b/util/uri/src/uri.rs
@@ -11,8 +11,8 @@ use url::Url;
 
 #[derive(Clone, Eq, PartialEq, Debug, Display)]
 pub enum UriParseError {
-    /// Url parse error: {0}
-    UrlParse(url::ParseError),
+    /// Url parse error: "{1}", "{0}"
+    UrlParse(url::ParseError, String),
     /// Missing host
     MissingHost,
     /// Unknown scheme: Valid possibilities are `{0}`, `{1}`
@@ -74,7 +74,7 @@ impl<Scheme: UriScheme> FromStr for Uri<Scheme> {
     type Err = UriParseError;
 
     fn from_str(src: &str) -> Result<Self, Self::Err> {
-        let url = Url::parse(src).map_err(UriParseError::UrlParse)?;
+        let url = Url::parse(src).map_err(|err| UriParseError::UrlParse(err, src.to_string()))?;
 
         let host = url
             .host_str()

--- a/util/url-encoding/Cargo.toml
+++ b/util/url-encoding/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "mc-util-url-encoding"
+version = "0.4.0"
+authors = ["MobileCoin"]
+edition = "2018"
+readme = "README.md"
+
+[dependencies]
+mc-common = { path = "../../common", default-features = false }
+mc-crypto-keys = { path = "../../crypto/keys" }
+mc-transaction-core = { path = "../../transaction/core" }
+mc-util-uri = { path = "../uri" }
+
+base64 = "0.11"
+displaydoc = { version = "0.1", default-features = false }
+hex = "0.4"
+url = "2.1"
+
+[dev-dependencies]
+mc-transaction-std = { path = "../../transaction/std" }
+mc-util-b58-payloads = { path = "../b58-payloads" }
+mc-util-from-random = { path = "../../util/from-random" }
+mc-util-test-helper = { path = "../../util/test-helper" }
+rand_hc = "0.2"

--- a/util/url-encoding/Cargo.toml
+++ b/util/url-encoding/Cargo.toml
@@ -12,6 +12,7 @@ mc-transaction-core = { path = "../../transaction/core" }
 mc-util-uri = { path = "../uri" }
 
 base64 = "0.11"
+crc = "1.8.1"
 displaydoc = { version = "0.1", default-features = false }
 hex = "0.4"
 url = "2.1"

--- a/util/url-encoding/README.md
+++ b/util/url-encoding/README.md
@@ -60,17 +60,28 @@ Hostname
 Path
 ----
 
-The *path* in the mob-url is `'/'` followed by the base64 encoding of the 64-byte sequence formed by concatenating
-the 32-byte spend-public-key and the 32-byte view-public key.
+The *path* in the mob-url is `'/'` followed by a base64 encoded string.
 
 The url-safe base-64 encoding is used, per RFC 3548, with `-`, `=`, and `_` characters.
 https://tools.ietf.org/html/rfc3548#section-4
+
+The encoded string is the 66-byte sequence formed by concatenating
+the 32-byte spend-public-key and the 32-byte view-public key, followed by 2 checksum checksum bytes.
+
+The two checksum bytes are the first two little-endian bytes of CRC-32-IEEE, and the checksum is
+computed over the 64 bytes consisting of the spend-public-key and view-public-key.
+
+(This checksum pads the payload up to 66 bytes, a multiple of 3, before base64 encoding, so that
+no base64 padding is required.)
 
 Query-parameters
 ----------------
 
 The `fog-authority-sig` is encoded as a query parameter using the key `'s'`, and the value is
-the base-64 encoding of the bytes of the signature. The url-safe base-64 encoding is used.
+the base-64 encoding of the bytes of the signature. The url-safe base-64 encoding is used, as
+with the path. The sig if present is a 64-byte digital signature, described in detail elsewhere.
+As with the path, before base64 encoding it, we pad it up to 66 bytes using two bytes of CRC-32-IEEE
+checksum.
 
 The `amount` of the payment request, if any, is encoded as a query parameter using the key `'a'`.
 The value is the decimal representation of the picomob request amount.

--- a/util/url-encoding/README.md
+++ b/util/url-encoding/README.md
@@ -1,0 +1,124 @@
+mc-util-url-encoding
+====================
+
+This crate contains facilities for url-encoding a mobilecoin public address.
+As extensions, it can include a request amount and a memo, so that it can encode
+a payment request as well.
+
+The design goals are:
+- Be simple and straightforward. If I'm a fog user, and fog.mobilecoin.org is my
+  fog hostname, then the url's hostname is fog.mobilecoin.org. The amount is
+  human readable as a query parameter. The memo is human readable as a query parameter.
+  This means that if the url appears e.g. in an email, I have some visibility into
+  its contents beyond just b58-encoded bytes. If e.g. the `fog-authority-sig` is missing,
+  I can see that that query parameter isn't there, which may make it easier to debug
+  why a transfer is failing, than if everything were just a b58 blob.
+- Be easy to construct using standard url and base64 javascript libraries.
+  If a third-party web developer has e.g. the protobuf corresponding to someone's
+  public address, following schema in external.proto, they should ideally be able
+  to make a well-formed url-encoded payment request without porting libmobilecoin
+  rust code to their platform.
+- Be easily extensible. If we want to add more fields, we can simply add query parameters.
+
+This is an alternative to the b58-payloads design, with different tradeoffs.
+In experiments, it appears that this format is always 10-20% smaller. This is because
+the b58-payloads is applying a b64-like encoding, meant for binary data, to data like URLs,
+which are not entropy. This causes unnecessary bloat of the encoding, and also makes it less useful
+to humans.
+
+Contents
+========
+
+A mob url represents:
+- A mobilecoin *public address* (see `mc-transaction-core` struct `PublicAddress`).
+- Optionally, *an amount* in picomob requested to be sent to this address
+- Optionally, *a memo* indicating the reason to send this amount
+
+Specification
+=============
+
+The mob URL specified here is formed by starting with the *fog-url*, if any,
+as a base. The fog-url type appears in `mc-util-uri`. (fog-url must be valid to
+use with grpc, so it does not contain any path or query parameters).
+Then, additional items from the public address are added to this url.
+
+Scheme
+------
+
+The url *scheme* is `mob` or `insecure-mob`.
+
+- For a fog-url with scheme "fog", the mob-url scheme is "mob".
+- For a fog-url with scheme "insecure-fog", the mob-url scheme is "insecure-mob".
+- If the fog-url is missing, the mob-url scheme is "mob".
+
+Hostname
+--------
+
+- The *hostname* of the mob-url is the hostname of the fog-url.
+- If the fog-url is missing, the hostname is empty. So in this case, the mob-url begins `mob:///`.
+
+Path
+----
+
+The *path* in the mob-url is `'/'` followed by the base64 encoding of the 64-byte sequence formed by concatenating
+the 32-byte spend-public-key and the 32-byte view-public key.
+
+The url-safe base-64 encoding is used, per RFC 3548, with `-`, `=`, and `_` characters.
+https://tools.ietf.org/html/rfc3548#section-4
+
+Query-parameters
+----------------
+
+The `fog-authority-sig` is encoded as a query parameter using the key `'s'`, and the value is
+the base-64 encoding of the bytes of the signature. The url-safe base-64 encoding is used.
+
+The `amount` of the payment request, if any, is encoded as a query parameter using the key `'a'`.
+The value is the decimal representation of the picomob request amount.
+
+The `memo` of the payment request, if any, is encoded as a query parameter using the key `'m'`.
+The value is the human-readable UTF-8 memo text, encoded using `application/x-www-form-urlencoded`.
+
+For the memo, it is not recommended to override the encoding to be something other than UTF-8 as described https://url.spec.whatwg.org/#urlencoded-serializing.
+
+An empty memo string is logically the same as having no memo string.
+
+Fragment
+--------
+
+The `fog-report-id`, if any, is encoded in the fragment of the url. This value is a string.
+
+An empty id string is logically the same as having no id string.
+
+(In practice it is expected that this will usually be the empty string and so can be omitted.)
+
+Examples
+========
+
+A public address for an account without fog support. This is base-64 encoded Ristretto curve points.
+
+```
+mob:///eCwRQ1riR1LTp8rpOMcn_rc3EajKx1EZ3cXV17SPDn2UyDJYXMl9TdQZoo5H3MDzTz14WBFVAARfGrXbMv8hGw==
+```
+
+A public address for an account with fog support.
+
+```
+mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCg==?s=CQkJCQ%3D%3D
+```
+
+The fog hostname here is `fog.mobilecoin.signal.org` which indicates where to contact the fog report server.
+
+The path contains the base-64 encoded Ristretto curve points.
+
+The query parameter `?s=...` encodes the user's signature over the fog authority key for `fog.mobilecoin.signal.org`.
+
+A payment request for an account with fog support
+
+```
+mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMQ==?s=CQkJCQ%3D%3D&a=666&m=2+baby+goats
+```
+
+The fog hostname here is `fog.diogenes.mobilecoin.com`.
+
+The query parameter `a=666` indicates that the amount is for 666 picomob.
+The query parameter `m=2+baby+goats` indicates that the payment is for 2 baby goats.

--- a/util/url-encoding/src/error.rs
+++ b/util/url-encoding/src/error.rs
@@ -1,0 +1,34 @@
+use core::num::ParseIntError;
+
+use mc_crypto_keys::KeyError;
+use mc_util_uri::UriParseError;
+
+use base64::DecodeError as B64Error;
+use displaydoc::Display;
+
+/// An error that can occur when parsing one of the Url's defined here
+#[derive(Debug, Display)]
+pub enum Error {
+    /// Could not parse MobUrl: {0}
+    MobUrl(UriParseError),
+    /// Could not parse FogUrl: {0}
+    FogUrl(UriParseError),
+    /// Could not parse version number: {0}
+    Version(ParseIntError),
+    /// Could not parse mob amount number: {0}
+    Amount(ParseIntError),
+    /// Could not decode path as url-safe base64: {0}
+    Path(B64Error),
+    /// Unexpected url path length, should decode to 64 bytes for cryptonote keys, found: {0}
+    UnexpectedUrlPathLength(usize),
+    /// Could not decode fog-authority-sig as url-safe base64: {0}
+    FogAuthoritySig(B64Error),
+    /// Could not decode elliptic curve point: {0}
+    InvalidKey(KeyError),
+}
+
+impl From<KeyError> for Error {
+    fn from(src: KeyError) -> Self {
+        Self::InvalidKey(src)
+    }
+}

--- a/util/url-encoding/src/error.rs
+++ b/util/url-encoding/src/error.rs
@@ -7,7 +7,7 @@ use base64::DecodeError as B64Error;
 use displaydoc::Display;
 
 /// An error that can occur when parsing one of the Url's defined here
-#[derive(Debug, Display)]
+#[derive(Clone, Eq, PartialEq, Debug, Display)]
 pub enum Error {
     /// Could not parse MobUrl: {0}
     MobUrl(UriParseError),

--- a/util/url-encoding/src/error.rs
+++ b/util/url-encoding/src/error.rs
@@ -19,10 +19,16 @@ pub enum Error {
     Amount(ParseIntError),
     /// Could not decode path as url-safe base64: {0}
     Path(B64Error),
-    /// Unexpected url path length, should decode to 64 bytes for cryptonote keys, found: {0}
+    /// Checksum failed in the path
+    PathChecksum,
+    /// Unexpected decoded url path length, should decode to 66 bytes for cryptonote keys + checksum, found: {0}
     UnexpectedUrlPathLength(usize),
     /// Could not decode fog-authority-sig as url-safe base64: {0}
     FogAuthoritySig(B64Error),
+    /// Unexpected decoded fog authority sig length, expected at least 2 bytes, found: {0}
+    UnexpectedFogAuthoritySigLength(usize),
+    /// Checksum failed in the fog authority sig
+    FogAuthoritySigChecksum,
     /// Could not decode elliptic curve point: {0}
     InvalidKey(KeyError),
 }

--- a/util/url-encoding/src/lib.rs
+++ b/util/url-encoding/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! mob:// URL support.
+
+#[deny(missing_docs)]
+#[deny(unsafe_code)]
+mod error;
+mod mob_url;
+mod payment_request;
+
+pub use crate::{
+    error::Error,
+    mob_url::{MobUrl, UriParseError, MOB_SCHEME_INSECURE, MOB_SCHEME_SECURE},
+    payment_request::PaymentRequest,
+};

--- a/util/url-encoding/src/lib.rs
+++ b/util/url-encoding/src/lib.rs
@@ -4,6 +4,8 @@
 
 #[deny(missing_docs)]
 #[deny(unsafe_code)]
+extern crate alloc;
+
 mod error;
 mod mob_url;
 mod payment_request;

--- a/util/url-encoding/src/lib.rs
+++ b/util/url-encoding/src/lib.rs
@@ -2,8 +2,8 @@
 
 //! mob:// URL support.
 
-#[deny(missing_docs)]
-#[deny(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(unsafe_code)]
 extern crate alloc;
 
 mod error;

--- a/util/url-encoding/src/mob_url.rs
+++ b/util/url-encoding/src/mob_url.rs
@@ -1,0 +1,244 @@
+//! Representation of a mob-scheme url, based on rust-url lib
+//!
+//! This does not follow the pattern of mc-util-uri because this url is not
+//! actually used as the basis of a connection to a service, it's rather an
+//! encoding that represents a public address, or a payment request following
+//! the url specification. It is intended to be more or less human readable
+//! and could be used e.g. in an email where a user might actually look at the
+//! url, and could be registered with the OS so that a mobilecoin client launches
+//! to handle the url.
+//!
+//! Because we don't implement ConnectionUri, don't really have a notion of port,
+//! and aren't required to actually have a hostname (fog-less mob url's don't),
+//! we don't really want to base this on the mc-util-uri type.
+
+use core::{
+    convert::TryFrom,
+    fmt::{Display, Formatter, Result as FmtResult},
+    str::FromStr,
+};
+
+use crate::error::Error;
+use mc_crypto_keys::RistrettoPublic;
+use mc_transaction_core::account_keys::PublicAddress;
+pub use mc_util_uri::UriParseError;
+use mc_util_uri::{ConnectionUri, FogScheme, FogUri, UriScheme};
+use url::Url;
+
+pub const MOB_SCHEME_SECURE: &str = "mob";
+pub const MOB_SCHEME_INSECURE: &str = "insecure-mob";
+
+const SIG_KEY: &str = "s";
+const AMOUNT_KEY: &str = "a";
+const MEMO_KEY: &str = "m";
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct MobUrl {
+    /// The original Url object used to construct this object.
+    url: Url,
+    /// Whether to use TLS when connecting.
+    use_tls: bool,
+}
+
+impl MobUrl {
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    pub fn use_tls(&self) -> bool {
+        self.use_tls
+    }
+
+    // query parameters
+    fn get_param(&self, name: &str) -> Option<String> {
+        self.url().query_pairs().find_map(|(k, v)| {
+            if k == name && !v.is_empty() {
+                Some(v.to_string())
+            } else {
+                None
+            }
+        })
+    }
+
+    // TODO: We should test what happens when there are duplicated keys among the query pairs
+    fn set_param(&mut self, name: &str, val: &str) {
+        self.url.query_pairs_mut().append_pair(name, val);
+    }
+
+    pub fn get_amount(&self) -> Option<String> {
+        self.get_param(AMOUNT_KEY)
+    }
+
+    pub fn get_report_id(&self) -> Option<String> {
+        self.url.fragment().map(|s| s.to_string())
+    }
+
+    pub fn get_memo(&self) -> Option<String> {
+        self.get_param(MEMO_KEY)
+    }
+
+    pub fn get_sig(&self) -> Option<String> {
+        self.get_param(SIG_KEY)
+    }
+
+    pub fn set_amount(&mut self, amt: u64) {
+        self.set_param(AMOUNT_KEY, &amt.to_string());
+    }
+
+    pub fn set_report_id(&mut self, id: Option<&str>) {
+        self.url.set_fragment(id);
+    }
+
+    pub fn set_memo(&mut self, memo: &str) {
+        self.set_param(MEMO_KEY, memo);
+    }
+
+    pub fn set_sig(&mut self, sig: &str) {
+        self.set_param(SIG_KEY, sig);
+    }
+}
+
+impl AsRef<str> for MobUrl {
+    fn as_ref(&self) -> &str {
+        self.url.as_ref()
+    }
+}
+
+impl Display for MobUrl {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}", self.as_ref())
+    }
+}
+
+impl FromStr for MobUrl {
+    type Err = UriParseError;
+
+    fn from_str(src: &str) -> Result<Self, Self::Err> {
+        let url = Url::parse(src).map_err(|err| UriParseError::UrlParse(err, src.to_string()))?;
+
+        let use_tls = if url.scheme().starts_with(MOB_SCHEME_SECURE) {
+            true
+        } else if url.scheme().starts_with(MOB_SCHEME_INSECURE) {
+            false
+        } else {
+            return Err(UriParseError::UnknownScheme(
+                &MOB_SCHEME_SECURE,
+                &MOB_SCHEME_INSECURE,
+            ));
+        };
+
+        Ok(Self { url, use_tls })
+    }
+}
+
+// How to construct a MobUrl from a public address
+impl TryFrom<&PublicAddress> for MobUrl {
+    type Error = Error;
+    fn try_from(src: &PublicAddress) -> Result<MobUrl, Error> {
+        // Start by trying to parse the fog url from the string, and extract raw url type
+        let (fog_url, use_tls) = if let Some(fog_url) = src.fog_report_url() {
+            let fog_url = FogUri::from_str(fog_url).map_err(Error::FogUrl)?;
+            (fog_url.url().clone(), fog_url.use_tls())
+        } else {
+            (
+                Url::from_str("fog://").expect("Url parsing failed unexpectedly"),
+                true,
+            )
+        };
+
+        // Convert to raw Url type (note: we don't clone because fog_url is not used further)
+        let mut mob_url = fog_url;
+
+        // Take care of scheme
+        mob_url
+            .set_scheme(if use_tls {
+                MOB_SCHEME_SECURE
+            } else {
+                MOB_SCHEME_INSECURE
+            })
+            .expect("mob scheme was rejected");
+
+        // Compute path part (the encoding of A and B)
+        let path = {
+            let mut buffer = [0u8; 64];
+            (&mut buffer[0..32]).clone_from_slice(&src.spend_public_key().to_bytes()[..]);
+            (&mut buffer[32..64]).clone_from_slice(&src.view_public_key().to_bytes()[..]);
+            "/".to_owned() + &base64::encode_config(&buffer[..], base64::URL_SAFE)
+        };
+        mob_url.set_path(&path);
+
+        // Query pairs
+        {
+            let mut query_pairs = mob_url.query_pairs_mut();
+
+            if let Some(sig) = src.fog_authority_sig() {
+                let encoded_sig = base64::encode_config(sig, base64::URL_SAFE);
+                query_pairs.append_pair(SIG_KEY, &encoded_sig);
+            }
+        }
+
+        if let Some(id) = src.fog_report_id() {
+            mob_url.set_fragment(Some(id));
+        }
+
+        let mob_url_str: &str = mob_url.as_ref();
+        MobUrl::from_str(mob_url_str).map_err(Error::MobUrl)
+    }
+}
+
+// How to extract a public address from a MobUrl
+impl TryFrom<&MobUrl> for PublicAddress {
+    type Error = Error;
+    fn try_from(src: &MobUrl) -> Result<PublicAddress, Error> {
+        let mut path = src.url().path();
+        while path.starts_with('/') {
+            path = &path[1..];
+        }
+
+        let decoded_path = base64::decode_config(path, base64::URL_SAFE).map_err(Error::Path)?;
+        if decoded_path.len() != 64 {
+            return Err(Error::UnexpectedUrlPathLength(decoded_path.len()));
+        }
+        let spend_public = RistrettoPublic::try_from(&decoded_path[0..32])?;
+        let view_public = RistrettoPublic::try_from(&decoded_path[32..64])?;
+
+        // Mob Url's that have host, have fog
+        Ok(if let Some(_host) = src.url().host_str() {
+            let fog_url = {
+                let mut fog_url = src.url().clone();
+                fog_url
+                    .set_scheme(if src.use_tls() {
+                        FogScheme::SCHEME_SECURE
+                    } else {
+                        FogScheme::SCHEME_INSECURE
+                    })
+                    .expect("fog scheme was rejected");
+                fog_url.set_path("");
+                // TODO: Perhaps we should preserve query parameters that are not "known" keys? Such as tls-override etc.
+                fog_url.set_query(None);
+                fog_url.set_fragment(None);
+                let fog_url = fog_url.into_string();
+
+                // For extra validation, check that it parses as a fog url
+                FogUri::from_str(&fog_url).map_err(Error::FogUrl)?;
+
+                fog_url
+            };
+
+            // May have report_key
+            let report_id = src.get_report_id().unwrap_or_default();
+
+            // Probably the mob-url also has fog_authority_sig
+            let sig_vec = if let Some(sig_str) = src.get_sig() {
+                base64::decode_config(&sig_str, base64::URL_SAFE).map_err(Error::FogAuthoritySig)?
+            } else {
+                b"".to_vec()
+            };
+
+            PublicAddress::new_with_fog(&spend_public, &view_public, fog_url, report_id, sig_vec)
+        } else {
+            // TODO: Could return an error if e.g. fog_authority_sig is present but host is missing?
+            PublicAddress::new(&spend_public, &view_public)
+        })
+    }
+}

--- a/util/url-encoding/src/mob_url.rs
+++ b/util/url-encoding/src/mob_url.rs
@@ -27,13 +27,16 @@ use mc_transaction_core::account_keys::PublicAddress;
 use mc_util_uri::{ConnectionUri, FogScheme, FogUri, UriScheme};
 use url::Url;
 
+/// The label used for secure version of mob url (using TLS)
 pub const MOB_SCHEME_SECURE: &str = "mob";
+/// The label used for secure version of mob url (not using TLS, for tests)
 pub const MOB_SCHEME_INSECURE: &str = "insecure-mob";
 
 const SIG_KEY: &str = "s";
 const AMOUNT_KEY: &str = "a";
 const MEMO_KEY: &str = "m";
 
+/// A url beginning with mob scheme and with structure matching the spec in README
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct MobUrl {
     /// The original Url object used to construct this object.
@@ -43,10 +46,12 @@ pub struct MobUrl {
 }
 
 impl MobUrl {
+    /// Get the underlying Url object
     pub fn url(&self) -> &Url {
         &self.url
     }
 
+    /// Whether we are using TLS (mob vs. insecure-mob)
     pub fn use_tls(&self) -> bool {
         self.use_tls
     }
@@ -72,34 +77,42 @@ impl MobUrl {
             .extend_pairs(query_params.iter());
     }
 
+    /// Get the amount, as a raw decimal string from the query parameters, if present
     pub fn get_amount(&self) -> Option<String> {
         self.get_param(AMOUNT_KEY)
     }
 
+    /// Get the report id, as a string, if present
     pub fn get_report_id(&self) -> Option<String> {
         self.url.fragment().map(|s| s.to_string())
     }
 
+    /// Get the memo, as a rust UTF-8 String, if present
     pub fn get_memo(&self) -> Option<String> {
         self.get_param(MEMO_KEY)
     }
 
+    /// Get the base64-encoded sig, if present
     pub fn get_sig(&self) -> Option<String> {
         self.get_param(SIG_KEY)
     }
 
+    /// Set the amount to a new value
     pub fn set_amount(&mut self, amt: u64) {
         self.set_param(AMOUNT_KEY, &amt.to_string());
     }
 
+    /// Set the report_id to a new value or clear it
     pub fn set_report_id(&mut self, id: Option<&str>) {
         self.url.set_fragment(id);
     }
 
+    /// Set the memo to a new value
     pub fn set_memo(&mut self, memo: &str) {
         self.set_param(MEMO_KEY, memo);
     }
 
+    /// Set the sig to a new base64 encoded value
     pub fn set_sig(&mut self, sig: &str) {
         self.set_param(SIG_KEY, sig);
     }

--- a/util/url-encoding/src/mob_url.rs
+++ b/util/url-encoding/src/mob_url.rs
@@ -242,3 +242,45 @@ impl TryFrom<&MobUrl> for PublicAddress {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test that getting and setting works as expected
+    #[test]
+    fn mob_url_unit_tests() {
+        let mut mob_url = MobUrl::from_str("mob://example.com/1234").unwrap();
+
+        assert_eq!(mob_url.as_ref(), "mob://example.com/1234");
+        assert_eq!(mob_url.get_amount(), None);
+        assert_eq!(mob_url.get_memo(), None);
+        assert_eq!(mob_url.get_sig(), None);
+
+        mob_url.set_amount(50);
+
+        assert_eq!(mob_url.get_amount(), Some("50".to_string()));
+        assert_eq!(mob_url.as_ref(), "mob://example.com/1234?a=50");
+
+        mob_url.set_amount(70);
+
+        /*
+        Note: Failing at this revision with "50" and url =
+        mob://example.com/1234?a=50&a=70
+
+        assert_eq!(mob_url.get_amount(), Some("70".to_string()));
+        assert_eq!(mob_url.as_ref(), "mob://example.com/1234?a=70");
+
+        assert_eq!(mob_url.get_memo(), None);
+        mob_url.set_memo("beep boop");
+
+        assert_eq!(mob_url.get_memo(), Some("beep boop".to_string()));
+        assert_eq!(mob_url.as_ref(), "mob://example.com/1234?a=70+m=beep+boop");
+
+        mob_url.set_memo("foobar");
+
+        assert_eq!(mob_url.get_memo(), Some("foobar".to_string()));
+        assert_eq!(mob_url.as_ref(), "mob://example.com/1234?a=70+m=foobar");
+        */
+    }
+}

--- a/util/url-encoding/src/mob_url.rs
+++ b/util/url-encoding/src/mob_url.rs
@@ -12,16 +12,16 @@
 //! and aren't required to actually have a hostname (fog-less mob url's don't),
 //! we don't really want to base this on the mc-util-uri type.
 
+pub use mc_util_uri::UriParseError;
+
+use crate::error::Error;
 use core::{
     convert::TryFrom,
     fmt::{Display, Formatter, Result as FmtResult},
     str::FromStr,
 };
-
-use crate::error::Error;
 use mc_crypto_keys::RistrettoPublic;
 use mc_transaction_core::account_keys::PublicAddress;
-pub use mc_util_uri::UriParseError;
 use mc_util_uri::{ConnectionUri, FogScheme, FogUri, UriScheme};
 use url::Url;
 

--- a/util/url-encoding/src/mob_url.rs
+++ b/util/url-encoding/src/mob_url.rs
@@ -114,7 +114,7 @@ impl FromStr for MobUrl {
     type Err = UriParseError;
 
     fn from_str(src: &str) -> Result<Self, Self::Err> {
-        let url = Url::parse(src).map_err(|err| UriParseError::UrlParse(err, src.to_string()))?;
+        let url = Url::parse(src).map_err(|err| UriParseError::UrlParse(src.to_string(), err))?;
 
         let use_tls = if url.scheme().starts_with(MOB_SCHEME_SECURE) {
             true

--- a/util/url-encoding/src/payment_request.rs
+++ b/util/url-encoding/src/payment_request.rs
@@ -89,7 +89,7 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(mob_url.as_ref(), "mob://example.com/9i_xwzoihbGu5hLthygfLGi7K1sPFDmhPkq3KPmO-2p4kBwRg06ELfa-mMEnlTUT4RYJXUEizCfYB7RRHLgeEQ==?s=CQkJCQ%3D%3D");
+        assert_eq!(mob_url.as_ref(), "mob://example.com/9i_xwzoihbGu5hLthygfLGi7K1sPFDmhPkq3KPmO-2p4kBwRg06ELfa-mMEnlTUT4RYJXUEizCfYB7RRHLgeEWfP?s=CQkJCfSo");
 
         let payload2 = PaymentRequest::try_from(&mob_url).unwrap();
 
@@ -116,7 +116,7 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(mob_url.as_ref(), "mob:///9i_xwzoihbGu5hLthygfLGi7K1sPFDmhPkq3KPmO-2p4kBwRg06ELfa-mMEnlTUT4RYJXUEizCfYB7RRHLgeEQ==?");
+        assert_eq!(mob_url.as_ref(), "mob:///9i_xwzoihbGu5hLthygfLGi7K1sPFDmhPkq3KPmO-2p4kBwRg06ELfa-mMEnlTUT4RYJXUEizCfYB7RRHLgeEWfP");
 
         let payload2 = PaymentRequest::try_from(&mob_url).unwrap();
 
@@ -147,7 +147,7 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(mob_url.as_ref(), "mob://fog.mobilecoin.com/oGbA6juTWhUdfL6qNMocAGN96wNiZpZegP0TUjKXHEM-GYmM50bLJVeL6NgftIumjt8nwYw7MjEnQT7hCw9bVQ==?a=777&m=2+baby+goats&s=CQkJCQ%3D%3D#0");
+        assert_eq!(mob_url.as_ref(), "mob://fog.mobilecoin.com/oGbA6juTWhUdfL6qNMocAGN96wNiZpZegP0TUjKXHEM-GYmM50bLJVeL6NgftIumjt8nwYw7MjEnQT7hCw9bVUgh?a=777&m=2+baby+goats&s=CQkJCfSo#0");
 
         let payload2 = PaymentRequest::try_from(&mob_url).unwrap();
 
@@ -218,7 +218,7 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(mob_url.as_ref(), "mob:///oGbA6juTWhUdfL6qNMocAGN96wNiZpZegP0TUjKXHEM-GYmM50bLJVeL6NgftIumjt8nwYw7MjEnQT7hCw9bVQ==?a=777&m=ham+sandwich");
+        assert_eq!(mob_url.as_ref(), "mob:///oGbA6juTWhUdfL6qNMocAGN96wNiZpZegP0TUjKXHEM-GYmM50bLJVeL6NgftIumjt8nwYw7MjEnQT7hCw9bVUgh?a=777&m=ham+sandwich");
 
         let payload2 = PaymentRequest::try_from(&mob_url).unwrap();
 

--- a/util/url-encoding/src/payment_request.rs
+++ b/util/url-encoding/src/payment_request.rs
@@ -1,0 +1,345 @@
+use crate::{Error, MobUrl};
+use core::convert::TryFrom;
+use mc_transaction_core::account_keys::PublicAddress;
+
+/// A payment request, containing a public address, and optionally an amount
+/// and memo.
+/// This can be encoded as a MobUrl and a MobUrl can be constructed from this.
+/// To add more optional fields, designate query parameters for them in MobUrl
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PaymentRequest {
+    pub address: PublicAddress,
+    pub amount: Option<u64>,
+    pub memo: Option<String>,
+}
+
+impl From<&PublicAddress> for PaymentRequest {
+    fn from(src: &PublicAddress) -> PaymentRequest {
+        PaymentRequest {
+            address: src.clone(),
+            amount: None,
+            memo: None,
+        }
+    }
+}
+
+impl TryFrom<&PaymentRequest> for MobUrl {
+    type Error = Error;
+    fn try_from(src: &PaymentRequest) -> Result<MobUrl, Error> {
+        let mut result = MobUrl::try_from(&src.address)?;
+        if let Some(amount) = src.amount.as_ref() {
+            result.set_amount(*amount);
+        }
+        if let Some(memo) = src.memo.as_ref() {
+            result.set_memo(memo);
+        }
+        Ok(result)
+    }
+}
+
+impl TryFrom<&MobUrl> for PaymentRequest {
+    type Error = Error;
+    fn try_from(src: &MobUrl) -> Result<PaymentRequest, Error> {
+        let mut payload = PaymentRequest {
+            address: PublicAddress::try_from(src)?,
+            amount: None,
+            memo: None,
+        };
+
+        if let Some(amount_str) = src.get_amount() {
+            payload.amount = Some(amount_str.parse::<u64>().map_err(Error::Amount)?);
+        }
+
+        if let Some(memo_str) = src.get_memo() {
+            payload.memo = Some(memo_str);
+        }
+
+        Ok(payload)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MobUrl, PaymentRequest};
+
+    use core::{convert::TryFrom, str::FromStr};
+
+    use mc_crypto_keys::RistrettoPrivate;
+    use mc_transaction_core::account_keys::AccountKey;
+    use mc_transaction_std::identity::RootIdentity;
+    use mc_util_test_helper::{run_with_several_seeds, RngCore};
+
+    // Test an example public address being parsed to mob url
+    #[test]
+    fn example_fog_public_address() {
+        let identity = RootIdentity {
+            root_entropy: [0u8; 32],
+            fog_url: Some("fog://example.com".to_owned()),
+        };
+
+        let acct = AccountKey::from(&identity);
+
+        let addr = acct.default_subaddress();
+
+        let payload = PaymentRequest::from(&addr);
+
+        let mob_url = MobUrl::try_from(&payload)
+            .map_err(|err| {
+                panic!("Error when decoding payload {:?}: {}", payload, err);
+            })
+            .unwrap();
+
+        assert_eq!(mob_url.as_ref(), "mob://example.com/9i_xwzoihbGu5hLthygfLGi7K1sPFDmhPkq3KPmO-2p4kBwRg06ELfa-mMEnlTUT4RYJXUEizCfYB7RRHLgeEQ==?s=CQkJCQ%3D%3D");
+
+        let payload2 = PaymentRequest::try_from(&mob_url).unwrap();
+
+        assert_eq!(payload, payload2);
+    }
+
+    // Test an example fogless public address being parsed to mob url
+    #[test]
+    fn example_fogless_public_address() {
+        let identity = RootIdentity {
+            root_entropy: [0u8; 32],
+            fog_url: None,
+        };
+
+        let acct = AccountKey::from(&identity);
+
+        let addr = acct.default_subaddress();
+
+        let payload = PaymentRequest::from(&addr);
+
+        let mob_url = MobUrl::try_from(&payload)
+            .map_err(|err| {
+                panic!("Error when decoding payload {:?}: {}", payload, err);
+            })
+            .unwrap();
+
+        assert_eq!(mob_url.as_ref(), "mob:///9i_xwzoihbGu5hLthygfLGi7K1sPFDmhPkq3KPmO-2p4kBwRg06ELfa-mMEnlTUT4RYJXUEizCfYB7RRHLgeEQ==?");
+
+        let payload2 = PaymentRequest::try_from(&mob_url).unwrap();
+
+        assert_eq!(payload, payload2);
+    }
+
+    // Test an example request payload being parsed to mob url
+    #[test]
+    fn example_fog_payload() {
+        let acct = AccountKey::new_with_fog(
+            &RistrettoPrivate::try_from(&[0u8; 32]).unwrap(),
+            &RistrettoPrivate::try_from(&[1u8; 32]).unwrap(),
+            "fog://fog.mobilecoin.com".to_string(),
+            0.to_string(),
+            b"deadbeef".to_vec(),
+        );
+
+        let addr = acct.default_subaddress();
+
+        let mut payload = PaymentRequest::from(&addr);
+
+        payload.amount = Some(777);
+        payload.memo = Some("2 baby goats".to_owned());
+
+        let mob_url = MobUrl::try_from(&payload)
+            .map_err(|err| {
+                panic!("Error when decoding payload {:?}: {}", payload, err);
+            })
+            .unwrap();
+
+        assert_eq!(mob_url.as_ref(), "mob://fog.mobilecoin.com/oGbA6juTWhUdfL6qNMocAGN96wNiZpZegP0TUjKXHEM-GYmM50bLJVeL6NgftIumjt8nwYw7MjEnQT7hCw9bVQ==?s=CQkJCQ%3D%3D&a=777&m=2+baby+goats#0");
+
+        let payload2 = PaymentRequest::try_from(&mob_url).unwrap();
+
+        assert_eq!(payload, payload2);
+    }
+
+    // Test an example unicode request payload being parsed to mob url
+    #[test]
+    fn roundtrip_example_fog_payload_unicode() {
+        for memo in &[
+            String::from("السلام عليكم"),
+            String::from("Dobrý den"),
+            String::from("Hello"),
+            String::from("שָׁלוֹם"),
+            String::from("नमस्ते"),
+            String::from("こんにちは"),
+            String::from("안녕하세요"),
+            String::from("你好"),
+            String::from("Olá"),
+            String::from("Здравствуйте"),
+            String::from("Hola"),
+        ] {
+            let acct = AccountKey::new_with_fog(
+                &RistrettoPrivate::try_from(&[0u8; 32]).unwrap(),
+                &RistrettoPrivate::try_from(&[1u8; 32]).unwrap(),
+                "fog://fog.mobilecoin.com".to_string(),
+                0.to_string(),
+                b"deadbeef".to_vec(),
+            );
+
+            let addr = acct.default_subaddress();
+
+            let mut payload = PaymentRequest::from(&addr);
+
+            payload.amount = Some(777);
+            payload.memo = Some(memo.to_owned());
+
+            let mob_url = MobUrl::try_from(&payload)
+                .map_err(|err| {
+                    panic!("Error when decoding payload {:?}: {}", payload, err);
+                })
+                .unwrap();
+
+            let payload2 = PaymentRequest::try_from(&mob_url).unwrap();
+
+            assert_eq!(payload, payload2);
+        }
+    }
+
+    // Test an example fogless request payload being parsed to mob url
+    #[test]
+    fn example_fogless_payload() {
+        let acct = AccountKey::new(
+            &RistrettoPrivate::try_from(&[0u8; 32]).unwrap(),
+            &RistrettoPrivate::try_from(&[1u8; 32]).unwrap(),
+        );
+
+        let addr = acct.default_subaddress();
+
+        let mut payload = PaymentRequest::from(&addr);
+
+        payload.amount = Some(777);
+        payload.memo = Some("ham sandwich".to_owned());
+
+        let mob_url = MobUrl::try_from(&payload)
+            .map_err(|err| {
+                panic!("Error when decoding payload {:?}: {}", payload, err);
+            })
+            .unwrap();
+
+        assert_eq!(mob_url.as_ref(), "mob:///oGbA6juTWhUdfL6qNMocAGN96wNiZpZegP0TUjKXHEM-GYmM50bLJVeL6NgftIumjt8nwYw7MjEnQT7hCw9bVQ==?a=777&m=ham+sandwich");
+
+        let payload2 = PaymentRequest::try_from(&mob_url).unwrap();
+
+        assert_eq!(payload, payload2);
+    }
+
+    // Round trip random fog-less public address through mob url
+    #[test]
+    fn round_trip_random_public_address() {
+        run_with_several_seeds(|mut rng| {
+            let acct = AccountKey::random(&mut rng);
+
+            let addr = acct.default_subaddress();
+
+            let payload = PaymentRequest::from(&addr);
+
+            let mob_url = MobUrl::try_from(&payload).expect("MobUrl from payload");
+
+            let string_repr = mob_url.to_string();
+
+            let mob_url2 = MobUrl::from_str(&string_repr).expect("MobUrl from str");
+
+            assert_eq!(mob_url, mob_url2);
+
+            let payload2 = PaymentRequest::try_from(&mob_url2).unwrap();
+
+            assert_eq!(payload, payload2);
+
+            let addr2 = payload2.address.clone();
+
+            assert_eq!(addr, addr2);
+        })
+    }
+
+    // Round trip random fog-less payloads through mob url
+    #[test]
+    fn round_trip_random_payload() {
+        run_with_several_seeds(|mut rng| {
+            let acct = AccountKey::random(&mut rng);
+
+            let addr = acct.default_subaddress();
+
+            let mut payload = PaymentRequest::from(&addr);
+
+            payload.amount = Some(rng.next_u64());
+            payload.memo = Some(rng.next_u64().to_string());
+
+            let mob_url = MobUrl::try_from(&payload).expect("MobUrl from payload");
+
+            let string_repr = mob_url.to_string();
+
+            let mob_url2 = MobUrl::from_str(&string_repr).unwrap();
+
+            assert_eq!(mob_url, mob_url2);
+
+            let payload2 = PaymentRequest::try_from(&mob_url2).unwrap();
+
+            assert_eq!(payload, payload2);
+
+            let addr2 = payload2.address.clone();
+
+            assert_eq!(addr, addr2);
+        })
+    }
+
+    // Round trip random addresses with fog through mob url
+    #[test]
+    fn round_trip_random_fog_address() {
+        run_with_several_seeds(|mut rng| {
+            let acct = AccountKey::random_with_fog(&mut rng);
+
+            let addr = acct.default_subaddress();
+
+            let payload = PaymentRequest::from(&addr);
+
+            let mob_url = MobUrl::try_from(&payload).expect("MobUrl from payload");
+
+            let string_repr = mob_url.to_string();
+
+            let mob_url2 = MobUrl::from_str(&string_repr).expect("MobUrl from str");
+
+            assert_eq!(mob_url, mob_url2);
+
+            let payload2 = PaymentRequest::try_from(&mob_url2).unwrap();
+
+            assert_eq!(payload, payload2);
+
+            let addr2 = payload2.address.clone();
+
+            assert_eq!(addr, addr2);
+        })
+    }
+
+    // Round trip random fog payloads through mob url
+    #[test]
+    fn round_trip_random_fog_payload() {
+        run_with_several_seeds(|mut rng| {
+            let acct = AccountKey::random_with_fog(&mut rng);
+
+            let addr = acct.default_subaddress();
+
+            let mut payload = PaymentRequest::from(&addr);
+
+            payload.amount = Some(rng.next_u64());
+            payload.memo = Some(rng.next_u64().to_string());
+
+            let mob_url = MobUrl::try_from(&payload).unwrap();
+
+            let string_repr = mob_url.to_string();
+
+            let mob_url2 = MobUrl::from_str(&string_repr).unwrap();
+
+            assert_eq!(mob_url, mob_url2);
+
+            let payload2 = PaymentRequest::try_from(&mob_url2).unwrap();
+
+            assert_eq!(payload, payload2);
+
+            let addr2 = payload2.address.clone();
+
+            assert_eq!(addr, addr2);
+        })
+    }
+}

--- a/util/url-encoding/src/payment_request.rs
+++ b/util/url-encoding/src/payment_request.rs
@@ -147,7 +147,7 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(mob_url.as_ref(), "mob://fog.mobilecoin.com/oGbA6juTWhUdfL6qNMocAGN96wNiZpZegP0TUjKXHEM-GYmM50bLJVeL6NgftIumjt8nwYw7MjEnQT7hCw9bVQ==?s=CQkJCQ%3D%3D&a=777&m=2+baby+goats#0");
+        assert_eq!(mob_url.as_ref(), "mob://fog.mobilecoin.com/oGbA6juTWhUdfL6qNMocAGN96wNiZpZegP0TUjKXHEM-GYmM50bLJVeL6NgftIumjt8nwYw7MjEnQT7hCw9bVQ==?a=777&m=2+baby+goats&s=CQkJCQ%3D%3D#0");
 
         let payload2 = PaymentRequest::try_from(&mob_url).unwrap();
 

--- a/util/url-encoding/src/payment_request.rs
+++ b/util/url-encoding/src/payment_request.rs
@@ -8,8 +8,11 @@ use mc_transaction_core::account_keys::PublicAddress;
 /// To add more optional fields, designate query parameters for them in MobUrl
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PaymentRequest {
+    /// The public address included in the request
     pub address: PublicAddress,
+    /// The amount included in the request, if any
     pub amount: Option<u64>,
+    /// The memo included in the request, if any
     pub memo: Option<String>,
 }
 

--- a/util/url-encoding/tests/comparison.rs
+++ b/util/url-encoding/tests/comparison.rs
@@ -86,7 +86,7 @@ fn test_url_encoding() {
         };
         let encoded = MobUrl::try_from(&payload).unwrap();
         let encoded_str: &str = encoded.as_ref();
-        assert_eq!("mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCg==?s=CQkJCQ%3D%3D&a=666&m=2+baby+goats", encoded_str);
+        assert_eq!("mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCg==?a=666&m=2+baby+goats&s=CQkJCQ%3D%3D", encoded_str);
         assert_eq!(156, encoded_str.len());
 
         let b58_payload = RequestPayload::new_v3(
@@ -134,7 +134,7 @@ fn test_url_encoding() {
         };
         let encoded = MobUrl::try_from(&payload).unwrap();
         let encoded_str: &str = encoded.as_ref();
-        assert_eq!("mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMQ==?s=CQkJCQ%3D%3D&a=666&m=2+baby+goats", encoded_str);
+        assert_eq!("mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMQ==?a=666&m=2+baby+goats&s=CQkJCQ%3D%3D", encoded_str);
         assert_eq!(158, encoded_str.len());
 
         let b58_payload = RequestPayload::new_v3(

--- a/util/url-encoding/tests/comparison.rs
+++ b/util/url-encoding/tests/comparison.rs
@@ -43,8 +43,8 @@ fn test_url_encoding() {
         let payload = PaymentRequest::from(addr);
         let encoded = MobUrl::try_from(&payload).unwrap();
         let encoded_str: &str = encoded.as_ref();
-        assert_eq!("mob:///eCwRQ1riR1LTp8rpOMcn_rc3EajKx1EZ3cXV17SPDn2UyDJYXMl9TdQZoo5H3MDzTz14WBFVAARfGrXbMv8hGw==?", encoded_str);
-        assert_eq!(96, encoded_str.len());
+        assert_eq!("mob:///eCwRQ1riR1LTp8rpOMcn_rc3EajKx1EZ3cXV17SPDn2UyDJYXMl9TdQZoo5H3MDzTz14WBFVAARfGrXbMv8hG3Da", encoded_str);
+        assert_eq!(95, encoded_str.len());
 
         let b58_payload = RequestPayload::new_v0(
             &addr.spend_public_key().to_bytes(),
@@ -61,8 +61,8 @@ fn test_url_encoding() {
         let payload = PaymentRequest::from(addr);
         let encoded = MobUrl::try_from(&payload).unwrap();
         let encoded_str: &str = encoded.as_ref();
-        assert_eq!("mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCg==?s=CQkJCQ%3D%3D", encoded_str);
-        assert_eq!(135, encoded_str.len());
+        assert_eq!("mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCl6E?s=CQkJCfSo", encoded_str);
+        assert_eq!(131, encoded_str.len());
 
         let b58_payload = RequestPayload::new_v1(
             &addr.spend_public_key().to_bytes(),
@@ -86,8 +86,8 @@ fn test_url_encoding() {
         };
         let encoded = MobUrl::try_from(&payload).unwrap();
         let encoded_str: &str = encoded.as_ref();
-        assert_eq!("mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCg==?a=666&m=2+baby+goats&s=CQkJCQ%3D%3D", encoded_str);
-        assert_eq!(156, encoded_str.len());
+        assert_eq!("mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCl6E?a=666&m=2+baby+goats&s=CQkJCfSo", encoded_str);
+        assert_eq!(152, encoded_str.len());
 
         let b58_payload = RequestPayload::new_v3(
             &addr.spend_public_key().to_bytes(),
@@ -109,7 +109,7 @@ fn test_url_encoding() {
         let payload = PaymentRequest::from(addr);
         let encoded = MobUrl::try_from(&payload).unwrap();
         let encoded_str: &str = encoded.as_ref();
-        assert_eq!("mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMQ==?s=CQkJCQ%3D%3D", encoded_str);
+        assert_eq!("mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMRqp?s=CQkJCfSo", encoded_str);
 
         let b58_payload = RequestPayload::new_v1(
             &addr.spend_public_key().to_bytes(),
@@ -134,8 +134,8 @@ fn test_url_encoding() {
         };
         let encoded = MobUrl::try_from(&payload).unwrap();
         let encoded_str: &str = encoded.as_ref();
-        assert_eq!("mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMQ==?a=666&m=2+baby+goats&s=CQkJCQ%3D%3D", encoded_str);
-        assert_eq!(158, encoded_str.len());
+        assert_eq!("mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMRqp?a=666&m=2+baby+goats&s=CQkJCfSo", encoded_str);
+        assert_eq!(154, encoded_str.len());
 
         let b58_payload = RequestPayload::new_v3(
             &addr.spend_public_key().to_bytes(),

--- a/util/url-encoding/tests/comparison.rs
+++ b/util/url-encoding/tests/comparison.rs
@@ -1,0 +1,154 @@
+use core::convert::TryFrom;
+use mc_crypto_keys::RistrettoPrivate;
+use mc_transaction_core::account_keys::{AccountKey, PublicAddress};
+use mc_util_b58_payloads::payloads::RequestPayload;
+use mc_util_from_random::FromRandom;
+use mc_util_test_helper::SeedableRng;
+use mc_util_url_encoding::{MobUrl, PaymentRequest};
+use rand_hc::Hc128Rng;
+
+fn sample_pub_addresses() -> Vec<PublicAddress> {
+    let mut rng = Hc128Rng::from_seed([1u8; 32]);
+
+    let accts = [
+        AccountKey::new(
+            &RistrettoPrivate::from_random(&mut rng),
+            &RistrettoPrivate::from_random(&mut rng),
+        ),
+        AccountKey::new_with_fog(
+            &RistrettoPrivate::from_random(&mut rng),
+            &RistrettoPrivate::from_random(&mut rng),
+            "fog://fog.mobilecoin.signal.org",
+            "".to_string(),
+            b"12345678",
+        ),
+        AccountKey::new_with_fog(
+            &RistrettoPrivate::from_random(&mut rng),
+            &RistrettoPrivate::from_random(&mut rng),
+            "fog://fog.diogenes.mobilecoin.com",
+            "".to_string(),
+            b"99999999",
+        ),
+    ];
+
+    accts.iter().map(|acct| acct.default_subaddress()).collect()
+}
+
+#[test]
+fn test_url_encoding() {
+    let addrs = sample_pub_addresses();
+
+    {
+        let addr = &addrs[0];
+        let payload = PaymentRequest::from(addr);
+        let encoded = MobUrl::try_from(&payload).unwrap();
+        let encoded_str: &str = encoded.as_ref();
+        assert_eq!("mob:///eCwRQ1riR1LTp8rpOMcn_rc3EajKx1EZ3cXV17SPDn2UyDJYXMl9TdQZoo5H3MDzTz14WBFVAARfGrXbMv8hGw==?", encoded_str);
+        assert_eq!(96, encoded_str.len());
+
+        let b58_payload = RequestPayload::new_v0(
+            &addr.spend_public_key().to_bytes(),
+            &addr.view_public_key().to_bytes(),
+        )
+        .unwrap();
+        let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
+        assert_eq!("mob:///8BicLagkcC2AxG2foBd76LFAPNpLiwat5C6r57FHz3ddWiNCQYk4JEzpwvUd1NJbDeuPNCeM1gQMq8dyw1b72zkKpYqToWJW", b58_encoded);
+        assert_eq!(103, b58_encoded.len());
+    }
+
+    {
+        let addr = &addrs[1];
+        let payload = PaymentRequest::from(addr);
+        let encoded = MobUrl::try_from(&payload).unwrap();
+        let encoded_str: &str = encoded.as_ref();
+        assert_eq!("mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCg==?s=CQkJCQ%3D%3D", encoded_str);
+        assert_eq!(135, encoded_str.len());
+
+        let b58_payload = RequestPayload::new_v1(
+            &addr.spend_public_key().to_bytes(),
+            &addr.view_public_key().to_bytes(),
+            addr.fog_report_url().unwrap(),
+            "",
+            addr.fog_authority_sig().unwrap(),
+        )
+        .unwrap();
+        let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
+        assert_eq!("mob:///5PFsXuSi9PUaJueuB4KxgWYiLXdL6EyvLmFGYiJ4Y5eGNJjHcZUraPTT1jTFd5QR7TXCTyYt5cLLxntmnvQnvr2Xq6czwZwGBMuhPEX6yoBFY2D1CeqGhQrmqcCGVm6y3abyVAL6rfrhbfe5SyBM", b58_encoded);
+        assert_eq!(155, b58_encoded.len());
+    }
+
+    {
+        let addr = &addrs[1];
+        let payload = PaymentRequest {
+            address: addr.clone(),
+            amount: Some(666),
+            memo: Some("2 baby goats".to_string()),
+        };
+        let encoded = MobUrl::try_from(&payload).unwrap();
+        let encoded_str: &str = encoded.as_ref();
+        assert_eq!("mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCg==?s=CQkJCQ%3D%3D&a=666&m=2+baby+goats", encoded_str);
+        assert_eq!(156, encoded_str.len());
+
+        let b58_payload = RequestPayload::new_v3(
+            &addr.spend_public_key().to_bytes(),
+            &addr.view_public_key().to_bytes(),
+            addr.fog_report_url().unwrap(),
+            "",
+            addr.fog_authority_sig().unwrap(),
+            666,
+            "2 baby goats",
+        )
+        .unwrap();
+        let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
+        assert_eq!("mob:///2iXQ1GUJPLuKZvKhGeCMDQdM4VsMvGNK3tVm7Kf68Hohf7Yhz6zigcDrh9x43PudHp4y5L5djNSy4rKRJtmEV8mHYm7Nt6b8p1NuNjZqV72qtru1uDgVgzmSqXAYS8wgXteqQBqnvQwE71ZranhPcCL1of38Tgz4J3z8Hc8ckjBmH9cnN", b58_encoded);
+        assert_eq!(184, b58_encoded.len());
+    }
+
+    {
+        let addr = &addrs[2];
+        let payload = PaymentRequest::from(addr);
+        let encoded = MobUrl::try_from(&payload).unwrap();
+        let encoded_str: &str = encoded.as_ref();
+        assert_eq!("mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMQ==?s=CQkJCQ%3D%3D", encoded_str);
+
+        let b58_payload = RequestPayload::new_v1(
+            &addr.spend_public_key().to_bytes(),
+            &addr.view_public_key().to_bytes(),
+            addr.fog_report_url().unwrap(),
+            "",
+            addr.fog_authority_sig().unwrap(),
+        )
+        .unwrap();
+        let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
+        assert_eq!("mob:///2M12NoHpvM5XMLtr4DYvdDvt9wUv1AsC2BbxCQD9ZsdanGbCA1V1wpXszfyYXh3Hr7f3RqzX3xZ1vtFJTkdinGYqJZCCbT8NqpEDk8S79ifZwgjjqZ63xzP4jH2rcgbLK9q1u2TdS1DyuwpH1857LHd", b58_encoded);
+
+        assert!(encoded_str.len() < b58_encoded.len());
+    }
+
+    {
+        let addr = &addrs[2];
+        let payload = PaymentRequest {
+            address: addr.clone(),
+            amount: Some(666),
+            memo: Some("2 baby goats".to_string()),
+        };
+        let encoded = MobUrl::try_from(&payload).unwrap();
+        let encoded_str: &str = encoded.as_ref();
+        assert_eq!("mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMQ==?s=CQkJCQ%3D%3D&a=666&m=2+baby+goats", encoded_str);
+        assert_eq!(158, encoded_str.len());
+
+        let b58_payload = RequestPayload::new_v3(
+            &addr.spend_public_key().to_bytes(),
+            &addr.view_public_key().to_bytes(),
+            addr.fog_report_url().unwrap(),
+            "",
+            addr.fog_authority_sig().unwrap(),
+            666,
+            "2 baby goats",
+        )
+        .unwrap();
+        let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
+        assert_eq!("mob:///SaxbkSaDTRXWa6r5Ccfpu5FpHp8JwHtvXbwyvNbGde4YioYMWAJnT3zJZVCxGYvjWdZmBv37EMVFuJjYycKwqyV9J7MjfzYDZgiMYzzBmM74pJZs7cDD92b3Dj613AkKVgsbRCJ1tcj7zLzwVtMoocra7evyxRVHJgwiasazJV5Jgxwan5G", b58_encoded);
+        assert_eq!(186, b58_encoded.len());
+    }
+}


### PR DESCRIPTION
Soundtrack of this PR: https://www.youtube.com/watch?v=AjPySjTNMf0

### Motivation

This is an alternative to the b58-encoding scheme, outlined by James
sometime in Jan or Feb. I have tried to fill in the details.

The goals are described in the README.md, I'll recap here though.

QR-codes are not the only use-case for a mobilecoin url encoding.
Sometimes a human may actually want to use the URL e.g. in an email or something.

URL-encoding schemes are already widely used in software, and most OS's allow
that a program can be registered to handle url's of a custom scheme type.
When those URL encodings are created, usually they use standard techniques like
query parameters to encode the data, so that they are at least partly understandable
to humans. This is different from the b58-encoding approach where the entire payload
is treated as binary data and then encoded, so that the whole thing is opaque.

In this encoding, here is an example payment request:

```
mob://fog.mobilecoin.com/oGbA6juTWhUdfL6qNMocAGN96wNiZpZegP0TUjKXHEM-GYmM50bLJVeL6NgftIumjt8nwYw7MjEnQT7hCw9bVQ==?s=CQkJCQ%3D%3D&a=777&m=2+baby+goats
```

The fog.mobilecoin.com is the fog host, which shows that the user's account is registered with a particular service. I can see that the amount is 777, and the memo field indicates that the payment is for "2 baby goats". I can see from the url that there is a fog authority signature (s=...) and I don't need to b58-decode it to see that.

Here is an example in this format when there is no fog-url (a fogless account):

```
mob:///oGbA6juTWhUdfL6qNMocAGN96wNiZpZegP0TUjKXHEM-GYmM50bLJVeL6NgftIumjt8nwYw7MjEnQT7hCw9bVQ==?a=777&m=ham+sandwich
```

Even though it's mostly opaque, I can still see the amount is 777 and the memo indicates that it's for "ham sandwich".

From the readme:

> The design goals are:
> - Be simple and straightforward. If I'm a fog user, and fog.mobilecoin.org is my
  fog hostname, then the url's hostname is fog.mobilecoin.org. The amount is
  human readable as a query parameter. The memo is human readable as a query parameter.
  This means that if the url appears e.g. in an email, I have some visibility into
  its contents beyond just b58-encoded bytes. If e.g. the `fog-authority-sig` is missing,
  I can see that that query parameter isn't there, which may make it easier to debug
  why a transfer is failing, than if everything were just a b58 blob.
> - Be easy to construct using standard url and base64 javascript libraries.
  If a third-party web developer has e.g. the protobuf corresponding to someone's
  public address, following schema in external.proto, they should ideally be able
  to make a well-formed url-encoded payment request without porting libmobilecoin
  rust code to their platform.
> - Be easily extensible. If we want to add more fields, we can simply add query parameters.
>
> This is an alternative to the b58-payloads design, with different tradeoffs.
It's possible that the b58-payloads will be slightly smaller and therefore lead
to a slightly better QR code. In some use-cases that isn't important.
>
> It's also not clear-cut that b58-payloads are always smaller and more efficient than this one.
The b58 compression is slightly less efficient than b64, and the b58 compression is applied even
to things that are already URLs, like the fog-url, so the fog-url gets ~30% larger or so.
This url-encoding uses the fog-url as is and extends it, so the 30% penalty doesn't apply to
the fog-url at all. So for a large fog-url this format is competitive in size.

In measurements, it turns out that this is actually significantly smaller than the b58 encoding payloads, 10-20% smaller, with larger savings when the user has fog.

It's also worth noting that this format can co-exist with the b58 encoding, or they can simply use two different schemes.

The API is also a little nicer, there is only one payload struct, with optional members, as opposed to four structures which are subsets of one another and a binary versioning tag.

### In this PR

- Adds `mc-util-url-encoding` for encoding public addresses, together with optional amount and memo information
- Completes "mob-url" outlined in internal RFC from Feb
- Adds round-trip tests, and begins to impose requirement that fog-url contains the `fog://` scheme or the `insecure-fog://` scheme. Schemeless url's are not allowed.

### Future Work

Remove hacks that were adding the scheme into the data that are in the internal SDK and test client. Require that bootstrap etc. provide the scheme whenever we have a URL. Particularly, `example.com` is not a valid fog url.
