### PR TITLE
add a convenience method for parsing VerificationReportData timestamp

### DIFF
--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -19,6 +19,7 @@ std = [
     "failure/std",
     "mbedtls/std",
     "sha2/std",
+    "chrono",
 ]
 
 # This means "use the fake SGX stuff where required"
@@ -37,6 +38,7 @@ mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", tag 
 binascii = "0.1.2"
 bitflags = "1.2"
 cfg-if = "0.1"
+chrono = { version = "0.4.10", optional = true }
 digest = { version = "0.8", default-features = false }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
 hex_fmt = "0.3"

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -19,7 +19,6 @@ std = [
     "failure/std",
     "mbedtls/std",
     "sha2/std",
-    "chrono",
 ]
 
 # This means "use the fake SGX stuff where required"
@@ -38,7 +37,7 @@ mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", tag 
 binascii = "0.1.2"
 bitflags = "1.2"
 cfg-if = "0.1"
-chrono = { version = "0.4.10", optional = true }
+chrono = { version = "0.4.10", default-features = false, features = ["alloc"] }
 digest = { version = "0.8", default-features = false }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
 hex_fmt = "0.3"

--- a/attest/core/src/error.rs
+++ b/attest/core/src/error.rs
@@ -614,6 +614,8 @@ pub enum VerifyError {
     EpidPseudonym(EpidPseudonymError),
     #[fail(display = "The quote in a verification report does not match the expected quote.")]
     IasQuoteMismatch,
+    #[fail(display = "There was an error parsing the timestamp {}: {}", _0, _1)]
+    TimestampParse(String, String),
     #[fail(display = "There was an unknown error")]
     Unknown,
 }

--- a/attest/core/src/ias/verify.rs
+++ b/attest/core/src/ias/verify.rs
@@ -235,7 +235,6 @@ impl VerificationReportData {
     }
 
     /// Try and parse the timestamp string into a chrono object.
-    #[cfg(feature = "std")]
     pub fn parse_timestamp(&self) -> Result<chrono::DateTime<chrono::Utc>, VerifyError> {
         // Intel provides the timestamp as ISO8601 (compatible with RFC3339) but without the
         // Z specifier, which is required for chrono to be happy.

--- a/attest/core/src/ias/verify.rs
+++ b/attest/core/src/ias/verify.rs
@@ -716,6 +716,27 @@ mod test {
         let data = VerificationReportData::try_from(&report)
             .expect("Could not parse IAS verification report");
 
+        let timestamp = data.parse_timestamp().expect("failed parsing timestamp");
+        assert_eq!(timestamp.to_rfc3339(), "2019-06-19T22:11:17.616333+00:00");
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "failed parsing timestamp: TimestampParse(\"invalid\", \"input contains invalid characters\")"
+    )]
+    fn test_parse_timestamp_with_invalid_timestamp() {
+        let report = VerificationReport {
+            sig: VerificationSignature::default(),
+            chain: Vec::default(),
+            http_body: String::from(IAS_WITH_PIB),
+        };
+
+        let mut data = VerificationReportData::try_from(&report)
+            .expect("Could not parse IAS verification report");
+
+        data.timestamp = "invalid".to_string();
+
+        // This is expected to fail.
         let _timestamp = data.parse_timestamp().expect("failed parsing timestamp");
     }
 }

