### PR TITLE
Remove external.RistrettoPublic, replace with CompressedRistretto

### DIFF
--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -13,13 +13,6 @@ option java_outer_classname = "MobileCoinAPI";
 // `keys` crate
 ///////////////////////////////////////////////////////////////////////////////
 
-/// Note: This is used only in mobilecoind. It is not recommended to use
-/// uncompressed RistrettoPublic in protobuf types because the decompressions
-/// may be unnecessary and can cause significant performance hit.
-message RistrettoPublic {
-    bytes data = 1;
-}
-
 /// A Ristretto private key.
 message RistrettoPrivate {
     bytes data = 1;
@@ -31,9 +24,12 @@ message CompressedRistretto {
 }
 
 /// A 32-byte scalar associated to the ristretto group.
-/// This is the same as RistrettoPrivate, but they are used in different places,
-/// the transaction crate generally uses CurveScalar and higher-level crates use
-/// RistrettoPrivate.
+/// This is the same as RistrettoPrivate, but they are used in different places.
+/// Many crates only need keys to perform key exchange operations, and strictly
+/// use the RistrettoPublic and RistrettoPrivate types.
+/// The transaction crate often uses CurveScalar and sometimes must perform
+/// raw elliptic curve operations etc.
+/// This type can possibly be factored out.
 message CurveScalar {
     bytes data = 1;
 }

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -25,11 +25,7 @@ message CompressedRistretto {
 
 /// A 32-byte scalar associated to the ristretto group.
 /// This is the same as RistrettoPrivate, but they are used in different places.
-/// Many crates only need keys to perform key exchange operations, and strictly
-/// use the RistrettoPublic and RistrettoPrivate types.
-/// The transaction crate often uses CurveScalar and sometimes must perform
-/// raw elliptic curve operations etc.
-/// This type can possibly be factored out.
+/// TODO: MC-1605 Consider to factor out this type, or just this proto message.
 message CurveScalar {
     bytes data = 1;
 }

--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -130,25 +130,6 @@ impl From<&RistrettoPrivate> for external::CurveScalar {
     }
 }
 
-/// Convert RistrettoPublic --> external::RistrettoPublic
-impl From<&RistrettoPublic> for external::RistrettoPublic {
-    fn from(other: &RistrettoPublic) -> Self {
-        let mut key = external::RistrettoPublic::new();
-        key.set_data(other.into());
-        key
-    }
-}
-
-/// Convert external::RistrettoPublic --> RistrettoPublic.
-impl TryFrom<&external::RistrettoPublic> for RistrettoPublic {
-    type Error = ConversionError;
-
-    fn try_from(source: &external::RistrettoPublic) -> Result<Self, Self::Error> {
-        let bytes: &[u8] = source.get_data();
-        RistrettoPublic::try_from(bytes).map_err(|_| ConversionError::ArrayCastError)
-    }
-}
-
 /// Convert external::CompressedRistretto --> RistrettoPublic.
 impl TryFrom<&external::CompressedRistretto> for RistrettoPublic {
     type Error = ConversionError;
@@ -156,15 +137,6 @@ impl TryFrom<&external::CompressedRistretto> for RistrettoPublic {
     fn try_from(source: &external::CompressedRistretto) -> Result<Self, Self::Error> {
         let bytes: &[u8] = source.get_data();
         RistrettoPublic::try_from(bytes).map_err(|_| ConversionError::ArrayCastError)
-    }
-}
-
-/// Convert CompressedRistrettoPublic --> external::RistrettoPublic
-impl From<CompressedRistrettoPublic> for external::RistrettoPublic {
-    fn from(other: CompressedRistrettoPublic) -> Self {
-        let mut key = external::RistrettoPublic::new();
-        key.set_data(other.as_bytes().to_vec());
-        key
     }
 }
 

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -147,7 +147,7 @@ message ReceiverTxReceipt {
     external.PublicAddress recipient = 1;
 
     // The public key of the TxOut sent to this recipient.
-    external.RistrettoPublic tx_public_key = 2;
+    external.CompressedRistretto tx_public_key = 2;
 
     // The hash of the TxOut sent to this recipient.
     bytes tx_out_hash = 3;
@@ -298,14 +298,14 @@ message ReadTransferCodeRequest {
 }
 message ReadTransferCodeResponse {
     bytes entropy = 1;
-    external.RistrettoPublic tx_public_key = 2;
+    external.CompressedRistretto tx_public_key = 2;
     string memo = 3;
 }
 
 // Encode entropy/tx_public_key/memo into a base-58 "MobileCoin Transfer Code".
 message GetTransferCodeRequest {
     bytes entropy = 1;
-    external.RistrettoPublic tx_public_key = 2;
+    external.CompressedRistretto tx_public_key = 2;
     string memo = 3;
 }
 message GetTransferCodeResponse {


### PR DESCRIPTION
Soundtrack of this PR: https://www.youtube.com/watch?v=q_7l0ozbHVA

### Motivation

Generally, we should not use RistrettoPublic in serialized types,
we should try to use CompressedRistretto, because decompressing
a ristretto point requires elliptic curve operations and is pretty
slow. In early performance profiling, consensus spent most of its
time doing this, and that is why we created the CompressedRistretto
type.

The protobuf type external.RistrettoPublic is actually identical
to external.CompressedRistretto, we don't need both, and we should
discourage people from using RistrettoPublic in their serialized
structs.

### In this PR

Remove `external.RistrettoPublic`
Fixup mobilecoind_api.
Turns out we have enough conversions on external.CompressedRistretto
now that no code changes are required.

Fog-125