### PR TITLE
Rename fog_report_key to fog_report_id, per discussion

### DIFF
--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -61,10 +61,10 @@ message AccountKey {
     /// Empty string when not in use, i.e. for accounts that don't have fog service.
     string fog_report_url = 3;
 
-    /// Optional fog report key.
-    /// The fog report server may serve multiple reports, this key disambiguates
+    /// Optional fog report id.
+    /// The fog report server may serve multiple reports, this id disambiguates
     /// which one to use when sending to this account.
-    string fog_report_key = 4;
+    string fog_report_id = 4;
 
     /// Optional fingerprint of fog authority key.
     /// Empty when not in use.
@@ -84,10 +84,10 @@ message PublicAddress {
     /// Indicates the place at which the fog report server should be contacted.
     string fog_report_url = 3;
 
-    /// Optional fog report key.
-    /// The fog report server may serve multiple reports, this key disambiguates
+    /// Optional fog report id.
+    /// The fog report server may serve multiple reports, this id disambiguates
     /// which one to use when sending to this account.
-    string fog_report_key = 4;
+    string fog_report_id = 4;
 
     /// Signature of fog authority fingerprint using private key which
     /// corresponds to view_public_key.

--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -809,8 +809,8 @@ impl From<&AccountKey> for external::AccountKey {
             dst.set_fog_authority_key_fingerprint(fingerprint.to_vec());
         }
 
-        if let Some(key) = src.fog_report_key() {
-            dst.set_fog_report_key(key.to_string());
+        if let Some(key) = src.fog_report_id() {
+            dst.set_fog_report_id(key.to_string());
         }
 
         dst
@@ -840,7 +840,7 @@ impl TryFrom<&external::AccountKey> for AccountKey {
                 &spend_private_key,
                 &view_private_key,
                 &src.fog_report_url,
-                src.fog_report_key.clone(),
+                src.fog_report_id.clone(),
                 &src.fog_authority_key_fingerprint[..],
             ))
         }
@@ -862,8 +862,8 @@ impl From<&PublicAddress> for external::PublicAddress {
             dst.set_fog_authority_sig(sig.to_vec());
         }
 
-        if let Some(key) = src.fog_report_key() {
-            dst.set_fog_report_key(key.to_string());
+        if let Some(key) = src.fog_report_id() {
+            dst.set_fog_report_id(key.to_string());
         }
 
         dst
@@ -893,7 +893,7 @@ impl TryFrom<&external::PublicAddress> for PublicAddress {
                 &spend_public_key,
                 &view_public_key,
                 &src.fog_report_url,
-                src.fog_report_key.clone(),
+                src.fog_report_id.clone(),
                 src.fog_authority_sig.clone(),
             ))
         }
