### PR TITLE
test that CI catches libmobilecoin complaints

### DIFF
--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -378,9 +378,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         let payload = RequestPayload::new_v3(
             &view_key,
             &spend_key,
-            receiver.fog_report_url().unwrap_or(&""),
-            receiver.fog_report_id().unwrap_or(&""),
-            receiver.fog_authority_sig().unwrap_or(&[]),
+            "", // mobilecoind does not support fog
             request.get_value(),
             request.get_memo(),
         )

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -112,24 +112,24 @@ pub struct RequestPayload {
     /// UTF-8 encoded fog report service URL. (Version 1+)
     pub fog_report_url: String,
 
-    /// Bytes of user's signature over fog authority key (Version 1+)
-    pub fog_authority_sig: Vec<u8>,
-
-    /// The key labelling fog reports for this public address (Version 1+)
-    pub fog_report_id: String,
-
     /// The requested value in picoMOB. (Version 2+)
     pub value: u64,
 
     /// UTF-8 encoded memo message. (Version 3+)
     pub memo: String,
+
+    /// Bytes of user's signature over fog authority key (Version 4+)
+    pub fog_authority_sig: Vec<u8>,
+
+    /// The key labeling fog reports for this public address (Version 4+)
+    pub fog_report_id: String,
 }
 
 impl fmt::Debug for RequestPayload {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "version:{}, vpk:{}, spk:{}, fog:{}, fog-sig:{}, fog-report-key:{} value:{}, memo:{}",
+            "version:{}, vpk:{}, spk:{}, fog:{}, fog-sig:{}, fog-id:{} value:{}, memo:{}",
             self.version,
             hex_fmt::HexFmt(&self.view_public_key),
             hex_fmt::HexFmt(&self.spend_public_key),
@@ -168,19 +168,6 @@ impl RequestPayload {
             )?;
             payload.fog_report_url = String::from_utf8(fog_report_url_bytes.to_vec())?;
             validate_fog_report_url(&payload.fog_report_url)?;
-
-            let fog_authority_sig_size_byte =
-                checked_split_off(&mut buffer_bytes, 1, "fog_sig_size_byte")?;
-            let fog_authority_sig_size = fog_authority_sig_size_byte[0] as usize;
-            payload.fog_authority_sig =
-                checked_split_off(&mut buffer_bytes, fog_authority_sig_size, "fog_sig_bytes")?;
-
-            let fog_report_id_size_byte =
-                checked_split_off(&mut buffer_bytes, 1, "fog_report_id_size_byte")?;
-            let fog_report_id_size = fog_report_id_size_byte[0] as usize;
-            let fog_report_id_bytes =
-                checked_split_off(&mut buffer_bytes, fog_report_id_size, "fog_report_id_bytes")?;
-            payload.fog_report_id = String::from_utf8(fog_report_id_bytes.to_vec())?;
         }
         if payload.version >= 2 {
             let value_bytes = checked_split_off(&mut buffer_bytes, 8, "value_bytes")?;
@@ -195,6 +182,20 @@ impl RequestPayload {
             payload.memo = String::from_utf8(memo_bytes.to_vec())?;
             validate_memo(&payload.memo)?;
         }
+        if payload.version >= 4 {
+            let fog_authority_sig_size_byte =
+                checked_split_off(&mut buffer_bytes, 1, "fog_sig_size_byte")?;
+            let fog_authority_sig_size = fog_authority_sig_size_byte[0] as usize;
+            payload.fog_authority_sig =
+                checked_split_off(&mut buffer_bytes, fog_authority_sig_size, "fog_sig_bytes")?;
+
+            let fog_report_id_size_byte =
+                checked_split_off(&mut buffer_bytes, 1, "fog_report_id_size_byte")?;
+            let fog_report_id_size = fog_report_id_size_byte[0] as usize;
+            let fog_report_id_bytes =
+                checked_split_off(&mut buffer_bytes, fog_report_id_size, "fog_report_id_bytes")?;
+            payload.fog_report_id = String::from_utf8(fog_report_id_bytes.to_vec())?;
+        }
         // ignore possible future bytes
         Ok(payload)
     }
@@ -206,26 +207,23 @@ impl RequestPayload {
             view_public_key: *view_key,
             spend_public_key: *spend_key,
             fog_report_url: "".to_owned(),
-            fog_report_id: Default::default(),
-            fog_authority_sig: Default::default(),
             value: 0,
             memo: "".to_owned(),
+            fog_report_id: Default::default(),
+            fog_authority_sig: Default::default(),
         })
     }
 
