### PR TITLE
Add tests that show what happens when there are unicode characters in memo

### DIFF
--- a/util/url-encoding/README.md
+++ b/util/url-encoding/README.md
@@ -31,8 +31,8 @@ Contents
 
 A mob url represents:
 - A mobilecoin *public address* (see `mc-transaction-core` struct `PublicAddress`).
-- Optionally, *an amount* in picomob requested to be sent to this address
-- Optionally, *a memo* indicating the reason to send this amount
+- Optionally, *an amount* in picomob (u64) requested to be sent to this address
+- Optionally, *a memo* (utf-8 string) indicating the reason to send this amount
 
 Specification
 =============
@@ -108,13 +108,13 @@ Examples
 A public address for an account without fog support. This is base-64 encoded Ristretto curve points.
 
 ```
-mob:///eCwRQ1riR1LTp8rpOMcn_rc3EajKx1EZ3cXV17SPDn2UyDJYXMl9TdQZoo5H3MDzTz14WBFVAARfGrXbMv8hGw==
+mob:///9i_xwzoihbGu5hLthygfLGi7K1sPFDmhPkq3KPmO-2p4kBwRg06ELfa-mMEnlTUT4RYJXUEizCfYB7RRHLgeEWfP
 ```
 
 A public address for an account with fog support.
 
 ```
-mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCg==?s=CQkJCQ%3D%3D
+mob://fog.mobilecoin.com/oGbA6juTWhUdfL6qNMocAGN96wNiZpZegP0TUjKXHEM-GYmM50bLJVeL6NgftIumjt8nwYw7MjEnQT7hCw9bVUgh?s=CQkJCfSo
 ```
 
 The fog hostname here is `fog.mobilecoin.signal.org` which indicates where to contact the fog report server.
@@ -126,7 +126,7 @@ The query parameter `?s=...` encodes the user's signature over the fog authority
 A payment request for an account with fog support
 
 ```
-mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMQ==?s=CQkJCQ%3D%3D&a=666&m=2+baby+goats
+mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMRqp?a=666&m=2+baby+goats&s=CQkJCfSo
 ```
 
 The fog hostname here is `fog.diogenes.mobilecoin.com`.

--- a/util/url-encoding/src/payment_request.rs
+++ b/util/url-encoding/src/payment_request.rs
@@ -159,6 +159,37 @@ mod tests {
 
     // Test an example unicode request payload being parsed to mob url
     #[test]
+    fn example_unicode_fog_payload() {
+        let acct = AccountKey::new_with_fog(
+            &RistrettoPrivate::try_from(&[0u8; 32]).unwrap(),
+            &RistrettoPrivate::try_from(&[1u8; 32]).unwrap(),
+            "fog://fog.mobilecoin.com".to_string(),
+            0.to_string(),
+            b"deadbeef".to_vec(),
+        );
+
+        let addr = acct.default_subaddress();
+
+        let mut payload = PaymentRequest::from(&addr);
+
+        payload.amount = Some(777);
+        payload.memo = Some("لسلام عليكم".to_owned());
+
+        let mob_url = MobUrl::try_from(&payload)
+            .map_err(|err| {
+                panic!("Error when decoding payload {:?}: {}", payload, err);
+            })
+            .unwrap();
+
+        assert_eq!(mob_url.as_ref(), "mob://fog.mobilecoin.com/oGbA6juTWhUdfL6qNMocAGN96wNiZpZegP0TUjKXHEM-GYmM50bLJVeL6NgftIumjt8nwYw7MjEnQT7hCw9bVUgh?a=777&m=%D9%84%D8%B3%D9%84%D8%A7%D9%85+%D8%B9%D9%84%D9%8A%D9%83%D9%85&s=CQkJCfSo#0");
+
+        let payload2 = PaymentRequest::try_from(&mob_url).unwrap();
+
+        assert_eq!(payload, payload2);
+    }
+
+    // Test an example unicode request payload being parsed to mob url
+    #[test]
     fn roundtrip_example_fog_payload_unicode() {
         for memo in &[
             String::from("السلام عليكم"),


### PR DESCRIPTION
Soundtrack of this PR: https://www.youtube.com/watch?v=MbXWrmQW-OE

### Motivation

Add tests that show what happens when there are unicode characters in the memo, this concern was raised in discussion,
before this commit we were only testing for roundtrip integrity.

The test shows that percent-encoding is used on the unicode codepoints, which is what I expect based on the spec here: https://url.spec.whatwg.org/#urlencoded-serializing

### In this PR

Add an extra test case for mob ulr, fixup out of date examples in readme