### PR TITLE
RistrettoPublic(schnorrkel::PublicKey)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,6 +2424,7 @@ dependencies = [
  "prost",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+ "schnorrkel",
  "semver",
  "serde",
  "serde_json",
@@ -4487,6 +4488,21 @@ checksum = "039c25b130bd8c1321ee2d7de7fde2659fa9c2744e4bb29711cfc852ea53cd19"
 dependencies = [
  "lazy_static",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "schnorrkel"
+version = "0.9.1"
+source = "git+https://github.com/sugargoat/schnorrkel?rev=60eedb2d3e005539052e1a2aef864bc78323c66c#60eedb2d3e005539052e1a2aef864bc78323c66c"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "curve25519-dalek",
+ "merlin",
+ "rand_core 0.5.1",
+ "sha2",
+ "subtle 2.2.2",
+ "zeroize 1.1.0",
 ]
 
 [[package]]

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -71,6 +71,16 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +836,7 @@ dependencies = [
  "mc-util-serial 0.4.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.9.1 (git+https://github.com/sugargoat/schnorrkel?rev=60eedb2d3e005539052e1a2aef864bc78323c66c)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "signature 1.0.0-pre.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1285,6 +1296,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "schnorrkel"
+version = "0.9.1"
+source = "git+https://github.com/sugargoat/schnorrkel?rev=60eedb2d3e005539052e1a2aef864bc78323c66c#60eedb2d3e005539052e1a2aef864bc78323c66c"
+dependencies = [
+ "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1638,8 @@ dependencies = [
 "checksum aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
+"checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
@@ -1700,6 +1728,7 @@ dependencies = [
 "checksum rjson 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5510dbde48c4c37bf69123b1f636b6dd5f8dffe1f4e358af03c46a4947dca219"
 "checksum rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+"checksum schnorrkel 0.9.1 (git+https://github.com/sugargoat/schnorrkel?rev=60eedb2d3e005539052e1a2aef864bc78323c66c)" = "<none>"
 "checksum secrecy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb052cf770a381fa9a6ee63038ff9a0b11d30abb53be970672e950649ff0bfb"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -23,7 +23,6 @@ sha2 = { version = "0.8", default-features = false }
 x25519-dalek = { version = "0.6", default-features = false, features = ["nightly", "u64_backend"] }
 zeroize = { version = "1", default-features = false }
 
-# FIXME: may not need this revision, as not using rng methods in ristretto.rs
 # NOTE: Introduces *_rng methods that take an rng to bypass rand_hack that fails no_std builds
 schnorrkel = { git = "https://github.com/sugargoat/schnorrkel", rev = "60eedb2d3e005539052e1a2aef864bc78323c66c", default-features = false}
 

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -23,6 +23,7 @@ sha2 = { version = "0.8", default-features = false }
 x25519-dalek = { version = "0.6", default-features = false, features = ["nightly", "u64_backend"] }
 zeroize = { version = "1", default-features = false }
 
+# FIXME: may not need this revision, as not using rng methods in ristretto.rs
 # NOTE: Introduces *_rng methods that take an rng to bypass rand_hack that fails no_std builds
 schnorrkel = { git = "https://github.com/sugargoat/schnorrkel", rev = "60eedb2d3e005539052e1a2aef864bc78323c66c", default-features = false}
 

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -23,6 +23,9 @@ sha2 = { version = "0.8", default-features = false }
 x25519-dalek = { version = "0.6", default-features = false, features = ["nightly", "u64_backend"] }
 zeroize = { version = "1", default-features = false }
 
+# NOTE: Introduces *_rng methods that take an rng to bypass rand_hack that fails no_std builds
+schnorrkel = { git = "https://github.com/sugargoat/schnorrkel", rev = "60eedb2d3e005539052e1a2aef864bc78323c66c", default-features = false}
+
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
 curve25519-dalek = { version = "2.0", default-features = false, features = ["simd_backend", "nightly"] }
 ed25519-dalek = { git = "https://github.com/cbeck88/ed25519-dalek", rev = "c0b0ab31d3572de6fb01d6b4a4f052784034b0b2", default-features = false, features = ["alloc", "nightly", "serde", "simd_backend"] }

--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -25,7 +25,7 @@ use mc_util_repr_bytes::{
 };
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use schnorrkel::{PublicKey, MiniSecretKey, ExpansionMode};
+use schnorrkel::{PublicKey, MiniSecretKey, ExpansionMode, SecretKey};
 use zeroize::Zeroize;
 
 /// A Ristretto-format private scalar
@@ -105,7 +105,14 @@ impl PrivateKey for RistrettoPrivate {
 
 impl FromRandom for RistrettoPrivate {
     fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> RistrettoPrivate {
-        Self(Scalar::random(csprng))
+        let mini_secret = MiniSecretKey::generate_with(csprng);
+        let secret = mini_secret.expand_to_keypair(ExpansionMode::Uniform).secret.clone();
+        // The scalar is the first 32 bytes in canonical representation
+        let mut scalar_bytes: [u8; 32] = [0u8; 32];
+        scalar_bytes[..32].copy_from_slice(&secret.to_bytes()[..32]);
+        // FIXME: error handling
+        let scalar = Scalar::from_canonical_bytes(scalar_bytes).ok_or(KeyError::InvalidPrivateKey).expect("Could not get scalar from RistrettoPrivate");
+        Self(scalar)
     }
 }
 
@@ -269,10 +276,13 @@ impl crate::traits::PublicKey for RistrettoPublic {}
 impl From<&RistrettoPrivate> for RistrettoPublic {
     fn from(private: &RistrettoPrivate) -> Self {
         let scalar: &Scalar = private.as_ref();
-        let mut bytes_slice = [0u8; 32];
-        bytes_slice[..32].copy_from_slice(&scalar.to_bytes());
-        let mini_secret = MiniSecretKey::from_bytes(&bytes_slice).expect("Could not create MiniSecretKey from bytes");
-        Self(mini_secret.expand_to_keypair(ExpansionMode::Uniform).public)
+        let mut bytes_slice = [0u8; 64];
+        bytes_slice[..64].copy_from_slice(&scalar.to_bytes());
+
+        // We can construct the SecretKey directly from the Scalar
+        // FIXME: do we need to ensure that we include the Nonce?
+        let secret = SecretKey::from_bytes(&bytes_slice).expect("Could not construct SecretKey from scalar bytes");
+        Self(secret.to_public())
     }
 }
 

--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -113,7 +113,6 @@ impl FromRandom for RistrettoPrivate {
         // The scalar is the first 32 bytes in canonical representation
         let mut scalar_bytes: [u8; 32] = [0u8; 32];
         scalar_bytes[0..32].copy_from_slice(&secret.to_bytes()[0..32]);
-        // FIXME: error handling
         let scalar = Scalar::from_canonical_bytes(scalar_bytes)
             .ok_or(KeyError::InvalidPrivateKey)
             .expect("Could not get scalar from RistrettoPrivate");

--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -280,7 +280,6 @@ impl From<&RistrettoPrivate> for RistrettoPublic {
         bytes_slice[..32].copy_from_slice(&scalar.to_bytes());
 
         // We can construct the SecretKey directly from the Scalar
-        // FIXME: do we need to ensure that we include the Nonce?
         let secret = SecretKey::from_bytes(&bytes_slice).expect("Could not construct SecretKey from scalar bytes");
         Self(secret.to_public())
     }
@@ -292,7 +291,6 @@ impl From<&RistrettoEphemeralPrivate> for RistrettoPublic {
         bytes_slice[..32].copy_from_slice(&private.0.to_bytes());
 
         // We can construct the SecretKey directly from the Scalar
-        // FIXME: do we need to ensure that we include the Nonce?
         let secret = SecretKey::from_bytes(&bytes_slice).expect("Could not construct SecretKey from scalar bytes");
         Self(secret.to_public())
     }

--- a/crypto/keys/src/traits.rs
+++ b/crypto/keys/src/traits.rs
@@ -46,7 +46,6 @@ impl From<LengthMismatch> for KeyError {
     }
 }
 
-// FIXME: wrap the SignatureError, or match on it
 impl From<SignatureError> for KeyError {
     fn from(_src: SignatureError) -> Self { KeyError::SchnorrkelError}
 }

--- a/crypto/keys/src/traits.rs
+++ b/crypto/keys/src/traits.rs
@@ -16,6 +16,7 @@ use mc_crypto_digestible::Digestible;
 use mc_util_from_random::FromRandom;
 use rand_core::{CryptoRng, RngCore};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use schnorrkel::SignatureError;
 
 /// A collection of common errors for use by implementers
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Fail, Ord, PartialEq, PartialOrd, Serialize)]
@@ -35,12 +36,19 @@ pub enum KeyError {
     SignatureMismatch,
     #[fail(display = "There was an opaque error returned by another crate or library")]
     InternalError,
+    #[fail(display = "Schnorrkel signature error")]
+    SchnorrkelError,
 }
 
 impl From<LengthMismatch> for KeyError {
     fn from(src: LengthMismatch) -> Self {
         KeyError::LengthMismatch(src.found, src.expected)
     }
+}
+
+// FIXME: wrap the SignatureError, or match on it
+impl From<SignatureError> for KeyError {
+    fn from(_src: SignatureError) -> Self { KeyError::SchnorrkelError}
 }
 
 /// A trait indicating that a key can be read/written as ASN.1 using the

--- a/crypto/keys/src/traits.rs
+++ b/crypto/keys/src/traits.rs
@@ -15,8 +15,8 @@ use failure::Fail;
 use mc_crypto_digestible::Digestible;
 use mc_util_from_random::FromRandom;
 use rand_core::{CryptoRng, RngCore};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use schnorrkel::SignatureError;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// A collection of common errors for use by implementers
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Fail, Ord, PartialEq, PartialOrd, Serialize)]
@@ -47,7 +47,9 @@ impl From<LengthMismatch> for KeyError {
 }
 
 impl From<SignatureError> for KeyError {
-    fn from(_src: SignatureError) -> Self { KeyError::SchnorrkelError}
+    fn from(_src: SignatureError) -> Self {
+        KeyError::SchnorrkelError
+    }
 }
 
 /// A trait indicating that a key can be read/written as ASN.1 using the

--- a/transaction/core/src/constants.rs
+++ b/transaction/core/src/constants.rs
@@ -36,13 +36,13 @@ cfg_if::cfg_if! {
         ///
         ///   let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         ///   let foundation_account_key = AccountKey::random(&mut rng);
-        pub const FEE_SPEND_PUBLIC_KEY: [u8; 32] = [38, 181, 7, 198, 49, 36, 162, 245, 233, 64, 180, 251, 137, 228, 178, 187, 10, 32, 120, 237, 12, 142, 85, 26, 213, 146, 104, 185, 100, 110, 194, 65];
+        pub const FEE_SPEND_PUBLIC_KEY: [u8; 32] = [148, 59, 218, 190, 201, 192, 223, 42, 109, 112, 217, 83, 6, 121, 195, 4, 17, 136, 18, 30, 159, 4, 177, 12, 119, 238, 54, 220, 167, 212, 4, 117];
 
         /// Testnet fee recipient view public key.
-        pub const FEE_VIEW_PUBLIC_KEY: [u8; 32] = [82, 34, 161, 233, 174, 50, 210, 28, 35, 17, 74, 92, 230, 187, 57, 224, 203, 86, 174, 163, 80, 212, 97, 157, 67, 177, 32, 112, 97, 177, 3, 70];
+        pub const FEE_VIEW_PUBLIC_KEY: [u8; 32] = [150, 99, 44, 152, 218, 46, 166, 167, 51, 163, 9, 41, 171, 78, 145, 80, 231, 248, 163, 94, 17, 238, 231, 161, 238, 11, 105, 177, 104, 12, 236, 18];
 
         /// The private key is only used by tests. This does not need to be specified for main net.
-        pub const FEE_VIEW_PRIVATE_KEY: [u8; 32] = [21, 152, 99, 251, 140, 2, 50, 154, 2, 171, 188, 60, 163, 243, 204, 195, 241, 78, 204, 85, 202, 52, 250, 242, 215, 247, 175, 59, 121, 185, 111, 8];
+        pub const FEE_VIEW_PRIVATE_KEY: [u8; 32] = [202, 221, 141, 9, 53, 168, 1, 178, 106, 217, 81, 136, 44, 237, 27, 116, 156, 245, 154, 71, 174, 175, 0, 33, 84, 68, 77, 24, 214, 13, 92, 9];
 
     } else if #[cfg(feature="main-net-fee-keys")] {
         compile_error!("main net keys are not available yet");


### PR DESCRIPTION
Soundtrack of this PR: [Quarantine Love Song](https://www.youtube.com/watch?v=pE49WK-oNjU)

### Motivation

Currently, our keys implementation does not take advantage of the schnorrkel API for constructing keypairs, which handles proper expansion from secret key material.

### In this PR
* Changes RistrettoPublic to wrap a schnorrkel::PublicKey
* Updates resulting fee constants

[MC-1611](https://mobilecoin.atlassian.net/browse/MC-1611)

### Future Work
* Update schnorrkel signature verification in #246 