### PR TITLE
MC-1626 Add cargo config to trusted enclave for options

### DIFF
--- a/consensus/enclave/trusted/.cargo/config
+++ b/consensus/enclave/trusted/.cargo/config
@@ -2,4 +2,4 @@
 rustflags = ["-D", "warnings"]
 
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake", "-C", "target-feature=+lvi-load-hardening"]
+rustflags = ["-D", "warnings", "-C", "target-cpu=skylake", "-C", "target-feature=+lvi-cfi,+lvi-load-hardening"]

--- a/consensus/enclave/trusted/.cargo/config
+++ b/consensus/enclave/trusted/.cargo/config
@@ -1,0 +1,5 @@
+[build]
+rustflags = ["-D", "warnings"]
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-D", "warnings", "-C", "target-cpu=skylake", "-C", "target-feature=+lvi-load-hardening"]


### PR DESCRIPTION
### Motivation

This adds the consensus enclave cargo config file to turn on lvi load hardening.

### In this PR
* Copy the top-level cargo config to the enclave to enable LVI load hardening via compiler flags.

### Future Work
* Updating other repositories to do the same.