-    /// Create a version 1 RequestPayload
+    /// Create a version 1 RequestPayload - this is deprecated because fog now requires a signature
+    #[deprecated]
     pub fn new_v1(
         view_key: &[u8; 32],
         spend_key: &[u8; 32],
         fog_report_url: &str,
-        fog_report_id: &str,
-        fog_authority_sig: &[u8],
     ) -> Result<Self, Error> {
         let mut result = RequestPayload::new_v0(view_key, spend_key)?;
         validate_fog_report_url(fog_report_url)?;
         result.fog_report_url = fog_report_url.to_owned();
-        result.fog_report_id = fog_report_id.to_owned();
-        result.fog_authority_sig = fog_authority_sig.to_vec();
         result.version = 1;
         Ok(result)
     }
@@ -235,17 +233,11 @@ impl RequestPayload {
         view_key: &[u8; 32],
         spend_key: &[u8; 32],
         fog_report_url: &str,
-        fog_report_id: &str,
-        fog_authority_sig: &[u8],
         value: u64,
     ) -> Result<Self, Error> {
-        let mut result = RequestPayload::new_v1(
-            view_key,
-            spend_key,
-            fog_report_url,
-            fog_report_id,
-            fog_authority_sig,
-        )?;
+        let mut result = RequestPayload::new_v0(view_key, spend_key)?;
+        validate_fog_report_url(fog_report_url)?;
+        result.fog_report_url = fog_report_url.to_owned();
         result.value = value;
         result.version = 2;
         Ok(result)
@@ -256,22 +248,30 @@ impl RequestPayload {
         view_key: &[u8; 32],
         spend_key: &[u8; 32],
         fog_report_url: &str,
-        fog_report_id: &str,
-        fog_authority_sig: &[u8],
         value: u64,
         memo: &str,
     ) -> Result<Self, Error> {
-        let mut result = RequestPayload::new_v2(
-            view_key,
-            spend_key,
-            fog_report_url,
-            fog_report_id,
-            fog_authority_sig,
-            value,
-        )?;
+        let mut result = RequestPayload::new_v2(view_key, spend_key, fog_report_url, value)?;
         validate_memo(memo)?;
         result.memo = memo.to_owned();
         result.version = 3;
+        Ok(result)
+    }
+
+    /// Create a version 4 RequestPayload
+    pub fn new_v4(
+        view_key: &[u8; 32],
+        spend_key: &[u8; 32],
+        fog_report_url: &str,
+        value: u64,
+        memo: &str,
+        fog_report_id: &str,
+        fog_authority_sig: &[u8],
+    ) -> Result<Self, Error> {
+        let mut result = RequestPayload::new_v3(view_key, spend_key, fog_report_url, value, memo)?;
+        result.fog_report_id = fog_report_id.to_owned();
+        result.fog_authority_sig = fog_authority_sig.to_vec();
+        result.version = 4;
         Ok(result)
     }
 
@@ -281,11 +281,15 @@ impl RequestPayload {
     /// [5]               version (< 256)
     /// [6..38]           public view key bytes [0..32]
     /// [38..70]          public spend key bytes [0..32]
-    /// [70]              length of fog service URL (f < 256)
-    /// [71..F=(71+f)]    fog service URL as utf-8 encoded string (< 256 bytes)
+    /// [70]              length of fog_report_url (f < 256)
+    /// [71..F=(71+f)]    fog_report_url as utf-8 encoded string (< 256 bytes)
     /// [F..F+8]          u64 picoMOB value requested
     /// [F+8]             length of memo (m < 256)
     /// [F+9..M=(F+9+m)]  memo as utf-8 encoded string (< 256 bytes)
+    /// [FIXME]           length of fog_authority_sig
+    /// [FIXME]           fog_authority_sig bytes (< 256 bytes)
+    /// [FIXME]           length of fog_report_id
+    /// [FIXME]           fog_report_id bytes (< 256 bytes)
     /// [M..]             future version data (ignored)
     pub fn encode(&self) -> String {
         let mut bytes_vec = Vec::new();
@@ -298,10 +302,6 @@ impl RequestPayload {
         if self.version >= 1 {
             bytes_vec.push(self.fog_report_url.len() as u8);
             bytes_vec.extend_from_slice(&self.fog_report_url.as_bytes());
-            bytes_vec.push(self.fog_authority_sig.len() as u8);
-            bytes_vec.extend_from_slice(self.fog_authority_sig.as_ref());
-            bytes_vec.push(self.fog_report_id.len() as u8);
-            bytes_vec.extend_from_slice(self.fog_report_id.as_ref());
         }
         if self.version >= 2 {
             bytes_vec.extend_from_slice(&self.value.to_le_bytes());
@@ -309,6 +309,12 @@ impl RequestPayload {
         if self.version >= 3 {
             bytes_vec.push(self.memo.len() as u8);
             bytes_vec.extend_from_slice(&self.memo.as_bytes());
+        }
+        if self.version >= 4 {
+            bytes_vec.push(self.fog_authority_sig.len() as u8);
+            bytes_vec.extend_from_slice(self.fog_authority_sig.as_ref());
+            bytes_vec.push(self.fog_report_id.len() as u8);
+            bytes_vec.extend_from_slice(self.fog_report_id.as_ref());
         }
         encode_payload(bytes_vec)
     }
@@ -343,7 +349,7 @@ impl TryFrom<&PublicAddress> for RequestPayload {
         let spend_pub: [u8; 32] = src.spend_public_key().to_bytes();
         let mut payload = RequestPayload::new_v0(&view_pub, &spend_pub)?;
         if let Some(fog_report_url_string) = src.fog_report_url() {
-            payload.version = 1;
+            payload.version = 4;
             payload.fog_report_url = fog_report_url_string.to_string();
             if let Some(sig) = src.fog_authority_sig() {
                 payload.fog_authority_sig = sig.to_vec();
@@ -611,7 +617,7 @@ mod testing {
         );
         let alice_request_payload = RequestPayload::try_from(&alice_public).unwrap();
         let alice_b58_str = alice_request_payload.encode();
-        assert_eq!(alice_b58_str, "4kKfdpo1cuAGpMGXdbCEMgWuJJCLwrc8sJ6b82AELfS1JEXyBjcbM2cx1xoPmf3v6yb2ypAukn1CaDxsKCJvpWMrLn2KE8MsKSSkTwSzEcSh99ogR6eMqLePtMrQ1t647");
+        assert_eq!(alice_b58_str, "5F24DBwfEGBN18LevLEt3wZHknBk1tSC32QfMzSoiPcMrJyErBqBiNQpfFWboY1DHAjwjkBf2qfUbGvjvcdJ6Uhp6qcZ1NChFutR2MpiyTkrKm7NhCrT6KjtDkQBxr7rw74oFzvh7rkrK");
         let alice_payload = RequestPayload::decode(&alice_b58_str).unwrap();
         let alice_decoded = PublicAddress::try_from(&alice_payload).unwrap();
         assert_eq!(alice_public, alice_decoded);
@@ -637,7 +643,7 @@ mod testing {
         );
         let bob_request_payload = RequestPayload::try_from(&bob_public).unwrap();
         let bob_b58_str = bob_request_payload.encode();
-        assert_eq!(bob_b58_str, "21BA6veypXUoUpzDWBQGUHfUcpVG1PjGsAJyng9Y5hdLFGvGbSVsyxfNuKJeYHpJKAXXksUUJrvjBn4UnXnPDhX7rMZ4RqYLidkkHkBf5Ah9adj7CXNB1sgaiqNfF7ftNgqe");
+        assert_eq!(bob_b58_str, "22M3RU5KkQ5izkdPhjAmj6KWs2Md3AuJTfeg7NxoJRyMsmiwV2NpdkA9ABrQSrHZuiEyHMJ4zxVwAeFDbjAHwx42AoFoLbYRkv19nwWFPLihthriKxCmvYpgVrzUpSbz27U1ASRhspZcqavc");
         let bob_payload = RequestPayload::decode(&bob_b58_str).unwrap();
         let bob_decoded = PublicAddress::try_from(&bob_payload).unwrap();
         assert_eq!(bob_public, bob_decoded);

--- a/util/url-encoding/tests/comparison.rs
+++ b/util/url-encoding/tests/comparison.rs
@@ -106,27 +106,6 @@ fn test_url_encoding() {
 
     {
         let addr = &addrs[2];
-        let payload = PaymentRequest::from(addr);
-        let encoded = MobUrl::try_from(&payload).unwrap();
-        let encoded_str: &str = encoded.as_ref();
-        assert_eq!("mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMRqp?s=SC9cs96Ry9z4Js_VXkC35IMnTjpQCtEujN8D-R15qTsJloN2pZ75BbSzGtQJ99kBt8mM2YBhlTW9wuCfzHU3gJmx", encoded_str);
-
-        let b58_payload = RequestPayload::new_v1(
-            &addr.spend_public_key().to_bytes(),
-            &addr.view_public_key().to_bytes(),
-            addr.fog_report_url().unwrap(),
-            "",
-            addr.fog_authority_sig().unwrap(),
-        )
-        .unwrap();
-        let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
-        assert_eq!("mob:///B5bnf3HTWMZLpvVse4aKVr3UWqZdV1FwHaUcx9wTVk5FqtAwKGQswhnZj5nFz8UmVNY1RSHsgYrfKWyf37rvg4eSBobaBryzo32i7k3ksi4wwiFRbdLhM2yECpGLMqox7YhWdLyGTHozgB1udkccUmjURQhy4h8ZdedtXntyNAidgbhUetYdawrygn6Y9JnwafZU8jyoKZj3kUAAs7xqy45BeBd41nXaQguz9X6P", b58_encoded);
-
-        assert!(encoded_str.len() < b58_encoded.len());
-    }
-
-    {
-        let addr = &addrs[2];
         let payload = PaymentRequest {
             address: addr.clone(),
             amount: Some(666),
@@ -137,18 +116,18 @@ fn test_url_encoding() {
         assert_eq!("mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMRqp?a=666&m=2+baby+goats&s=SC9cs96Ry9z4Js_VXkC35IMnTjpQCtEujN8D-R15qTsJloN2pZ75BbSzGtQJ99kBt8mM2YBhlTW9wuCfzHU3gJmx", encoded_str);
         assert_eq!(234, encoded_str.len());
 
-        let b58_payload = RequestPayload::new_v3(
+        let b58_payload = RequestPayload::new_v4(
             &addr.spend_public_key().to_bytes(),
             &addr.view_public_key().to_bytes(),
             addr.fog_report_url().unwrap(),
-            "",
-            addr.fog_authority_sig().unwrap(),
             666,
             "2 baby goats",
+            "",
+            addr.fog_authority_sig().unwrap(),
         )
         .unwrap();
         let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
-        assert_eq!("mob:///GTzg6TLXXx2WiSWBkSwH9KC5qof4R7iMZZvjhTPcT52wWDcoqxZhVFzBjUKi8t6m7TwyLRJWjq2jaLv58QJB6dfhZe1FLwzaMKYi8ibXqvCG6DEJ7YJXGUsL7RNN8ife3otBVaUReYaTMjHGihCpfppKGmHy2yzetAmwgPkqHkLQaTjGN12U8RU4n6gkNpawX87wBP9UZxA1zphZdRpSZwDNZJqSgmf4kcanY7sf6dVaqdTuVgBUuDRx93Nog9PK16NJW", b58_encoded);
+        assert_eq!("fixme", b58_encoded);
         assert_eq!(268, b58_encoded.len());
     }
 }

--- a/util/url-encoding/tests/comparison.rs
+++ b/util/url-encoding/tests/comparison.rs
@@ -58,27 +58,6 @@ fn test_url_encoding() {
 
     {
         let addr = &addrs[1];
-        let payload = PaymentRequest::from(addr);
-        let encoded = MobUrl::try_from(&payload).unwrap();
-        let encoded_str: &str = encoded.as_ref();
-        assert_eq!("mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCl6E?s=KovIno-JXUsQuTSmUj4MDowMENWBpAbrHcT61x72MWNc24hBmdiRlPtpuxSdju_eaMXKeSrLLHjP7VltAuI_hP1f", encoded_str);
-        assert_eq!(211, encoded_str.len());
-
-        let b58_payload = RequestPayload::new_v1(
-            &addr.spend_public_key().to_bytes(),
-            &addr.view_public_key().to_bytes(),
-            addr.fog_report_url().unwrap(),
-            "",
-            addr.fog_authority_sig().unwrap(),
-        )
-        .unwrap();
-        let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
-        assert_eq!("mob:///49XpEmD6GpoQtxBRMwuUd5LWqaMFd939QPAh4EPw9rndk637NwBYY9LRvAWAEafeRoPoQ9ZFSC44Epo547c4gtnb9V2ouXLGYGm8uVS5EjYrMaCpTeP2DLaxiJsxHd2qFTJi1qbftNXfKf4nQNy1CtaTPDytvR1cFT58WcVGpyUPX1Qw3qf5nznBjxZUE3fCQcmZXbqvfie8xAjXRHaP5RBn7s7CQBRqgTnmSX", b58_encoded);
-        assert_eq!(237, b58_encoded.len());
-    }
-
-    {
-        let addr = &addrs[1];
         let payload = PaymentRequest {
             address: addr.clone(),
             amount: Some(666),
@@ -89,18 +68,18 @@ fn test_url_encoding() {
         assert_eq!("mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCl6E?a=666&m=2+baby+goats&s=KovIno-JXUsQuTSmUj4MDowMENWBpAbrHcT61x72MWNc24hBmdiRlPtpuxSdju_eaMXKeSrLLHjP7VltAuI_hP1f", encoded_str);
         assert_eq!(232, encoded_str.len());
 
-        let b58_payload = RequestPayload::new_v3(
+        let b58_payload = RequestPayload::new_v4(
             &addr.spend_public_key().to_bytes(),
             &addr.view_public_key().to_bytes(),
             addr.fog_report_url().unwrap(),
-            "",
-            addr.fog_authority_sig().unwrap(),
             666,
             "2 baby goats",
+            "",
+            addr.fog_authority_sig().unwrap(),
         )
         .unwrap();
         let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
-        assert_eq!("mob:///2EdRJD64CAZ3T8QnbVT9fQe4BjmrKACEyzDmui5yWc2q3ZfjiCkusBn9kjFquJuDMJVJsYwqFGeXk8spmn33RFXyvGNTAZnTXA4AtjrYbx2kLkLySPi7tz17YSLtmpb5FGG9B3iGsA16SvKsiXj6dkvaHaddDKdHVrwo86uveUka36R2vaaTS4uzCxKnBPXwj7fB72dYY6yefjCZYGWAsqJbjNZ6tv8hvi8qB9tUYwKq21jHGyJQwaw63V1DWiXZCPk", b58_encoded);
+        assert_eq!("fixme", b58_encoded);
         assert_eq!(266, b58_encoded.len());
     }
 

--- a/util/url-encoding/tests/comparison.rs
+++ b/util/url-encoding/tests/comparison.rs
@@ -106,7 +106,7 @@ fn test_url_encoding() {
         )
         .unwrap();
         let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
-        assert_eq!("fixme", b58_encoded);
+        assert_eq!("mob:///8dUCXPapoK52Zvhdfb3YHpKJRDPKvXAJmeKjkAxXv7o4QDftDV2JPybwQXzzuU5pqqS3QJkGFnFVWzxDNdd86vEDm3HDdHSgjjX2b2dxW9PDP9Ly3ziqLsLvy1d9xpdVUGAo6gniDHbjNypcVXwyU7hQUmbuHK8YsfJkKz2DPj8GxT5dgMhNzgbmzenpoexERAc1NehdHpwi6e6Tro63i6ny7akE2911sxb8Ar12Lgk44Zsfvf43oRtQVmGGpWR5idGb1", b58_encoded);
         assert_eq!(268, b58_encoded.len());
     }
 }

--- a/util/url-encoding/tests/comparison.rs
+++ b/util/url-encoding/tests/comparison.rs
@@ -80,7 +80,7 @@ fn test_url_encoding() {
         .unwrap();
         let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
         assert_eq!("mob:///CzpFtx52f77AfogondLHGH4ZnhraB4igZKptek36H2mUPmj3qtLCV4UWB8QaDUqro3xBoKb4rXDSBm2nxV6GNz6pNfG5nwrdG17pPACnuh1NNFxyyUyEL6ckUfUhEYvPXLAy3JZhWCyi6g1S5MQd4NvaPXcptK14T5X2NP1yQei4paCBty8JxM4sc8mJa34NXYSySTnqAR53qC2WzmVKWtfuAAQXZU2jPR1kxZ2tJCdhBtERcfzsjKUAwZZMAYfgP9", b58_encoded);
-        assert_eq!(258, b58_encoded.len());
+        assert_eq!(265, b58_encoded.len());
     }
 
     {

--- a/util/url-encoding/tests/comparison.rs
+++ b/util/url-encoding/tests/comparison.rs
@@ -79,8 +79,8 @@ fn test_url_encoding() {
         )
         .unwrap();
         let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
-        assert_eq!("fixme", b58_encoded);
-        assert_eq!(266, b58_encoded.len());
+        assert_eq!("mob:///CzpFtx52f77AfogondLHGH4ZnhraB4igZKptek36H2mUPmj3qtLCV4UWB8QaDUqro3xBoKb4rXDSBm2nxV6GNz6pNfG5nwrdG17pPACnuh1NNFxyyUyEL6ckUfUhEYvPXLAy3JZhWCyi6g1S5MQd4NvaPXcptK14T5X2NP1yQei4paCBty8JxM4sc8mJa34NXYSySTnqAR53qC2WzmVKWtfuAAQXZU2jPR1kxZ2tJCdhBtERcfzsjKUAwZZMAYfgP9", b58_encoded);
+        assert_eq!(258, b58_encoded.len());
     }
 
     {


### PR DESCRIPTION
This patch should fail CI because it uses a deprecated fn in android-bindings.