### PR TITLE
Return confirmation numbers with receipts in mobilecoind

### DIFF
--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -128,6 +128,9 @@ message TxProposal {
     /// This is needed to map recipients to their respective TxOuts.
     map<uint64, uint64> outlay_index_to_tx_out_index = 5;
 
+    /// A list of the confirmation numbers, in the same order
+    /// as the outlays.
+    repeated bytes outlay_confirmation_numbers = 6;
 }
 
 // Structure used to check transaction status as a Sender.
@@ -154,6 +157,9 @@ message ReceiverTxReceipt {
 
     // Tombstone block set in the transaction.
     uint64 tombstone = 4;
+
+    // Confirmation number for this TxOut
+    bytes confirmation_number = 5;
 }
 
 // Structure used to report monitor status

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -12,10 +12,10 @@ use mc_mobilecoind_api::{self};
 use mc_transaction_core::{
     account_keys::PublicAddress,
     ring_signature::KeyImage,
-    tx::{Tx, TxOut},
+    tx::{Tx, TxOut, TxOutConfirmationNumber},
 };
 use protobuf::RepeatedField;
-use std::{convert::TryFrom, iter::FromIterator};
+use std::{convert::TryFrom, iter::FromIterator, vec::Vec};
 
 impl From<&UnspentTxOut> for mc_mobilecoind_api::UnspentTxOut {
     fn from(src: &UnspentTxOut) -> Self {
@@ -93,6 +93,12 @@ impl From<&TxProposal> for mc_mobilecoind_api::TxProposal {
                 .iter()
                 .map(|(key, val)| (*key as u64, *val as u64)),
         ));
+        dst.set_outlay_confirmation_numbers(
+            src.outlay_confirmation_numbers
+                .iter()
+                .map(|val| val.as_ref().to_vec())
+                .collect(),
+        );
 
         dst
     }
@@ -137,11 +143,18 @@ impl TryFrom<&mc_mobilecoind_api::TxProposal> for TxProposal {
             }
         }
 
+        let outlay_confirmation_numbers = src
+            .get_outlay_confirmation_numbers()
+            .iter()
+            .map(TxOutConfirmationNumber::from)
+            .collect();
+
         Ok(Self {
             utxos,
             outlays,
             tx,
             outlay_index_to_tx_out_index,
+            outlay_confirmation_numbers,
         })
     }
 }
@@ -277,6 +290,7 @@ mod test {
         };
 
         let outlay_index_to_tx_out_index = HashMap::from_iter(vec![(0, 0)]);
+        let outlay_confirmation_numbers = vec![TxOutConfirmationNumber::from([0u8; 32])];
 
         // Rust -> Proto
         let rust = TxProposal {
@@ -284,6 +298,7 @@ mod test {
             outlays: vec![outlay],
             tx,
             outlay_index_to_tx_out_index,
+            outlay_confirmation_numbers,
         };
 
         let proto = mc_mobilecoind_api::TxProposal::from(&rust);

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -15,7 +15,7 @@ use mc_transaction_core::{
     tx::{Tx, TxOut, TxOutConfirmationNumber},
 };
 use protobuf::RepeatedField;
-use std::{convert::TryFrom, iter::FromIterator, vec::Vec};
+use std::{convert::TryFrom, iter::FromIterator};
 
 impl From<&UnspentTxOut> for mc_mobilecoind_api::UnspentTxOut {
     fn from(src: &UnspentTxOut) -> Self {

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -756,9 +756,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
 
                 if tx_proposal.outlay_confirmation_numbers.len() > outlay_index {
                     receiver_tx_receipt.set_confirmation_number(
-                        tx_proposal.outlay_confirmation_numbers[outlay_index]
-                            .as_ref()
-                            .to_vec(),
+                        tx_proposal.outlay_confirmation_numbers[outlay_index].to_vec(),
                     );
                 }
 
@@ -2384,9 +2382,10 @@ mod test {
                 );
 
                 assert_eq!(receipt.tombstone, tx.prefix.tombstone_block);
+                let mut confirmation_bytes = [0u8; 32];
+                confirmation_bytes.copy_from_slice(&receipt.confirmation_number);
 
-                let confirmation_number =
-                    TxOutConfirmationNumber::from(&receipt.confirmation_number);
+                let confirmation_number = TxOutConfirmationNumber::from(confirmation_bytes);
                 assert!(outlay_confirmation_numbers.contains(&confirmation_number));
             }
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -754,6 +754,14 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                 receiver_tx_receipt.set_tx_out_hash(tx_out.hash().to_vec());
                 receiver_tx_receipt.set_tombstone(tx_proposal.tx.prefix.tombstone_block);
 
+                if tx_proposal.outlay_confirmation_numbers.len() > outlay_index {
+                    receiver_tx_receipt.set_confirmation_number(
+                        tx_proposal.outlay_confirmation_numbers[outlay_index]
+                            .as_ref()
+                            .to_vec(),
+                    );
+                }
+
                 Ok(receiver_tx_receipt)
             })
             .collect::<Result<Vec<mc_mobilecoind_api::ReceiverTxReceipt>, RpcStatus>>()?;

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -452,6 +452,14 @@ impl ReprBytes for TxOutConfirmationNumber {
     }
 }
 
+impl From<&Vec<u8>> for TxOutConfirmationNumber {
+    fn from(src: &Vec<u8>) -> Self {
+        let mut bytes = [0u8; 32];
+        bytes.copy_from_slice(src);
+        Self {0: bytes}
+    }
+}
+
 derive_prost_message_from_repr_bytes!(TxOutConfirmationNumber);
 
 #[cfg(test)]

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -456,7 +456,7 @@ impl From<&Vec<u8>> for TxOutConfirmationNumber {
     fn from(src: &Vec<u8>) -> Self {
         let mut bytes = [0u8; 32];
         bytes.copy_from_slice(src);
-        Self {0: bytes}
+        Self { 0: bytes }
     }
 }
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -452,14 +452,6 @@ impl ReprBytes for TxOutConfirmationNumber {
     }
 }
 
-impl From<&Vec<u8>> for TxOutConfirmationNumber {
-    fn from(src: &Vec<u8>) -> Self {
-        let mut bytes = [0u8; 32];
-        bytes.copy_from_slice(src);
-        Self { 0: bytes }
-    }
-}
-
 derive_prost_message_from_repr_bytes!(TxOutConfirmationNumber);
 
 #[cfg(test)]


### PR DESCRIPTION
Soundtrack of this PR: [https://www.youtube.com/watch?v=o2dbcH1DsLo](Receipts)

### Motivation

We recently added confirmation numbers to TransactionBuilder which allow a sender to prove that they created a particular transaction. We need to expose this functionality in mobilecoind. This first PR returns the confirmation numbers as part of the receipt.

### In this PR
* Adds confirmation number list to the TxProposal struct
* Returns confirmation numbers as of the recipient transaction receipt

### Future Work
* Call to validate confirmation numbers
* Add all this to the REST API
