### PR TITLE
prefer std::{HashSet, HashMap} to mc_common

### DIFF
--- a/consensus/scp/src/msg.rs
+++ b/consensus/scp/src/msg.rs
@@ -6,13 +6,13 @@ use crate::{
     msg::Topic::*,
     quorum_set::QuorumSet,
 };
-use mc_common::{HashSet, NodeID};
+use mc_common::NodeID;
 use mc_crypto_digestible::Digestible;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
     cmp,
     cmp::Ordering,
-    collections::{hash_map::DefaultHasher, BTreeSet},
+    collections::{hash_map::DefaultHasher, BTreeSet, HashSet},
     fmt::{Debug, Display},
     hash::{Hash, Hasher},
 };

--- a/consensus/scp/src/predicates.rs
+++ b/consensus/scp/src/predicates.rs
@@ -4,7 +4,7 @@
 use mc_common::NodeID;
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
-    sync::Arc
+    sync::Arc,
 };
 
 use crate::{

--- a/consensus/scp/src/predicates.rs
+++ b/consensus/scp/src/predicates.rs
@@ -3,7 +3,7 @@
 //! Predicates for use in trust decisions for SCP.
 use mc_common::NodeID;
 use std::{
-    collections::{BTreeSet, HashSet, HashMap},
+    collections::{BTreeSet, HashMap, HashSet},
     sync::Arc
 };
 

--- a/consensus/scp/src/predicates.rs
+++ b/consensus/scp/src/predicates.rs
@@ -1,8 +1,11 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 //! Predicates for use in trust decisions for SCP.
-use mc_common::{HashMap, HashSet, NodeID};
-use std::{collections::BTreeSet, sync::Arc};
+use mc_common::NodeID;
+use std::{
+    collections::{BTreeSet, HashSet, HashMap},
+    sync::Arc
+};
 
 use crate::{
     core_types::{Ballot, GenericNodeId, Value},
@@ -178,7 +181,6 @@ impl<'a, V: Value, ID: GenericNodeId> Predicate<V, ID> for FuncPredicate<'a, V, 
 mod predicates_tests {
     use super::*;
     use crate::{core_types::*, msg::*, quorum_set::*, test_utils::test_node_id};
-    use mc_common::HashMap;
     use std::iter::FromIterator;
 
     #[test]

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -7,7 +7,7 @@ use mc_common::{NodeID, ResponderId};
 use mc_crypto_digestible::Digestible;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashSet, HashMap},
+    collections::{HashMap, HashSet},
     fmt::Debug,
     hash::{Hash, Hasher},
     iter::FromIterator,

--- a/consensus/scp/src/quorum_set.rs
+++ b/consensus/scp/src/quorum_set.rs
@@ -3,10 +3,11 @@
 //! The quorum set is the essential unit of trust in SCP.
 //!
 //! A quorum set includes the members of the network, which a given node trusts and depends on.
-use mc_common::{HashMap, HashSet, NodeID, ResponderId};
+use mc_common::{NodeID, ResponderId};
 use mc_crypto_digestible::Digestible;
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::{HashSet, HashMap},
     fmt::Debug,
     hash::{Hash, Hasher},
     iter::FromIterator,

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -14,10 +14,10 @@ use crate::{
 };
 use mc_common::{
     logger::{log, o, Logger},
-    HashMap, HashSet, NodeID,
+    NodeID,
 };
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashSet, HashMap},
     fmt::Display,
     iter::FromIterator,
     sync::Arc,

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -17,7 +17,7 @@ use mc_common::{
     NodeID,
 };
 use std::{
-    collections::{BTreeSet, HashSet, HashMap},
+    collections::{BTreeSet, HashMap, HashSet},
     fmt::Display,
     iter::FromIterator,
     sync::Arc,

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -12,7 +12,7 @@ use mc_consensus_scp::{
     test_utils,
 };
 use std::{
-    collections::{BTreeSet, HashSet, HashMap},
+    collections::{BTreeSet, HashMap, HashSet},
     iter::FromIterator,
     sync::{Arc, Mutex},
     thread,

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -2,7 +2,7 @@
 
 use mc_common::{
     logger::{log, o, Logger},
-    HashMap, HashSet, NodeID,
+    NodeID,
 };
 use mc_consensus_scp::{
     core_types::{CombineFn, SlotIndex, ValidityFn},
@@ -12,7 +12,7 @@ use mc_consensus_scp::{
     test_utils,
 };
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashSet, HashMap},
     iter::FromIterator,
     sync::{Arc, Mutex},
     thread,

--- a/ledger/sync/src/ledger_sync_service.rs
+++ b/ledger/sync/src/ledger_sync_service.rs
@@ -463,7 +463,7 @@ fn group_by_block(
 
             let group: &mut HashSet<ResponderId> = block_id_to_group
                 .entry(block.id.clone())
-                .or_insert_with(HashMap::default);
+                .or_insert_with(HashSet::default);
 
             group.insert(responder_id.clone());
         }

--- a/ledger/sync/src/ledger_sync_service.rs
+++ b/ledger/sync/src/ledger_sync_service.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use mc_common::{
     logger::{log, Logger},
-    HashMap, HashSet, ResponderId,
+    ResponderId,
 };
 use mc_connection::{
     BlockchainConnection, Connection, ConnectionManager, RetryableBlockchainConnection,
@@ -22,7 +22,7 @@ use mc_transaction_core::{
 use mc_util_uri::ConnectionUri;
 use retry::delay::Fibonacci;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap, HashSet},
     iter::FromIterator,
     sync::{Arc, Condvar, Mutex},
     thread,

--- a/ledger/sync/src/ledger_sync_service.rs
+++ b/ledger/sync/src/ledger_sync_service.rs
@@ -463,7 +463,7 @@ fn group_by_block(
 
             let group: &mut HashSet<ResponderId> = block_id_to_group
                 .entry(block.id.clone())
-                .or_insert(HashSet::default());
+                .or_insert_with(HashMap::default);
 
             group.insert(responder_id.clone());
         }

--- a/ledger/sync/src/network_state_trait.rs
+++ b/ledger/sync/src/network_state_trait.rs
@@ -2,8 +2,9 @@
 
 //! Tracks the state of peers' ledgers.
 
-use mc_common::{HashSet, ResponderId};
+use mc_common::ResponderId;
 use mc_transaction_core::BlockIndex;
+use std::collections::HashSet;
 
 /// An interface for an object that keeps track of the network's status, allowing SyncService to
 /// check if the local node has fallen behind a certain block index.

--- a/ledger/sync/src/polling_network_state.rs
+++ b/ledger/sync/src/polling_network_state.rs
@@ -6,7 +6,7 @@
 use crate::{network_state_trait::NetworkState, scp_network_state::SCPNetworkState};
 use mc_common::{
     logger::{log, Logger},
-    HashMap, HashSet, ResponderId,
+    ResponderId,
 };
 use mc_connection::{
     BlockchainConnection, Connection, ConnectionManager, RetryableBlockchainConnection,
@@ -18,6 +18,7 @@ use mc_transaction_core::BlockIndex;
 use mc_util_uri::ConnectionUri;
 use retry::delay::Fibonacci;
 use std::{
+    collections::{HashMap, HashSet},
     str::FromStr,
     sync::{Arc, Condvar, Mutex},
     thread,

--- a/ledger/sync/src/scp_network_state.rs
+++ b/ledger/sync/src/scp_network_state.rs
@@ -5,7 +5,7 @@
 use crate::network_state_trait::NetworkState;
 use mc_common::{
     logger::{log, Logger},
-    HashMap, HashSet, NodeID, ResponderId,
+    NodeID, ResponderId,
 };
 use mc_consensus_scp::{
     core_types::Ballot, msg::ExternalizePayload, predicates::FuncPredicate, GenericNodeId, Msg,
@@ -13,7 +13,11 @@ use mc_consensus_scp::{
 };
 use mc_transaction_core::BlockIndex;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{hash::Hash, iter::FromIterator};
+use std::{
+    collections::{HashMap, HashSet},
+    hash::Hash,
+    iter::FromIterator
+};
 
 pub struct SCPNetworkState<ID: GenericNodeId = NodeID> {
     // The local node ID.

--- a/ledger/sync/src/scp_network_state.rs
+++ b/ledger/sync/src/scp_network_state.rs
@@ -16,7 +16,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
-    iter::FromIterator
+    iter::FromIterator,
 };
 
 pub struct SCPNetworkState<ID: GenericNodeId = NodeID> {


### PR DESCRIPTION
Soundtrack of this PR: [LSO](https://soundcloud.com/lazysyruporchestra/take-the-long-way-home-remix)

### Motivation

The collections provided in `mc_common` were selected for use in the enclave. We've fallen into a habit of using them in places where the `std::collections` would be fine.

### In this PR
* change scp and ledger/sync to use std's HashSet and HashMap
