### PR TITLE
[MC-1604] Add Receipt to external.proto

### DIFF
--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -188,3 +188,26 @@ message TxHash {
     // Hash of a single transaction.
     bytes hash = 1;
 }
+
+// Given to the recipient of a transaction output by the sender so that the
+// recipient may verify that the other party is indeed the sender.
+//
+// Often given to the recipient before the transaction is finalized so that
+// the recipient may know to anticipate the arrival of a transaction output,
+// as well as know who it's from, when to consider it as having surpassed
+// the tombstone block, and the expected amount of the output.
+message Receipt {
+    // Public key of the TxOut.
+    CompressedRistretto public_key = 1;
+
+    // Confirmation number of the TxOut.
+    TxOutConfirmationNumber confirmation = 2;
+
+    // Tombstone block of the Tx that produced the TxOut.
+    // Note: This value is self-reported by the sender and is unverifiable.
+    uint64 tombstone_block = 3;
+
+    // Amount of the TxOut.
+    // Note: This value is self-reported by the sender and is unverifiable.
+    Amount amount = 4;
+}

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -104,6 +104,15 @@ message TxOutMembershipProof {
     repeated TxOutMembershipElement elements = 3;
 }
 
+// A hash of the shared secret of a transaction output.
+//
+// Can be used by the recipient of a transaction output to verify that the
+// bearer of this number knew the shared secret of the transaction output,
+// thereby providing evidence that they are the sender.
+message TxOutConfirmationNumber {
+    bytes hash = 1;
+}
+
 // Amount.
 message Amount {
     // A Pedersen commitment `v*G + s*H`

--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -943,7 +943,7 @@ mod conversion_tests {
     }
 
     #[test]
-    // blockchain::TxHash --> tx::TxHash
+    // external::TxHash --> tx::TxHash
     fn test_tx_hash_try_from() {
         let mut source = external::TxHash::new();
         source.set_hash(vec![7u8; 32]);

--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -628,6 +628,30 @@ impl TryFrom<&external::TxOutMembershipProof> for TxOutMembershipProof {
     }
 }
 
+/// Convert tx::TxOutConfirmationNumber --> external::TxOutConfirmationNumber.
+impl From<&tx::TxOutConfirmationNumber> for external::TxOutConfirmationNumber {
+    fn from(src: &tx::TxOutConfirmationNumber) -> Self {
+        let mut tx_confirmation = external::TxOutConfirmationNumber::new();
+        tx_confirmation.set_hash(src.to_vec());
+        tx_confirmation
+    }
+}
+
+/// Convert  external::TxOutConfirmationNumber --> tx::TxOutConfirmationNumber.
+impl TryFrom<&external::TxOutConfirmationNumber> for tx::TxOutConfirmationNumber {
+    type Error = ConversionError;
+
+    fn try_from(src: &external::TxOutConfirmationNumber) -> Result<Self, Self::Error> {
+        let bytes: &[u8] = src.get_hash();
+        let mut hash = [0u8; 32];
+        if bytes.len() != hash.len() {
+            return Err(ConversionError::ArrayCastError);
+        }
+        hash.copy_from_slice(bytes);
+        Ok(tx::TxOutConfirmationNumber::from(hash))
+    }
+}
+
 /// Convert mc_transaction_core::BlockID --> blockchain::BlockID.
 impl From<&mc_transaction_core::BlockID> for blockchain::BlockID {
     fn from(src: &mc_transaction_core::BlockID) -> Self {
@@ -1251,6 +1275,39 @@ mod conversion_tests {
             assert_eq!(bytes.len(), expected_hash.len());
             assert_eq!(bytes, expected_hash);
         }
+    }
+
+    #[test]
+    // tx::TxOutConfirmationNumber --> external::TxOutConfirmationNumber.
+    fn test_confirmation_number_from() {
+        let source: tx::TxOutConfirmationNumber = tx::TxOutConfirmationNumber::from([7u8; 32]);
+        let converted = external::TxOutConfirmationNumber::from(&source);
+        assert_eq!(converted.hash.as_slice(), source.as_ref());
+    }
+
+    #[test]
+    // external::TxOutConfirmationNumber --> tx::TxOutConfirmationNumber
+    fn test_confirmation_number_try_from() {
+        let mut source = external::TxOutConfirmationNumber::new();
+        source.set_hash(vec![7u8; 32]);
+        let converted = tx::TxOutConfirmationNumber::try_from(&source).unwrap();
+        assert_eq!(*converted.as_ref(), [7u8; 32]);
+    }
+
+    #[test]
+    // Unmarshalling too many bytes into a TxOutConfirmationNumber should produce an error.
+    fn test_confirmation_number_try_from_too_many_bytes() {
+        let mut source = external::TxOutConfirmationNumber::new();
+        source.set_hash(vec![7u8; 99]); // Too many bytes.
+        assert!(tx::TxOutConfirmationNumber::try_from(&source).is_err());
+    }
+
+    #[test]
+    // Unmarshalling too few bytes into a TxOutConfirmationNumber should produce an error.
+    fn test_confirmation_number_try_from_too_few_bytes() {
+        let mut source = external::TxOutConfirmationNumber::new();
+        source.set_hash(vec![7u8; 3]); // Too few bytes.
+        assert!(tx::TxOutConfirmationNumber::try_from(&source).is_err());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

The sender of a transaction has a need for a well-established way to notify the intended recipient to expect an incoming `TxOut` in a way that is verifiable, at least in part, by the recipient.

This `Receipt` structure provides the recipient with the following:
* The public key of the expected `TxOut`. Because `TxOut` public keys are unique in the ledger, this will uniquely identify the `TxOut`.
* The confirmation number of the `TxOut`, which can be used by the recipient of the `TxOut` to confirm that the `TxOut` is indeed intended for them, and to provide evidence that the other party is the sender, or at least knew the shared secret of the `TxOut`.
* The tombstone block of the `Tx` that produced the `TxOut`. One intended use-caes of `Receipt` is to represent a `TxOut` that is not yet in the ledger. By providing the tombstone block, the recipient can know when to stop expecting the `TxOut` and in turn consider the transaction having failed.
* The `Amount` of the `TxOut`, as reported by the sender. Note, however, that the recipient has no way to verify that the `Amount` represents the actual amount of the `TxOut`.

It should be noted that the tombstone block and `Amount` are both self-reported by the sender and there is no way for the recipient to assess their validity. They are provided on an informational basis only, so that the recipient may have the option to trust them, depending on how much trust they have in the sender.

### In this PR
* Adds `Receipt` to `external.proto`
* Adds `TxOutConfirmationNumber` to `external.proto`
* Adds conversion functions between `external::TxOutConfirmationNumber` and `tx::TxOutConfirmationNumber`
* Fixes a typo in a comment related to `TxHash` conversion

Fixes MC-1604

### Future Work
* Out of scope for this PR is providing a Rust-native structure to mirror `Receipt`. `Receipt` is primarily used by end-clients and, for the purposes of this PR, it is only being added to `external.proto`.
* MC-1576 - Add transaction receipt creation/verification to mobilecoind