@@ -1434,7 +1434,7 @@ mod conversion_tests {
 
             assert_eq!(proto_credentials.fog_authority_key_fingerprint.len(), 0);
 
-            assert_eq!(proto_credentials.fog_report_key, String::from(""));
+            assert_eq!(proto_credentials.fog_report_id, String::from(""));
 
             // external -> account_keys
             let account_key2 = AccountKey::try_from(&proto_credentials).unwrap();
@@ -1472,7 +1472,7 @@ mod conversion_tests {
                 vec![9, 9, 9, 9],
             );
 
-            assert_eq!(proto_credentials.fog_report_key, String::from("99"));
+            assert_eq!(proto_credentials.fog_report_id, String::from("99"));
 
             // external -> account_keys
             let account_key2 = AccountKey::try_from(&proto_credentials).unwrap();
@@ -1502,7 +1502,7 @@ mod conversion_tests {
 
             assert_eq!(proto_credentials.fog_authority_sig.len(), 0);
 
-            assert_eq!(proto_credentials.fog_report_key, String::from(""));
+            assert_eq!(proto_credentials.fog_report_id, String::from(""));
 
             // external -> public_addresss
             let public_address2 = PublicAddress::try_from(&proto_credentials).unwrap();
@@ -1537,7 +1537,7 @@ mod conversion_tests {
 
             assert_eq!(proto_credentials.fog_authority_sig, vec![9, 9, 9, 9],);
 
-            assert_eq!(proto_credentials.fog_report_key, "99");
+            assert_eq!(proto_credentials.fog_report_id, "99");
 
             // external -> public_addresss
             let public_address2 = PublicAddress::try_from(&proto_credentials).unwrap();

--- a/mobilecoind-json/src/main.rs
+++ b/mobilecoind-json/src/main.rs
@@ -253,7 +253,7 @@ struct JsonPublicAddress {
     /// Hex encoded signature bytes
     fog_authority_sig: String,
     /// String label for fog reports
-    fog_report_key: String,
+    fog_report_id: String,
 }
 
 // Helper conversion between json and protobuf
@@ -278,7 +278,7 @@ impl TryFrom<&JsonPublicAddress> for PublicAddress {
         public_address.set_view_public_key(view_public_key);
         public_address.set_spend_public_key(spend_public_key);
         public_address.set_fog_report_url(src.fog_report_url.clone());
-        public_address.set_fog_report_key(src.fog_report_key.clone());
+        public_address.set_fog_report_id(src.fog_report_id.clone());
         public_address.set_fog_authority_sig(
             hex::decode(&src.fog_authority_sig)
                 .map_err(|err| format!("Failed to decode fog authority sig hex: {}", err))?,
@@ -318,7 +318,7 @@ fn read_request(
             view_public_key: hex::encode(receiver.get_view_public_key().get_data().to_vec()),
             spend_public_key: hex::encode(receiver.get_spend_public_key().get_data().to_vec()),
             fog_report_url: String::from(receiver.get_fog_report_url()),
-            fog_report_key: String::from(receiver.get_fog_report_key()),
+            fog_report_id: String::from(receiver.get_fog_report_id()),
             fog_authority_sig: hex::encode(receiver.get_fog_authority_sig().to_vec()),
         },
         value: resp.get_value().to_string(),

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -381,7 +381,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             &view_key,
             &spend_key,
             receiver.fog_report_url().unwrap_or(&""),
-            receiver.fog_report_key().unwrap_or(&""),
+            receiver.fog_report_id().unwrap_or(&""),
             receiver.fog_authority_sig().unwrap_or(&[]),
             request.get_value(),
             request.get_memo(),

--- a/transaction/core/src/account_keys.rs
+++ b/transaction/core/src/account_keys.rs
@@ -55,10 +55,10 @@ pub struct PublicAddress {
     fog_report_url: String,
 
     /// The fog report server potentially returns multiple reports when queried.
-    /// This value is the key that indicates which of the reports to use.
+    /// This id string indicates which of the reports to use.
     /// Empty if no fog for this public address.
     #[prost(string, tag = "4")]
-    fog_report_key: String,
+    fog_report_id: String,
 
     /// A signature with the user's spend_private_key over the fog authority key fingerprint.
     /// Empty if no fog for this public address
@@ -80,8 +80,8 @@ impl fmt::Display for PublicAddress {
         if !self.fog_report_url.is_empty() {
             write!(f, ":'{}'", self.fog_report_url)?;
         }
-        if !self.fog_report_key.is_empty() {
-            write!(f, ":{}", self.fog_report_key)?;
+        if !self.fog_report_id.is_empty() {
+            write!(f, "#{}", self.fog_report_id)?;
         }
         Ok(())
     }
@@ -99,8 +99,8 @@ impl PublicAddress {
             view_public_key: *view_public_key,
             spend_public_key: *spend_public_key,
             fog_report_url: Default::default(),
+            fog_report_id: Default::default(),
             fog_authority_sig: Default::default(),
-            fog_report_key: Default::default(),
         }
     }
 
@@ -110,21 +110,21 @@ impl PublicAddress {
     /// `spend_public_key` - The user's public subaddress spend key `D`,
     /// `view_public_key` - The user's public subaddress view key `C`,
     /// `fog_report_url` - User's fog report server url
-    /// `fog_report_key` - The key labelling the report to use, from among the several reports which might be served by the fog report server.
+    /// `fog_report_id` - The id labelling the report to use, from among the several reports which might be served by the fog report server.
     /// `fog_authority_sig` - A signature over the fog authority fingerprint using the subaddress_spend_private_key
     #[inline]
     pub fn new_with_fog(
         spend_public_key: &RistrettoPublic,
         view_public_key: &RistrettoPublic,
         fog_report_url: impl ToString,
-        fog_report_key: String,
+        fog_report_id: String,
         fog_authority_sig: Vec<u8>,
     ) -> Self {
         Self {
             view_public_key: *view_public_key,
             spend_public_key: *spend_public_key,
             fog_report_url: fog_report_url.to_string(),
-            fog_report_key,
+            fog_report_id,
             fog_authority_sig,
         }
     }
@@ -158,11 +158,11 @@ impl PublicAddress {
     }
 
     /// Get the optional fog report key (if it exists / is not empty).
-    pub fn fog_report_key(&self) -> Option<&str> {
-        if self.fog_report_key.is_empty() {
+    pub fn fog_report_id(&self) -> Option<&str> {
+        if self.fog_report_id.is_empty() {
             None
         } else {
-            Some(&self.fog_report_key)
+            Some(&self.fog_report_id)
         }
     }
 }
@@ -188,7 +188,7 @@ pub struct AccountKey {
     /// The key labelling the report to use, from among the several reports
     /// which might be served by the fog report server.
     #[prost(string, tag = "4")]
-    fog_report_key: String,
+    fog_report_id: String,
 
     /// Fog Authority Key Fingerprint (if user has Fog service), empty otherwise
     #[prost(bytes, tag = "5")]
@@ -236,7 +236,7 @@ impl AccountKey {
             spend_private_key: *spend_private_key,
             view_private_key: *view_private_key,
             fog_report_url: Default::default(),
-            fog_report_key: Default::default(),
+            fog_report_id: Default::default(),
             fog_authority_key_fingerprint: Default::default(),
         }
     }
@@ -247,7 +247,7 @@ impl AccountKey {
     /// * `spend_private_key` - The user's private spend key `b`.
     /// * `view_private_key` - The user's private view key `a`.
     /// * `fog_report_url` - Url of fog report service
-    /// * `fog_report_key` - The key labelling the report to use, from among the
+    /// * `fog_report_id` - The id labelling the report to use, from among the
     ///                     several reports which might be served by the fog report server.
     /// * `fog_authority` - The fingerprint of the public key of the fog authority,
     ///                     which is signed by the user for the public address.
@@ -255,14 +255,14 @@ impl AccountKey {
         spend_private_key: &RistrettoPrivate,
         view_private_key: &RistrettoPrivate,
         fog_report_url: impl ToString,
-        fog_report_key: String,
+        fog_report_id: String,
         fog_authority: impl AsRef<[u8]>,
     ) -> Self {
         Self {
             spend_private_key: *spend_private_key,
             view_private_key: *view_private_key,
             fog_report_url: fog_report_url.to_string(),
-            fog_report_key,
+            fog_report_id,
             fog_authority_key_fingerprint: fog_authority.as_ref().to_vec(),
         }
     }
@@ -296,11 +296,11 @@ impl AccountKey {
     }
 
     /// Access the fog report key (if it exists).
-    pub fn fog_report_key(&self) -> Option<&str> {
-        if self.fog_report_key.is_empty() {
+    pub fn fog_report_id(&self) -> Option<&str> {
+        if self.fog_report_id.is_empty() {
             None
         } else {
-            Some(&self.fog_report_key)
+            Some(&self.fog_report_id)
         }
     }
 
@@ -356,7 +356,7 @@ impl AccountKey {
             view_public_key: subaddress_view_public,
             spend_public_key: subaddress_spend_public,
             fog_report_url: self.fog_report_url.clone(),
-            fog_report_key: self.fog_report_key.clone(),
+            fog_report_id: self.fog_report_id.clone(),
             fog_authority_sig: Default::default(),
         };
 


### PR DESCRIPTION

Soundtrack of this PR: https://www.youtube.com/watch?v=ktwlN_ocL-o

### Motivation

The term "fog_report_key" is ambiguous with actual cryptographic keys,
this is just an id / label string. In discussion it was proposed to rename it
to an id instead.

### In this PR

Rename the `fog_report_key` field to `fog_report_id`