### PR TITLE
add v4 payment requests

### DIFF
--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -375,7 +375,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         let view_key = receiver.view_public_key().to_bytes();
         let spend_key = receiver.spend_public_key().to_bytes();
 
-        let payload = RequestPayload::new_v3(
+        let payload = RequestPayload::new_v4(
             &view_key,
             &spend_key,
             receiver.fog_report_url().unwrap_or(&""),

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -379,10 +379,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             &view_key,
             &spend_key,
             receiver.fog_report_url().unwrap_or(&""),
-            receiver.fog_report_id().unwrap_or(&""),
-            receiver.fog_authority_sig().unwrap_or(&[]),
             request.get_value(),
             request.get_memo(),
+            receiver.fog_report_id().unwrap_or(&""),
+            receiver.fog_authority_sig().unwrap_or(&[]),
         )
         .map_err(|err| rpc_internal_error("RequestPayload.new_v3", err, &self.logger))?;
         let b58_code = payload.encode();

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -375,14 +375,12 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         let view_key = receiver.view_public_key().to_bytes();
         let spend_key = receiver.spend_public_key().to_bytes();
 
-        let payload = RequestPayload::new_v4(
+        let payload = RequestPayload::new_v3(
             &view_key,
             &spend_key,
-            receiver.fog_report_url().unwrap_or(&""),
+            "", // mobilecoind does not support fog
             request.get_value(),
             request.get_memo(),
-            receiver.fog_report_id().unwrap_or(&""),
-            receiver.fog_authority_sig().unwrap_or(&[]),
         )
         .map_err(|err| rpc_internal_error("RequestPayload.new_v3", err, &self.logger))?;
         let b58_code = payload.encode();

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -629,7 +629,7 @@ mod testing {
         );
         let alice_request_payload = RequestPayload::try_from(&alice_public).unwrap();
         let alice_b58_str = alice_request_payload.encode();
-        assert_eq!(alice_b58_str, "fixme");
+        assert_eq!(alice_b58_str, "5F24DBwfEGBN18LevLEt3wZHknBk1tSC32QfMzSoiPcMrJyErBqBiNQpfFWboY1DHAjwjkBf2qfUbGvjvcdJ6Uhp6qcZ1NChFutR2MpiyTkrKm7NhCrT6KjtDkQBxr7rw74oFzvh7rkrK");
         let alice_payload = RequestPayload::decode(&alice_b58_str).unwrap();
         let alice_decoded = PublicAddress::try_from(&alice_payload).unwrap();
         assert_eq!(alice_public, alice_decoded);

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -655,7 +655,7 @@ mod testing {
         );
         let bob_request_payload = RequestPayload::try_from(&bob_public).unwrap();
         let bob_b58_str = bob_request_payload.encode();
-        assert_eq!(bob_b58_str, "fixme");
+        assert_eq!(bob_b58_str, "22M3RU5KkQ5izkdPhjAmj6KWs2Md3AuJTfeg7NxoJRyMsmiwV2NpdkA9ABrQSrHZuiEyHMJ4zxVwAeFDbjAHwx42AoFoLbYRkv19nwWFPLihthriKxCmvYpgVrzUpSbz27U1ASRhspZcqavc");
         let bob_payload = RequestPayload::decode(&bob_b58_str).unwrap();
         let bob_decoded = PublicAddress::try_from(&bob_payload).unwrap();
         assert_eq!(bob_public, bob_decoded);

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -235,7 +235,9 @@ impl RequestPayload {
         fog_report_url: &str,
         value: u64,
     ) -> Result<Self, Error> {
-        let mut result = RequestPayload::new_v1(view_key, spend_key, fog_report_url)?;
+        let mut result = RequestPayload::new_v0(view_key, spend_key)?;
+        validate_fog_report_url(fog_report_url)?;
+        result.fog_report_url = fog_report_url.to_owned();
         result.value = value;
         result.version = 2;
         Ok(result)

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -629,7 +629,7 @@ mod testing {
         );
         let alice_request_payload = RequestPayload::try_from(&alice_public).unwrap();
         let alice_b58_str = alice_request_payload.encode();
-        assert_eq!(alice_b58_str, "5F24DBwfEGBN18LevLEt3wZHknBk1tSC32QfMzSoiPcMrJyErBqBiNQpfFWboY1DHAjwjkBf2qfUbGvjvcdJ6Uhp6qcZ1NChFutR2MpiyTkrKm7NhCrT6");
+        assert_eq!(alice_b58_str, "5F24DBwfEGBN18LevLEt3wZHknBk1tSC32QfMzSoiPcMrJyErBqBiNQpfFWboY1DHAjwjkBf2qfUbGvjvcdJ6Uhp6qcZ1NChFutR2MpiyTkrKm7NhCrT6KjtDkQBxr7rw74oFzvh7rkrK");
         let alice_payload = RequestPayload::decode(&alice_b58_str).unwrap();
         let alice_decoded = PublicAddress::try_from(&alice_payload).unwrap();
         assert_eq!(alice_public, alice_decoded);

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -234,11 +234,7 @@ impl RequestPayload {
         fog_report_url: &str,
         value: u64,
     ) -> Result<Self, Error> {
-        let mut result = RequestPayload::new_v1(
-            view_key,
-            spend_key,
-            fog_report_url,
-        )?;
+        let mut result = RequestPayload::new_v1(view_key, spend_key, fog_report_url)?;
         result.value = value;
         result.version = 2;
         Ok(result)
@@ -252,12 +248,7 @@ impl RequestPayload {
         value: u64,
         memo: &str,
     ) -> Result<Self, Error> {
-        let mut result = RequestPayload::new_v2(
-            view_key,
-            spend_key,
-            fog_report_url,
-            value,
-        )?;
+        let mut result = RequestPayload::new_v2(view_key, spend_key, fog_report_url, value)?;
         validate_memo(memo)?;
         result.memo = memo.to_owned();
         result.version = 3;
@@ -274,13 +265,7 @@ impl RequestPayload {
         fog_report_id: &str,
         fog_authority_sig: &[u8],
     ) -> Result<Self, Error> {
-        let mut result = RequestPayload::new_v3(
-            view_key,
-            spend_key,
-            fog_report_url,
-            value,
-            memo,
-        )?;
+        let mut result = RequestPayload::new_v3(view_key, spend_key, fog_report_url, value, memo)?;
         result.fog_report_id = fog_report_id.to_owned();
         result.fog_authority_sig = fog_authority_sig.to_vec();
         result.version = 4;

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -629,7 +629,7 @@ mod testing {
         );
         let alice_request_payload = RequestPayload::try_from(&alice_public).unwrap();
         let alice_b58_str = alice_request_payload.encode();
-        assert_eq!(alice_b58_str, "4kKfdpo1cuAGpMGXdbCEMgWuJJCLwrc8sJ6b82AELfS1JEXyBjcbM2cx1xoPmf3v6yb2ypAukn1CaDxsKCJvpWMrLn2KE8MsKSSkTwSzEcSh99ogR6eMqLePtMrQ1t647");
+        assert_eq!(alice_b58_str, "5F24DBwfEGBN18LevLEt3wZHknBk1tSC32QfMzSoiPcMrJyErBqBiNQpfFWboY1DHAjwjkBf2qfUbGvjvcdJ6Uhp6qcZ1NChFutR2MpiyTkrKm7NhCrT6");
         let alice_payload = RequestPayload::decode(&alice_b58_str).unwrap();
         let alice_decoded = PublicAddress::try_from(&alice_payload).unwrap();
         assert_eq!(alice_public, alice_decoded);

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -214,7 +214,8 @@ impl RequestPayload {
         })
     }
 
-    /// Create a version 1 RequestPayload
+    /// Create a version 1 RequestPayload - this is deprecated becuause fog now requires a signature
+    #[deprecated]
     pub fn new_v1(
         view_key: &[u8; 32],
         spend_key: &[u8; 32],

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -129,7 +129,7 @@ impl fmt::Debug for RequestPayload {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "version:{}, vpk:{}, spk:{}, fog:{}, fog-sig:{}, fog-report-key:{} value:{}, memo:{}",
+            "version:{}, vpk:{}, spk:{}, fog:{}, fog-sig:{}, fog-id:{} value:{}, memo:{}",
             self.version,
             hex_fmt::HexFmt(&self.view_public_key),
             hex_fmt::HexFmt(&self.spend_public_key),
@@ -281,7 +281,7 @@ impl RequestPayload {
             value,
             memo,
         )?;
-        result.fog_report_key = fog_report_key.to_owned();
+        result.fog_report_id = fog_report_id.to_owned();
         result.fog_authority_sig = fog_authority_sig.to_vec();
         result.version = 4;
         Ok(result)
@@ -300,8 +300,8 @@ impl RequestPayload {
     /// [F+9..M=(F+9+m)]  memo as utf-8 encoded string (< 256 bytes)
     /// [FIXME]           length of fog_authority_sig
     /// [FIXME]           fog_authority_sig bytes (< 256 bytes)
-    /// [FIXME]           length of fog_report_key
-    /// [FIXME]           fog_report_key bytes (< 256 bytes)
+    /// [FIXME]           length of fog_report_id
+    /// [FIXME]           fog_report_id bytes (< 256 bytes)
     /// [M..]             future version data (ignored)
     pub fn encode(&self) -> String {
         let mut bytes_vec = Vec::new();

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -214,7 +214,7 @@ impl RequestPayload {
         })
     }
 
-    /// Create a version 1 RequestPayload - this is deprecated becuause fog now requires a signature
+    /// Create a version 1 RequestPayload - this is deprecated because fog now requires a signature
     #[deprecated]
     pub fn new_v1(
         view_key: &[u8; 32],

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -667,7 +667,7 @@ mod testing {
         );
         let bob_request_payload = RequestPayload::try_from(&bob_public).unwrap();
         let bob_b58_str = bob_request_payload.encode();
-        assert_eq!(bob_b58_str, "fixme");
+        assert_eq!(bob_b58_str, "72wW29sWRpkXtzuMhrcr5zjM3wvWDQj2FGCZf4eswvAhFMtCxdQjEYYmJfXtdTa7fLxGyELd6TT62Zb6nw6Hk7TfaX8nBAid");
         let bob_payload = RequestPayload::decode(&bob_b58_str).unwrap();
         let bob_decoded = PublicAddress::try_from(&bob_payload).unwrap();
         assert_eq!(bob_public, bob_decoded);

--- a/util/b58-payloads/src/payloads.rs
+++ b/util/b58-payloads/src/payloads.rs
@@ -629,7 +629,7 @@ mod testing {
         );
         let alice_request_payload = RequestPayload::try_from(&alice_public).unwrap();
         let alice_b58_str = alice_request_payload.encode();
-        assert_eq!(alice_b58_str, "5F24DBwfEGBN18LevLEt3wZHknBk1tSC32QfMzSoiPcMrJyErBqBiNQpfFWboY1DHAjwjkBf2qfUbGvjvcdJ6Uhp6qcZ1NChFutR2MpiyTkrKm7NhCrT6KjtDkQBxr7rw74oFzvh7rkrK");
+        assert_eq!(alice_b58_str, "fixme");
         let alice_payload = RequestPayload::decode(&alice_b58_str).unwrap();
         let alice_decoded = PublicAddress::try_from(&alice_payload).unwrap();
         assert_eq!(alice_public, alice_decoded);
@@ -655,7 +655,7 @@ mod testing {
         );
         let bob_request_payload = RequestPayload::try_from(&bob_public).unwrap();
         let bob_b58_str = bob_request_payload.encode();
-        assert_eq!(bob_b58_str, "21BA6veypXUoUpzDWBQGUHfUcpVG1PjGsAJyng9Y5hdLFGvGbSVsyxfNuKJeYHpJKAXXksUUJrvjBn4UnXnPDhX7rMZ4RqYLidkkHkBf5Ah9adj7CXNB1sgaiqNfF7ftNgqe");
+        assert_eq!(bob_b58_str, "fixme");
         let bob_payload = RequestPayload::decode(&bob_b58_str).unwrap();
         let bob_decoded = PublicAddress::try_from(&bob_payload).unwrap();
         assert_eq!(bob_public, bob_decoded);
@@ -667,7 +667,7 @@ mod testing {
         );
         let bob_request_payload = RequestPayload::try_from(&bob_public).unwrap();
         let bob_b58_str = bob_request_payload.encode();
-        assert_eq!(bob_b58_str, "72wW29sWRpkXtzuMhrcr5zjM3wvWDQj2FGCZf4eswvAhFMtCxdQjEYYmJfXtdTa7fLxGyELd6TT62Zb6nw6Hk7TfaX8nBAid");
+        assert_eq!(bob_b58_str, "fixme");
         let bob_payload = RequestPayload::decode(&bob_b58_str).unwrap();
         let bob_decoded = PublicAddress::try_from(&bob_payload).unwrap();
         assert_eq!(bob_public, bob_decoded);

--- a/util/url-encoding/tests/comparison.rs
+++ b/util/url-encoding/tests/comparison.rs
@@ -58,27 +58,6 @@ fn test_url_encoding() {
 
     {
         let addr = &addrs[1];
-        let payload = PaymentRequest::from(addr);
-        let encoded = MobUrl::try_from(&payload).unwrap();
-        let encoded_str: &str = encoded.as_ref();
-        assert_eq!("mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCl6E?s=KovIno-JXUsQuTSmUj4MDowMENWBpAbrHcT61x72MWNc24hBmdiRlPtpuxSdju_eaMXKeSrLLHjP7VltAuI_hP1f", encoded_str);
-        assert_eq!(211, encoded_str.len());
-
-        let b58_payload = RequestPayload::new_v1(
-            &addr.spend_public_key().to_bytes(),
-            &addr.view_public_key().to_bytes(),
-            addr.fog_report_url().unwrap(),
-            "",
-            addr.fog_authority_sig().unwrap(),
-        )
-        .unwrap();
-        let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
-        assert_eq!("mob:///49XpEmD6GpoQtxBRMwuUd5LWqaMFd939QPAh4EPw9rndk637NwBYY9LRvAWAEafeRoPoQ9ZFSC44Epo547c4gtnb9V2ouXLGYGm8uVS5EjYrMaCpTeP2DLaxiJsxHd2qFTJi1qbftNXfKf4nQNy1CtaTPDytvR1cFT58WcVGpyUPX1Qw3qf5nznBjxZUE3fCQcmZXbqvfie8xAjXRHaP5RBn7s7CQBRqgTnmSX", b58_encoded);
-        assert_eq!(237, b58_encoded.len());
-    }
-
-    {
-        let addr = &addrs[1];
         let payload = PaymentRequest {
             address: addr.clone(),
             amount: Some(666),
@@ -89,40 +68,19 @@ fn test_url_encoding() {
         assert_eq!("mob://fog.mobilecoin.signal.org/rmiEqq-34E3Fbm3hwxaYJtPZzu9THCBkQaqJDeZwuXG8mf2yOhmGoZmnKTu3--ZCj--5MdTwwCib2p7Dn3KTCl6E?a=666&m=2+baby+goats&s=KovIno-JXUsQuTSmUj4MDowMENWBpAbrHcT61x72MWNc24hBmdiRlPtpuxSdju_eaMXKeSrLLHjP7VltAuI_hP1f", encoded_str);
         assert_eq!(232, encoded_str.len());
 
-        let b58_payload = RequestPayload::new_v3(
+        let b58_payload = RequestPayload::new_v4(
             &addr.spend_public_key().to_bytes(),
             &addr.view_public_key().to_bytes(),
             addr.fog_report_url().unwrap(),
-            "",
-            addr.fog_authority_sig().unwrap(),
             666,
             "2 baby goats",
-        )
-        .unwrap();
-        let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
-        assert_eq!("mob:///2EdRJD64CAZ3T8QnbVT9fQe4BjmrKACEyzDmui5yWc2q3ZfjiCkusBn9kjFquJuDMJVJsYwqFGeXk8spmn33RFXyvGNTAZnTXA4AtjrYbx2kLkLySPi7tz17YSLtmpb5FGG9B3iGsA16SvKsiXj6dkvaHaddDKdHVrwo86uveUka36R2vaaTS4uzCxKnBPXwj7fB72dYY6yefjCZYGWAsqJbjNZ6tv8hvi8qB9tUYwKq21jHGyJQwaw63V1DWiXZCPk", b58_encoded);
-        assert_eq!(266, b58_encoded.len());
-    }
-
-    {
-        let addr = &addrs[2];
-        let payload = PaymentRequest::from(addr);
-        let encoded = MobUrl::try_from(&payload).unwrap();
-        let encoded_str: &str = encoded.as_ref();
-        assert_eq!("mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMRqp?s=SC9cs96Ry9z4Js_VXkC35IMnTjpQCtEujN8D-R15qTsJloN2pZ75BbSzGtQJ99kBt8mM2YBhlTW9wuCfzHU3gJmx", encoded_str);
-
-        let b58_payload = RequestPayload::new_v1(
-            &addr.spend_public_key().to_bytes(),
-            &addr.view_public_key().to_bytes(),
-            addr.fog_report_url().unwrap(),
             "",
             addr.fog_authority_sig().unwrap(),
         )
         .unwrap();
         let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
-        assert_eq!("mob:///B5bnf3HTWMZLpvVse4aKVr3UWqZdV1FwHaUcx9wTVk5FqtAwKGQswhnZj5nFz8UmVNY1RSHsgYrfKWyf37rvg4eSBobaBryzo32i7k3ksi4wwiFRbdLhM2yECpGLMqox7YhWdLyGTHozgB1udkccUmjURQhy4h8ZdedtXntyNAidgbhUetYdawrygn6Y9JnwafZU8jyoKZj3kUAAs7xqy45BeBd41nXaQguz9X6P", b58_encoded);
-
-        assert!(encoded_str.len() < b58_encoded.len());
+        assert_eq!("mob:///CzpFtx52f77AfogondLHGH4ZnhraB4igZKptek36H2mUPmj3qtLCV4UWB8QaDUqro3xBoKb4rXDSBm2nxV6GNz6pNfG5nwrdG17pPACnuh1NNFxyyUyEL6ckUfUhEYvPXLAy3JZhWCyi6g1S5MQd4NvaPXcptK14T5X2NP1yQei4paCBty8JxM4sc8mJa34NXYSySTnqAR53qC2WzmVKWtfuAAQXZU2jPR1kxZ2tJCdhBtERcfzsjKUAwZZMAYfgP9", b58_encoded);
+        assert_eq!(265, b58_encoded.len());
     }
 
     {
@@ -137,18 +95,18 @@ fn test_url_encoding() {
         assert_eq!("mob://fog.diogenes.mobilecoin.com/krmSAg7MnM0fn-yTIjV6tHtRA7Zj2JRZ4pJ-_PcweTkAu7afknATa5hFwtc_Zvi8R6d36cnpMA0-inMbZHiqMRqp?a=666&m=2+baby+goats&s=SC9cs96Ry9z4Js_VXkC35IMnTjpQCtEujN8D-R15qTsJloN2pZ75BbSzGtQJ99kBt8mM2YBhlTW9wuCfzHU3gJmx", encoded_str);
         assert_eq!(234, encoded_str.len());
 
-        let b58_payload = RequestPayload::new_v3(
+        let b58_payload = RequestPayload::new_v4(
             &addr.spend_public_key().to_bytes(),
             &addr.view_public_key().to_bytes(),
             addr.fog_report_url().unwrap(),
-            "",
-            addr.fog_authority_sig().unwrap(),
             666,
             "2 baby goats",
+            "",
+            addr.fog_authority_sig().unwrap(),
         )
         .unwrap();
         let b58_encoded = "mob:///".to_string() + &b58_payload.encode();
-        assert_eq!("mob:///GTzg6TLXXx2WiSWBkSwH9KC5qof4R7iMZZvjhTPcT52wWDcoqxZhVFzBjUKi8t6m7TwyLRJWjq2jaLv58QJB6dfhZe1FLwzaMKYi8ibXqvCG6DEJ7YJXGUsL7RNN8ife3otBVaUReYaTMjHGihCpfppKGmHy2yzetAmwgPkqHkLQaTjGN12U8RU4n6gkNpawX87wBP9UZxA1zphZdRpSZwDNZJqSgmf4kcanY7sf6dVaqdTuVgBUuDRx93Nog9PK16NJW", b58_encoded);
+        assert_eq!("mob:///8dUCXPapoK52Zvhdfb3YHpKJRDPKvXAJmeKjkAxXv7o4QDftDV2JPybwQXzzuU5pqqS3QJkGFnFVWzxDNdd86vEDm3HDdHSgjjX2b2dxW9PDP9Ly3ziqLsLvy1d9xpdVUGAo6gniDHbjNypcVXwyU7hQUmbuHK8YsfJkKz2DPj8GxT5dgMhNzgbmzenpoexERAc1NehdHpwi6e6Tro63i6ny7akE2911sxb8Ar12Lgk44Zsfvf43oRtQVmGGpWR5idGb1", b58_encoded);
         assert_eq!(268, b58_encoded.len());
     }
 }


### PR DESCRIPTION
### Motivation

Recent changes to the b58 code scheme were not backwards compatible. This PR restores backwards compatibility and fixes the merge race introduced in reverted PR #256

### In this PR

* move new fields to version 4


