### PR TITLE
Validate confirmation numbers in mobilecoind tx_status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,6 +2644,7 @@ dependencies = [
  "mc-common",
  "mc-crypto-keys",
  "mc-transaction-core",
+ "mc-transaction-std",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "protobuf",

--- a/mobilecoind-json/src/main.rs
+++ b/mobilecoind-json/src/main.rs
@@ -423,6 +423,7 @@ fn check_transfer_status(
         mc_mobilecoind_api::TxStatus::Unknown => "unknown",
         mc_mobilecoind_api::TxStatus::Verified => "verified",
         mc_mobilecoind_api::TxStatus::TombstoneBlockExceeded => "failed",
+        mc_mobilecoind_api::TxStatus::InvalidConfirmationNumber => "invalid_confirmation",
     };
 
     Ok(Json(JsonStatusResponse {

--- a/mobilecoind/api/Cargo.toml
+++ b/mobilecoind/api/Cargo.toml
@@ -18,6 +18,7 @@ protobuf = "2.12"
 
 [dev-dependencies]
 mc-common = { path = "../../common", features = ["loggers"] }
+mc-transaction-std = { path = "../../transaction/std" }
 
 rand = "0.7"
 hex_fmt = "0.3"

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -74,7 +74,7 @@ enum TxStatus {
     TombstoneBlockExceeded = 2;
 
     // The transaction was found in the ledger but the confirmation number is incorrect
-    InvalidConfirmationCode = 3;
+    InvalidConfirmationNumber = 3;
 }
 
 // Structure used in specifying the list of outputs when generating a transaction.

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -483,7 +483,7 @@ message GetTxStatusAsSenderResponse {
 message GetTxStatusAsReceiverRequest {
     ReceiverTxReceipt receipt = 1;
 
-    // Optionally pass in an monitor ID to validate confirmation number
+    // Optionally pass in a monitor ID to validate confirmation number
     bytes monitor_id = 2;
 }
 message GetTxStatusAsReceiverResponse {

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -72,6 +72,9 @@ enum TxStatus {
 
     // Error: The transaction is not in the public ledger, and the tombstone block has been exceeded.
     TombstoneBlockExceeded = 2;
+
+    // The transaction was found in the ledger but the confirmation number is incorrect
+    InvalidConfirmationCode = 3;
 }
 
 // Structure used in specifying the list of outputs when generating a transaction.
@@ -479,6 +482,9 @@ message GetTxStatusAsSenderResponse {
 // Get the status of a submitted transaction as the Recipient (using the tx public key).
 message GetTxStatusAsReceiverRequest {
     ReceiverTxReceipt receipt = 1;
+
+    // Optionally pass in an monitor ID to validate confirmation number
+    bytes monitor_id = 2;
 }
 message GetTxStatusAsReceiverResponse {
     TxStatus status = 1;

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1010,8 +1010,9 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                         if !confirmation_number.validate(&tx_public_key, &view_private_key) {
                             let mut response =
                                 mc_mobilecoind_api::GetTxStatusAsReceiverResponse::new();
-                            response
-                                .set_status(mc_mobilecoind_api::TxStatus::InvalidConfirmationCode);
+                            response.set_status(
+                                mc_mobilecoind_api::TxStatus::InvalidConfirmationNumber,
+                            );
                             return Ok(response);
                         }
                     }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -958,13 +958,6 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             ));
         }
 
-        if request.get_receipt().get_confirmation_number().len() != 32 {
-            return Err(RpcStatus::new(
-                RpcStatusCode::INVALID_ARGUMENT,
-                Some("receipt.confirmation_number".to_string()),
-            ));
-        }
-
         // Check if the hash landed in the ledger.
         let mut hash_bytes = [0u8; 32];
         hash_bytes.copy_from_slice(&request.get_receipt().tx_out_hash);
@@ -1001,6 +994,13 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                                     )
                                 })?;
                         let view_private_key = monitor_data.account_key.view_private_key();
+
+                        if request.get_receipt().get_confirmation_number().len() != 32 {
+                            return Err(RpcStatus::new(
+                                RpcStatusCode::INVALID_ARGUMENT,
+                                Some("receipt.confirmation_number".to_string()),
+                            ));
+                        }
                         let confirmation_number = {
                             let mut confirmation_bytes = [0u8; 32];
                             confirmation_bytes
@@ -1833,7 +1833,6 @@ mod test {
         {
             let mut receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
             receipt.set_tombstone(1);
-            receipt.set_confirmation_number(vec![0u8; 32]);
 
             let mut request = mc_mobilecoind_api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
@@ -1849,7 +1848,6 @@ mod test {
             let mut receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
             receipt.set_tx_out_hash(hash.to_vec());
             receipt.set_tombstone(1);
-            receipt.set_confirmation_number(vec![0u8; 32]);
 
             let mut request = mc_mobilecoind_api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
@@ -1869,7 +1867,6 @@ mod test {
             let mut receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
             receipt.set_tx_out_hash(hash.to_vec());
             receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64 + 1);
-            receipt.set_confirmation_number(vec![0u8; 32]);
 
             let mut request = mc_mobilecoind_api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
@@ -1886,7 +1883,6 @@ mod test {
             let mut receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
             receipt.set_tx_out_hash(hash.to_vec());
             receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64);
-            receipt.set_confirmation_number(vec![0u8; 32]);
 
             let mut request = mc_mobilecoind_api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -968,7 +968,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                 match request.get_monitor_id().len() {
                     0 => { /* no monitor ID given */ }
                     32 => {
-                        let sender_monitor_id =
+                        let monitor_id =
                             MonitorId::try_from(&request.monitor_id).map_err(|err| {
                                 rpc_internal_error("monitor_id.try_from.bytes", err, &self.logger)
                             })?;
@@ -976,7 +976,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                         // Get monitor data for this monitor.
                         let monitor_data = self
                             .mobilecoind_db
-                            .get_monitor_data(&sender_monitor_id)
+                            .get_monitor_data(&monitor_id)
                             .map_err(|err| {
                                 rpc_internal_error(
                                     "mobilecoind_db.get_monitor_data",

--- a/testnet-client/src/main.rs
+++ b/testnet-client/src/main.rs
@@ -546,6 +546,13 @@ string that we send you. It should look something like:
                     println!();
                     break;
                 }
+                mc_mobilecoind_api::TxStatus::InvalidConfirmationNumber => {
+                    pb.finish_with_message(
+                        "Invalid Confirmation - transaction was successful, cannot confirm sender",
+                    );
+                    println!();
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Soundtrack of this PR: [Return of the Mack](https://www.youtube.com/watch?v=uB1D9wWxd2w)

### Motivation

The last mobilecoind PR added confirmation numbers to return receipts. This PR allows `GetTxStatusAsReceiver` to validate the confirmation numbers given a `monitor_id`. I have made the check optional for flexibility, if no `monitor_id` is given the check remains the same as before.

### In this PR
* Adds an optional `monitor_id` to `GetTxStatusAsReceiverRequest` to provide private view key
* Checks that at a confirmation number is valid for a given tx_pubkey and private view key
* Adds an additional return status `InvalidConfirmationNumber`

### Future Work
* Add this functionality to the REST API