--- a/attest/net/src/sim.rs
+++ b/attest/net/src/sim.rs
@@ -43,7 +43,7 @@ impl RaClient for SimClient {
                     json!({
                         "id": "0",
                         "version": 3,
-                        "timestamp": "FIXME",
+                        "timestamp": "2020-06-30T22:16:41.409742",
                         "isvEnclaveQuoteStatus": "OK",
                         "isvEnclaveQuoteBody": quote.to_base64_owned(),
                         "nonce": nonce.to_string(),
@@ -53,7 +53,7 @@ impl RaClient for SimClient {
                     json!({
                         "id": "0",
                         "version": 3,
-                        "timestamp": "FIXME",
+                        "timestamp": "2020-06-30T22:16:41.409742",
                         "isvEnclaveQuoteStatus": "OK",
                         "isvEnclaveQuoteBody": quote.to_base64_owned(),
                         "nonce": nonce.to_string()
@@ -65,7 +65,7 @@ impl RaClient for SimClient {
                     json!({
                         "id": "0",
                         "version": 3,
-                        "timestamp": "FIXME",
+                        "timestamp": "2020-06-30T22:16:41.409742",
                         "isvEnclaveQuoteStatus": "OK",
                         "isvEnclaveQuoteBody": quote.to_base64_owned(),
                         "epidPseudonym": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
@@ -74,7 +74,7 @@ impl RaClient for SimClient {
                     json!({
                         "id": "0",
                         "version": 3,
-                        "timestamp": "FIXME",
+                        "timestamp": "2020-06-30T22:16:41.409742",
                         "isvEnclaveQuoteStatus": "OK",
                         "isvEnclaveQuoteBody": quote.to_base64_owned()
                     })

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -14,7 +14,7 @@ use grpcio::{EnvBuilder, Environment, Server, ServerBuilder};
 use mc_attest_api::attest_grpc::create_attested_api;
 use mc_attest_core::{
     IasQuoteError, PibError, QuoteError, QuoteSignType, TargetInfoError, VerificationReport,
-    VerificationReportData, VerifyError,
+    VerifyError,
 };
 use mc_attest_enclave_api::{ClientSession, Error as AttestEnclaveError, PeerSession};
 use mc_attest_net::{Error as RaError, RaClient};
@@ -36,7 +36,6 @@ use mc_util_uri::{ConnectionUri, ConsensusPeerUriApi};
 use retry::{delay::Fibonacci, retry, Error as RetryError, OperationResult};
 use serde_json::json;
 use std::{
-    convert::TryFrom,
     env,
     sync::{Arc, Mutex},
     time::Instant,
@@ -65,8 +64,6 @@ pub enum ConsensusServiceError {
     BackgroundWorkQueueStart(String),
     #[fail(display = "Failed to stop background work queue: {}", _0)]
     BackgroundWorkQueueStop(String),
-    #[fail(display = "Attest verify report error: {}", _0)]
-    Verify(VerifyError),
 }
 
 impl From<EnclaveError> for ConsensusServiceError {
@@ -96,12 +93,6 @@ impl From<RaError> for ConsensusServiceError {
 impl From<TargetInfoError> for ConsensusServiceError {
     fn from(src: TargetInfoError) -> Self {
         ConsensusServiceError::TargetInfo(src)
-    }
-}
-
-impl From<VerifyError> for ConsensusServiceError {
-    fn from(src: VerifyError) -> Self {
-        ConsensusServiceError::Verify(src)
     }
 }
 
@@ -375,10 +366,13 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
             self.logger,
             "Starting enclave report cache update process..."
         );
-        let mut ias_report = self.start_report_cache()?;
+        let ias_report = self.start_report_cache()?;
         log::debug!(self.logger, "Verifying IAS report with enclave...");
-        let retval = match self.enclave.verify_ias_report(ias_report.clone()) {
-            Ok(()) => Ok(()),
+        match self.enclave.verify_ias_report(ias_report) {
+            Ok(()) => {
+                log::debug!(self.logger, "Enclave accepted report as valid...");
+                Ok(())
+            }
             Err(EnclaveError::Attest(AttestEnclaveError::Verify(VerifyError::IasQuote(
                 IasQuoteError::GroupRevoked(_, pib),
             ))))
@@ -399,26 +393,14 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
                     self.logger,
                     "TCB update complete, restarting reporting process"
                 );
-                ias_report = self.start_report_cache()?;
+                let ias_report = self.start_report_cache()?;
                 log::debug!(self.logger, "Verifying IAS report with enclave (again)...");
-                self.enclave.verify_ias_report(ias_report.clone())?;
+                self.enclave.verify_ias_report(ias_report)?;
+                log::debug!(self.logger, "Enclave accepted new report as valid...");
                 Ok(())
             }
             Err(other) => Err(other.into()),
-        };
-
-        if retval.is_ok() {
-            let ias_report_data = VerificationReportData::try_from(&ias_report)?;
-            let timestamp = ias_report_data.parse_timestamp()?;
-
-            log::debug!(
-                self.logger,
-                "Enclave accepted report as valid, report generated at {:?}...",
-                timestamp
-            );
         }
-
-        retval
     }
 
     fn start_user_rpc_server(&mut self) -> Result<(), ConsensusServiceError> {

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -14,7 +14,7 @@ use grpcio::{EnvBuilder, Environment, Server, ServerBuilder};
 use mc_attest_api::attest_grpc::create_attested_api;
 use mc_attest_core::{
     IasQuoteError, PibError, QuoteError, QuoteSignType, TargetInfoError, VerificationReport,
-    VerifyError,
+    VerificationReportData, VerifyError,
 };
 use mc_attest_enclave_api::{ClientSession, Error as AttestEnclaveError, PeerSession};
 use mc_attest_net::{Error as RaError, RaClient};
@@ -36,6 +36,7 @@ use mc_util_uri::{ConnectionUri, ConsensusPeerUriApi};
 use retry::{delay::Fibonacci, retry, Error as RetryError, OperationResult};
 use serde_json::json;
 use std::{
+    convert::TryFrom,
     env,
     sync::{Arc, Mutex},
     time::Instant,
@@ -64,6 +65,8 @@ pub enum ConsensusServiceError {
     BackgroundWorkQueueStart(String),
     #[fail(display = "Failed to stop background work queue: {}", _0)]
     BackgroundWorkQueueStop(String),
+    #[fail(display = "Attest verify report error: {}", _0)]
+    Verify(VerifyError),
 }
 
 impl From<EnclaveError> for ConsensusServiceError {
@@ -93,6 +96,12 @@ impl From<RaError> for ConsensusServiceError {
 impl From<TargetInfoError> for ConsensusServiceError {
     fn from(src: TargetInfoError) -> Self {
         ConsensusServiceError::TargetInfo(src)
+    }
+}
+
+impl From<VerifyError> for ConsensusServiceError {
+    fn from(src: VerifyError) -> Self {
+        ConsensusServiceError::Verify(src)
     }
 }
 
@@ -366,13 +375,10 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
             self.logger,
             "Starting enclave report cache update process..."
         );
-        let ias_report = self.start_report_cache()?;
+        let mut ias_report = self.start_report_cache()?;
         log::debug!(self.logger, "Verifying IAS report with enclave...");
-        match self.enclave.verify_ias_report(ias_report) {
-            Ok(()) => {
-                log::debug!(self.logger, "Enclave accepted report as valid...");
-                Ok(())
-            }
+        let retval = match self.enclave.verify_ias_report(ias_report.clone()) {
+            Ok(()) => Ok(()),
             Err(EnclaveError::Attest(AttestEnclaveError::Verify(VerifyError::IasQuote(
                 IasQuoteError::GroupRevoked(_, pib),
             ))))
@@ -393,14 +399,26 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
                     self.logger,
                     "TCB update complete, restarting reporting process"
                 );
-                let ias_report = self.start_report_cache()?;
+                ias_report = self.start_report_cache()?;
                 log::debug!(self.logger, "Verifying IAS report with enclave (again)...");
-                self.enclave.verify_ias_report(ias_report)?;
-                log::debug!(self.logger, "Enclave accepted new report as valid...");
+                self.enclave.verify_ias_report(ias_report.clone())?;
                 Ok(())
             }
             Err(other) => Err(other.into()),
+        };
+
+        if retval.is_ok() {
+            let ias_report_data = VerificationReportData::try_from(&ias_report)?;
+            let timestamp = ias_report_data.parse_timestamp()?;
+
+            log::debug!(
+                self.logger,
+                "Enclave accepted report as valid, report generated at {:?}...",
+                timestamp
+            );
         }
+
+        retval
     }
 
     fn start_user_rpc_server(&mut self) -> Result<(), ConsensusServiceError> {


### PR DESCRIPTION
### Motivation

We want to add some metrics around report timestamps. For that we need to be able to get a usable timestamp object. This PR adds a utility method for the timestamp parsing, in order to save us from duplicating this code anywhere timestamp parsing is required.

### In this PR
Adding `parse_timestamp` to `VerificationReportData`.

### Future Work
* Adding metrics that use the timestamp :)
