### PR TITLE
Encapsulates the validation function for TxOutConfirmationNumber

### DIFF
--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -23,6 +23,7 @@ use crate::{
     blake2b_256::Blake2b256,
     domain_separators::TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG,
     encrypted_fog_hint::EncryptedFogHint,
+    get_tx_out_shared_secret,
     onetime_keys::{compute_shared_secret, compute_tx_pubkey, create_onetime_public_key},
     range::Range,
     ring_signature::{KeyImage, SignatureRctBulletproofs},
@@ -406,6 +407,16 @@ impl TxOutConfirmationNumber {
     /// Copies self into a new Vec.
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()
+    }
+
+    pub fn validate(
+        &self,
+        tx_pubkey: &RistrettoPublic,
+        view_private_key: &RistrettoPrivate,
+    ) -> bool {
+        let shared_secret = get_tx_out_shared_secret(view_private_key, tx_pubkey);
+        let calculated_confirmation = TxOutConfirmationNumber::from(&shared_secret);
+        calculated_confirmation == *self
     }
 }
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -241,7 +241,6 @@ pub mod transaction_builder_tests {
     use mc_transaction_core::{
         account_keys::{AccountKey, DEFAULT_SUBADDRESS_INDEX},
         constants::{MAX_INPUTS, MAX_OUTPUTS},
-        get_tx_out_shared_secret,
         onetime_keys::*,
         ring_signature::KeyImage,
         tx::TxOutMembershipProof,
@@ -417,12 +416,7 @@ pub mod transaction_builder_tests {
         // The output should have the correct value and confirmation number
         {
             let public_key = RistrettoPublic::try_from(&output.public_key).unwrap();
-            let shared_secret = get_tx_out_shared_secret(recipient.view_private_key(), &public_key);
-            let (output_value, _blinding) = output.amount.get_value(&shared_secret).unwrap();
-            assert_eq!(output_value, value - BASE_FEE);
-            let calculated_confirmation = TxOutConfirmationNumber::from(&shared_secret);
-
-            assert_eq!(confirmation, calculated_confirmation);
+            assert!(confirmation.validate(&public_key, &recipient.view_private_key()));
         }
 
         // The transaction should have a valid signature.


### PR DESCRIPTION
Soundtrack of this PR: [One Tree Hill](https://www.youtube.com/watch?v=WfKhVV-7lxI)
(because I'm in Auckland)

### Motivation

The actual logic for using confirmation numbers is currently only in a test, this moves it to a method of TxOutConfirmationNumber so it can be easily called elsewhere.

### In this PR
* Additional method for validating confirmation numbers
* Updates transaction_builder test to use this new method

### Future Work
* Add calls to this for mobilecoind
