### PR TITLE
new fog fields require a new payload version for backwards compatibilty

### DIFF
--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -377,7 +377,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         let view_key = receiver.view_public_key().to_bytes();
         let spend_key = receiver.spend_public_key().to_bytes();
 
-        let payload = RequestPayload::new_v3(
+        let payload = RequestPayload::new_v4(
             &view_key,
             &spend_key,
             receiver.fog_report_url().unwrap_or(&""),

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -377,14 +377,12 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         let view_key = receiver.view_public_key().to_bytes();
         let spend_key = receiver.spend_public_key().to_bytes();
 
-        let payload = RequestPayload::new_v4(
+        let payload = RequestPayload::new_v3(
             &view_key,
             &spend_key,
-            receiver.fog_report_url().unwrap_or(&""),
+            "", // mobilecoind does not support fog
             request.get_value(),
             request.get_memo(),
-            receiver.fog_report_id().unwrap_or(&""),
-            receiver.fog_authority_sig().unwrap_or(&[]),
         )
         .map_err(|err| rpc_internal_error("RequestPayload.new_v3", err, &self.logger))?;
         let b58_code = payload.encode();

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -381,10 +381,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             &view_key,
             &spend_key,
             receiver.fog_report_url().unwrap_or(&""),
-            receiver.fog_report_id().unwrap_or(&""),
-            receiver.fog_authority_sig().unwrap_or(&[]),
             request.get_value(),
             request.get_memo(),
+            receiver.fog_report_id().unwrap_or(&""),
+            receiver.fog_authority_sig().unwrap_or(&[]),
         )
         .map_err(|err| rpc_internal_error("RequestPayload.new_v3", err, &self.logger))?;
         let b58_code = payload.encode();

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -629,7 +629,7 @@ mod testing {
         );
         let alice_request_payload = RequestPayload::try_from(&alice_public).unwrap();
         let alice_b58_str = alice_request_payload.encode();
-        assert_eq!(alice_b58_str, "fixme");
+        assert_eq!(alice_b58_str, "5F24DBwfEGBN18LevLEt3wZHknBk1tSC32QfMzSoiPcMrJyErBqBiNQpfFWboY1DHAjwjkBf2qfUbGvjvcdJ6Uhp6qcZ1NChFutR2MpiyTkrKm7NhCrT6KjtDkQBxr7rw74oFzvh7rkrK");
         let alice_payload = RequestPayload::decode(&alice_b58_str).unwrap();
         let alice_decoded = PublicAddress::try_from(&alice_payload).unwrap();
         assert_eq!(alice_public, alice_decoded);

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -655,7 +655,7 @@ mod testing {
         );
         let bob_request_payload = RequestPayload::try_from(&bob_public).unwrap();
         let bob_b58_str = bob_request_payload.encode();
-        assert_eq!(bob_b58_str, "fixme");
+        assert_eq!(bob_b58_str, "22M3RU5KkQ5izkdPhjAmj6KWs2Md3AuJTfeg7NxoJRyMsmiwV2NpdkA9ABrQSrHZuiEyHMJ4zxVwAeFDbjAHwx42AoFoLbYRkv19nwWFPLihthriKxCmvYpgVrzUpSbz27U1ASRhspZcqavc");
         let bob_payload = RequestPayload::decode(&bob_b58_str).unwrap();
         let bob_decoded = PublicAddress::try_from(&bob_payload).unwrap();
         assert_eq!(bob_public, bob_decoded);

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -235,7 +235,9 @@ impl RequestPayload {
         fog_report_url: &str,
         value: u64,
     ) -> Result<Self, Error> {
-        let mut result = RequestPayload::new_v1(view_key, spend_key, fog_report_url)?;
+        let mut result = RequestPayload::new_v0(view_key, spend_key)?;
+        validate_fog_report_url(fog_report_url)?;
+        result.fog_report_url = fog_report_url.to_owned();
         result.value = value;
         result.version = 2;
         Ok(result)

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -629,7 +629,7 @@ mod testing {
         );
         let alice_request_payload = RequestPayload::try_from(&alice_public).unwrap();
         let alice_b58_str = alice_request_payload.encode();
-        assert_eq!(alice_b58_str, "5F24DBwfEGBN18LevLEt3wZHknBk1tSC32QfMzSoiPcMrJyErBqBiNQpfFWboY1DHAjwjkBf2qfUbGvjvcdJ6Uhp6qcZ1NChFutR2MpiyTkrKm7NhCrT6");
+        assert_eq!(alice_b58_str, "5F24DBwfEGBN18LevLEt3wZHknBk1tSC32QfMzSoiPcMrJyErBqBiNQpfFWboY1DHAjwjkBf2qfUbGvjvcdJ6Uhp6qcZ1NChFutR2MpiyTkrKm7NhCrT6KjtDkQBxr7rw74oFzvh7rkrK");
         let alice_payload = RequestPayload::decode(&alice_b58_str).unwrap();
         let alice_decoded = PublicAddress::try_from(&alice_payload).unwrap();
         assert_eq!(alice_public, alice_decoded);

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -234,11 +234,7 @@ impl RequestPayload {
         fog_report_url: &str,
         value: u64,
     ) -> Result<Self, Error> {
-        let mut result = RequestPayload::new_v1(
-            view_key,
-            spend_key,
-            fog_report_url,
-        )?;
+        let mut result = RequestPayload::new_v1(view_key, spend_key, fog_report_url)?;
         result.value = value;
         result.version = 2;
         Ok(result)
@@ -252,12 +248,7 @@ impl RequestPayload {
         value: u64,
         memo: &str,
     ) -> Result<Self, Error> {
-        let mut result = RequestPayload::new_v2(
-            view_key,
-            spend_key,
-            fog_report_url,
-            value,
-        )?;
+        let mut result = RequestPayload::new_v2(view_key, spend_key, fog_report_url, value)?;
         validate_memo(memo)?;
         result.memo = memo.to_owned();
         result.version = 3;
@@ -274,13 +265,7 @@ impl RequestPayload {
         fog_report_id: &str,
         fog_authority_sig: &[u8],
     ) -> Result<Self, Error> {
-        let mut result = RequestPayload::new_v3(
-            view_key,
-            spend_key,
-            fog_report_url,
-            value,
-            memo,
-        )?;
+        let mut result = RequestPayload::new_v3(view_key, spend_key, fog_report_url, value, memo)?;
         result.fog_report_id = fog_report_id.to_owned();
         result.fog_authority_sig = fog_authority_sig.to_vec();
         result.version = 4;

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -629,7 +629,7 @@ mod testing {
         );
         let alice_request_payload = RequestPayload::try_from(&alice_public).unwrap();
         let alice_b58_str = alice_request_payload.encode();
-        assert_eq!(alice_b58_str, "4kKfdpo1cuAGpMGXdbCEMgWuJJCLwrc8sJ6b82AELfS1JEXyBjcbM2cx1xoPmf3v6yb2ypAukn1CaDxsKCJvpWMrLn2KE8MsKSSkTwSzEcSh99ogR6eMqLePtMrQ1t647");
+        assert_eq!(alice_b58_str, "5F24DBwfEGBN18LevLEt3wZHknBk1tSC32QfMzSoiPcMrJyErBqBiNQpfFWboY1DHAjwjkBf2qfUbGvjvcdJ6Uhp6qcZ1NChFutR2MpiyTkrKm7NhCrT6");
         let alice_payload = RequestPayload::decode(&alice_b58_str).unwrap();
         let alice_decoded = PublicAddress::try_from(&alice_payload).unwrap();
         assert_eq!(alice_public, alice_decoded);

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -214,7 +214,8 @@ impl RequestPayload {
         })
     }
 
-    /// Create a version 1 RequestPayload
+    /// Create a version 1 RequestPayload - this is deprecated becuause fog now requires a signature
+    #[deprecated]
     pub fn new_v1(
         view_key: &[u8; 32],
         spend_key: &[u8; 32],

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -129,7 +129,7 @@ impl fmt::Debug for RequestPayload {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "version:{}, vpk:{}, spk:{}, fog:{}, fog-sig:{}, fog-report-key:{} value:{}, memo:{}",
+            "version:{}, vpk:{}, spk:{}, fog:{}, fog-sig:{}, fog-id:{} value:{}, memo:{}",
             self.version,
             hex_fmt::HexFmt(&self.view_public_key),
             hex_fmt::HexFmt(&self.spend_public_key),
@@ -281,7 +281,7 @@ impl RequestPayload {
             value,
             memo,
         )?;
-        result.fog_report_key = fog_report_key.to_owned();
+        result.fog_report_id = fog_report_id.to_owned();
         result.fog_authority_sig = fog_authority_sig.to_vec();
         result.version = 4;
         Ok(result)
@@ -300,8 +300,8 @@ impl RequestPayload {
     /// [F+9..M=(F+9+m)]  memo as utf-8 encoded string (< 256 bytes)
     /// [FIXME]           length of fog_authority_sig
     /// [FIXME]           fog_authority_sig bytes (< 256 bytes)
-    /// [FIXME]           length of fog_report_key
-    /// [FIXME]           fog_report_key bytes (< 256 bytes)
+    /// [FIXME]           length of fog_report_id
+    /// [FIXME]           fog_report_id bytes (< 256 bytes)
     /// [M..]             future version data (ignored)
     pub fn encode(&self) -> String {
         let mut bytes_vec = Vec::new();

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -214,7 +214,7 @@ impl RequestPayload {
         })
     }
 
-    /// Create a version 1 RequestPayload - this is deprecated becuause fog now requires a signature
+    /// Create a version 1 RequestPayload - this is deprecated because fog now requires a signature
     #[deprecated]
     pub fn new_v1(
         view_key: &[u8; 32],

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -667,7 +667,7 @@ mod testing {
         );
         let bob_request_payload = RequestPayload::try_from(&bob_public).unwrap();
         let bob_b58_str = bob_request_payload.encode();
-        assert_eq!(bob_b58_str, "fixme");
+        assert_eq!(bob_b58_str, "72wW29sWRpkXtzuMhrcr5zjM3wvWDQj2FGCZf4eswvAhFMtCxdQjEYYmJfXtdTa7fLxGyELd6TT62Zb6nw6Hk7TfaX8nBAid");
         let bob_payload = RequestPayload::decode(&bob_b58_str).unwrap();
         let bob_decoded = PublicAddress::try_from(&bob_payload).unwrap();
         assert_eq!(bob_public, bob_decoded);

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -629,7 +629,7 @@ mod testing {
         );
         let alice_request_payload = RequestPayload::try_from(&alice_public).unwrap();
         let alice_b58_str = alice_request_payload.encode();
-        assert_eq!(alice_b58_str, "5F24DBwfEGBN18LevLEt3wZHknBk1tSC32QfMzSoiPcMrJyErBqBiNQpfFWboY1DHAjwjkBf2qfUbGvjvcdJ6Uhp6qcZ1NChFutR2MpiyTkrKm7NhCrT6KjtDkQBxr7rw74oFzvh7rkrK");
+        assert_eq!(alice_b58_str, "fixme");
         let alice_payload = RequestPayload::decode(&alice_b58_str).unwrap();
         let alice_decoded = PublicAddress::try_from(&alice_payload).unwrap();
         assert_eq!(alice_public, alice_decoded);
@@ -655,7 +655,7 @@ mod testing {
         );
         let bob_request_payload = RequestPayload::try_from(&bob_public).unwrap();
         let bob_b58_str = bob_request_payload.encode();
-        assert_eq!(bob_b58_str, "21BA6veypXUoUpzDWBQGUHfUcpVG1PjGsAJyng9Y5hdLFGvGbSVsyxfNuKJeYHpJKAXXksUUJrvjBn4UnXnPDhX7rMZ4RqYLidkkHkBf5Ah9adj7CXNB1sgaiqNfF7ftNgqe");
+        assert_eq!(bob_b58_str, "fixme");
         let bob_payload = RequestPayload::decode(&bob_b58_str).unwrap();
         let bob_decoded = PublicAddress::try_from(&bob_payload).unwrap();
         assert_eq!(bob_public, bob_decoded);
@@ -667,7 +667,7 @@ mod testing {
         );
         let bob_request_payload = RequestPayload::try_from(&bob_public).unwrap();
         let bob_b58_str = bob_request_payload.encode();
-        assert_eq!(bob_b58_str, "72wW29sWRpkXtzuMhrcr5zjM3wvWDQj2FGCZf4eswvAhFMtCxdQjEYYmJfXtdTa7fLxGyELd6TT62Zb6nw6Hk7TfaX8nBAid");
+        assert_eq!(bob_b58_str, "fixme");
         let bob_payload = RequestPayload::decode(&bob_b58_str).unwrap();
         let bob_decoded = PublicAddress::try_from(&bob_payload).unwrap();
         assert_eq!(bob_public, bob_decoded);


### PR DESCRIPTION
### Motivation

Recent changes to the b58 code scheme were not backwards compatible. This breaking change needs to be coordinated with our release schedule.

Even if we decide not to use the b58 codes in the SDK work, there's no reason to break backwards compatibility in the test client.

### In this PR

* move new fields to version 4

### Future Work

* actually verify the test vectors by comparison to calculation in javascript
* do this right! Separate serialization from encoding and use protobuf

