### PR TITLE
enable resolver = "2"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,7 @@
+cargo-features = ["resolver"]
+
 [workspace]
+resolver = "2"
 members = [
     "admin-http-gateway",
     "api",

--- a/attest/core/build.rs
+++ b/attest/core/build.rs
@@ -21,8 +21,7 @@ use mbedtls_sys::{
     },
     x509_crt,
 };
-use mc_crypto_rand::McRng;
-use rand_core::RngCore;
+use mc_crypto_rand::{McRng, RngCore};
 use std::{
     convert::TryFrom,
     env,

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -1,9 +1,12 @@
+cargo-features = ["resolver"]
+
 [package]
 name = "mc-consensus-enclave-trusted"
 version = "0.4.0"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "The MobileCoin Consensus Service's internal enclave entry point."
+resolver = "2"
 
 [lib]
 crate-type = ["staticlib"]


### PR DESCRIPTION
### Motivation

#253 had to workaround Cargo's build feature unification annoyance (`build-dependencies` features plaguing the actual package's dependencies) by gating stuff on the `std` feature. Since upgrading Rust, we can now use the new resolver (see https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#resolver).

### In this PR
* Switch us to the new resolver. I have confirmed this solves the issue in #253.