### PR TITLE
Switch to using Mozilla's lmdb fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,21 +1777,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
-name = "lmdb"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0908efb5d6496aa977d96f91413da2635a902e5e31dbef0bfb88986c248539"
+name = "lmdb-rkv"
+version = "0.14.0"
+source = "git+https://github.com/mozilla/lmdb-rs?rev=df1c2f5#df1c2f56e3088f097c719c57b9925ab51e26f3f4"
 dependencies = [
  "bitflags",
+ "byteorder",
  "libc",
- "lmdb-sys",
+ "lmdb-rkv-sys",
 ]
 
 [[package]]
-name = "lmdb-sys"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b392838cfe8858e86fac37cf97a0e8c55cc60ba0a18365cadc33092f128ce9"
+name = "lmdb-rkv-sys"
+version = "0.11.0"
+source = "git+https://github.com/mozilla/lmdb-rs?rev=df1c2f5#df1c2f56e3088f097c719c57b9925ab51e26f3f4"
 dependencies = [
  "cc",
  "libc",
@@ -2504,7 +2503,7 @@ version = "0.4.0"
 dependencies = [
  "curve25519-dalek",
  "failure",
- "lmdb",
+ "lmdb-rkv",
  "mc-common",
  "mc-crypto-keys",
  "mc-crypto-rand",
@@ -2593,7 +2592,7 @@ dependencies = [
  "futures",
  "grpcio",
  "hex_fmt",
- "lmdb",
+ "lmdb-rkv",
  "lru",
  "mc-api",
  "mc-attest-core",
@@ -3282,7 +3281,7 @@ name = "mc-watcher"
 version = "0.4.0"
 dependencies = [
  "failure",
- "lmdb",
+ "lmdb-rkv",
  "mc-api",
  "mc-common",
  "mc-crypto-keys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,3 +105,6 @@ prost = { git = "https://github.com/danburkert/prost", rev = "6113789f70b6970982
 prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
 dialoguer = { git = "https://github.com/mitsuhiko/dialoguer", rev = "a0c6c1e" }
 console = { git = "https://github.com/mitsuhiko/console", rev = "1307823" }
+
+# Override lmdb-rkv for a necessary bugfix (see https://github.com/mozilla/lmdb-rs/pull/80)
+lmdb-rkv = { git = "https://github.com/mozilla/lmdb-rs", rev = "df1c2f5" }

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -15,7 +15,7 @@ mc-util-from-random = { path = "../../util/from-random" }
 mc-util-serial = { path = "../../util/serial", features = ["std"] }
 
 failure = "0.1.5"
-lmdb = "0.8.0"
+lmdb-rkv = "0.14.0"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand = { version = "0.7", optional = true }
 rand_core = "0.5"

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -36,7 +36,7 @@ failure = "0.1.5"
 futures = "0.1"
 grpcio = "0.5.1"
 hex_fmt = "0.3"
-lmdb = "0.8.0"
+lmdb-rkv = "0.14.0"
 lru = { version = "0.1" }
 num_cpus = "1.12"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }

--- a/mobilecoind/src/utxo_store.rs
+++ b/mobilecoind/src/utxo_store.rs
@@ -257,27 +257,30 @@ impl UtxoStore {
             // match the list of key images. Keep track of which ones were successfully
             // removed so that we could clear their utxo data and return them to the caller.
             let mut cursor = db_txn.open_rw_cursor(self.subaddress_id_to_utxo_id)?;
-            match cursor.iter_dup_of(&subaddress_id.to_vec()) {
-                Ok(iterator) => {
-                    for (_subaddress_id_bytes, utxo_id_bytes) in iterator {
-                        // Remember: The utxo id bytes are equal to the KeyImage
-                        if key_images.contains(&utxo_id_bytes) {
-                            // utxo ids and key images are interchangeable so this is not expected to
-                            // fail.
-                            // Note that it is critical to read `utxo_id_bytes` BEFORE deleting due to
-                            // this bug: https://github.com/danburkert/lmdb-rs/issues/57
-                            removed_key_images.push(KeyImage::try_from(utxo_id_bytes).unwrap());
+            let _ = cursor
+                .iter_dup_of(&subaddress_id.to_vec())
+                .map(|result| {
+                    result
+                        .map_err(Error::from)
+                        .and_then(|(subaddress_id_bytes, utxo_id_bytes)| {
+                            // Sanity check.
+                            assert_eq!(subaddress_id_bytes, &subaddress_id.to_vec()[..]);
 
-                            cursor.del(WriteFlags::empty())?;
-                        }
-                    }
+                            // Remember: The utxo id bytes are equal to the KeyImage
+                            if key_images.contains(&utxo_id_bytes) {
+                                // utxo ids and key images are interchangeable so this is not expected to
+                                // fail.
+                                // Note that it is critical to read `utxo_id_bytes` BEFORE deleting due to
+                                // this bug: https://github.com/danburkert/lmdb-rs/issues/57
+                                removed_key_images.push(KeyImage::try_from(utxo_id_bytes).unwrap());
 
-                    Ok(())
-                }
-                Err(lmdb::Error::NotFound) => Ok(()),
-                Err(err) => Err(Error::LMDB(err)),
-            }?;
-            drop(cursor);
+                                cursor.del(WriteFlags::empty())?;
+                            }
+
+                            Ok(())
+                        })
+                })
+                .collect::<Result<Vec<()>, Error>>()?;
         }
 
         // Remove the actual UnspentTxOut data for every key image we successfully removed.
@@ -369,18 +372,19 @@ impl UtxoStore {
         subaddress_id: &SubaddressId,
     ) -> Result<Vec<UtxoId>, Error> {
         let mut cursor = db_txn.open_ro_cursor(self.subaddress_id_to_utxo_id)?;
-        match cursor.iter_dup_of(&subaddress_id.to_vec()) {
-            Ok(iter) => {
-                let mut results = Vec::new();
-                for (_subaddress_id_bytes, utxo_id_bytes) in iter {
-                    let utxo_id = UtxoId::try_from(utxo_id_bytes)?;
-                    results.push(utxo_id);
-                }
-                Ok(results)
-            }
-            Err(lmdb::Error::NotFound) => Ok(vec![]),
-            Err(err) => Err(err.into()),
-        }
+        Ok(cursor
+            .iter_dup_of(&subaddress_id.to_vec())
+            .map(|result| {
+                result
+                    .map_err(Error::from)
+                    .and_then(|(subaddress_id_bytes, utxo_id_bytes)| {
+                        // Sanity check.
+                        assert_eq!(subaddress_id.to_vec(), subaddress_id_bytes);
+
+                        Ok(UtxoId::try_from(utxo_id_bytes)?)
+                    })
+            })
+            .collect::<Result<Vec<_>, Error>>()?)
     }
 
     /// Get a single UnspentTxOut by its id.

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -20,7 +20,7 @@ mc-util-from-random = { path = "../util/from-random" }
 mc-util-serial = { path = "../util/serial" }
 
 failure = "0.1.5"
-lmdb = "0.8.0"
+lmdb-rkv = "0.14.0"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 structopt = "0.3"
 url = "2.1"


### PR DESCRIPTION
### Motivation

The old `lmdb` crate we were using (https://github.com/danburkert/lmdb-rs) appears to no longer be maintained, and has some bugs that affect us (such as https://github.com/danburkert/lmdb-rs/issues/58). Mozilla are maintaining their own [fork](https://github.com/mozilla/lmdb-rs) which addresses the bugs we ran into.

### In this PR
* Switching every use of the old crate with the new crate.

### Future Work
* The bugfix we need has not been released to crates.io yet, so we are getting the crate straight from git. Once its released we should remove the override to use the released version.
