### PR TITLE
Block num by tx out index

### DIFF
--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -30,6 +30,9 @@ pub trait Ledger: Clone + Send {
     /// Gets a block signature by its index in the blockchain.
     fn get_block_signature(&self, block_number: u64) -> Result<BlockSignature, Error>;
 
+    /// Gets block index by a TxOut global index.
+    fn get_block_index_by_tx_out_index(&self, tx_out_index: u64) -> Result<u64, Error>;
+
     /// Get the total number of TxOuts in the ledger.
     fn num_txos(&self) -> Result<u64, Error>;
 

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -44,6 +44,7 @@ pub const BLOCK_SIGNATURES_DB_NAME: &str = "ledger_db:block_signatures";
 pub const KEY_IMAGES_DB_NAME: &str = "ledger_db:key_images";
 pub const KEY_IMAGES_BY_BLOCK_DB_NAME: &str = "ledger_db:key_images_by_block";
 pub const TX_OUTS_BY_BLOCK_DB_NAME: &str = "ledger_db:tx_outs_by_block";
+pub const BLOCK_NUMBER_BY_TX_OUT_INDEX: &str = "ledger_db:block_number_by_tx_out_index";
 
 // Keys used by the `counts` database.
 const NUM_BLOCKS_KEY: &str = "num_blocks";
@@ -98,6 +99,10 @@ pub struct LedgerDB {
     /// This map allows retrieval of all TxOuts that were included in a given block number by
     /// querying `tx_out_store`.
     tx_outs_by_block: Database,
+
+    /// TxOut global index -> block number.
+    /// This map allows retrieval of the block a given TxOut belongs to.
+    block_number_by_tx_out_index: Database,
 
     /// Location on filesystem.
     path: PathBuf,
@@ -195,6 +200,14 @@ impl Ledger for LedgerDB {
         Ok(signature)
     }
 
+    /// Gets block index by a TxOut global index.
+    fn get_block_index_by_tx_out_index(&self, tx_out_index: u64) -> Result<u64, Error> {
+        let db_transaction = self.env.begin_ro_txn()?;
+        let key = u64_to_key_bytes(tx_out_index);
+        let block_index_bytes = db_transaction.get(self.block_number_by_tx_out_index, &key)?;
+        Ok(key_bytes_to_u64(&block_index_bytes))
+    }
+
     /// Returns the index of the TxOut with the given hash.
     fn get_tx_out_index_by_hash(&self, tx_out_hash: &[u8; 32]) -> Result<u64, Error> {
         let db_transaction: RoTransaction = self.env.begin_ro_txn()?;
@@ -279,7 +292,7 @@ impl LedgerDB {
     #[allow(clippy::unreadable_literal)]
     pub fn open(path: PathBuf) -> Result<LedgerDB, Error> {
         let env = Environment::new()
-            .set_max_dbs(21)
+            .set_max_dbs(22)
             .set_map_size(MAX_LMDB_FILE_SIZE)
             // TODO - needed because currently our test cloud machines have slow disks.
             .set_flags(EnvironmentFlags::NO_SYNC)
@@ -319,6 +332,7 @@ impl LedgerDB {
         let key_images = env.open_db(Some(KEY_IMAGES_DB_NAME))?;
         let key_images_by_block = env.open_db(Some(KEY_IMAGES_BY_BLOCK_DB_NAME))?;
         let tx_outs_by_block = env.open_db(Some(TX_OUTS_BY_BLOCK_DB_NAME))?;
+        let block_number_by_tx_out_index = env.open_db(Some(BLOCK_NUMBER_BY_TX_OUT_INDEX))?;
 
         let tx_out_store = TxOutStore::new(&env)?;
 
@@ -331,6 +345,7 @@ impl LedgerDB {
             key_images,
             key_images_by_block,
             tx_outs_by_block,
+            block_number_by_tx_out_index,
             metadata_store,
             tx_out_store,
         })
@@ -339,7 +354,7 @@ impl LedgerDB {
     /// Creates a fresh Ledger Database in the given path.
     pub fn create(path: PathBuf) -> Result<(), Error> {
         let env = Environment::new()
-            .set_max_dbs(20)
+            .set_max_dbs(22)
             .set_map_size(MAX_LMDB_FILE_SIZE)
             .open(&path)
             .unwrap_or_else(|_| {
@@ -355,6 +370,7 @@ impl LedgerDB {
         env.create_db(Some(KEY_IMAGES_DB_NAME), DatabaseFlags::empty())?;
         env.create_db(Some(KEY_IMAGES_BY_BLOCK_DB_NAME), DatabaseFlags::empty())?;
         env.create_db(Some(TX_OUTS_BY_BLOCK_DB_NAME), DatabaseFlags::empty())?;
+        env.create_db(Some(BLOCK_NUMBER_BY_TX_OUT_INDEX), DatabaseFlags::empty())?;
 
         MetadataStore::create(&env)?;
         TxOutStore::create(&env)?;
@@ -463,12 +479,21 @@ impl LedgerDB {
         )?;
 
         // Write the actual TxOuts.
+        let block_index_bytes= u64_to_key_bytes(block_index);
+
         for tx_out in tx_outs {
             if self.contains_tx_out_public_key(&tx_out.public_key)? {
                 return Err(Error::DuplicateOutputPublicKey);
             }
 
-            self.tx_out_store.push(tx_out, db_transaction)?;
+            let tx_out_index = self.tx_out_store.push(tx_out, db_transaction)?;
+
+            db_transaction.put(
+                self.block_number_by_tx_out_index,
+                &u64_to_key_bytes(tx_out_index),
+                &block_index_bytes,
+                WriteFlags::NO_OVERWRITE,
+            )?;
         }
 
         // Done.
@@ -699,6 +724,9 @@ mod ledger_db_test {
         let key_images = ledger_db.get_key_images_by_block(0).unwrap();
         assert_eq!(key_images.len(), 0);
 
+        let block_index = ledger_db.get_block_index_by_tx_out_index(0).unwrap();
+        assert_eq!(block_index, 0);
+
         // === Create and append a non-origin block. ===
 
         let recipient_account_key = AccountKey::random(&mut rng);
@@ -747,6 +775,10 @@ mod ledger_db_test {
                 ledger_db.get_tx_out_by_index((i + 1) as u64).unwrap(),
                 *tx_out
             );
+
+            // All tx outs are in the second block.
+            let block_index = ledger_db.get_block_index_by_tx_out_index((i + 1) as u64).unwrap();
+            assert_eq!(block_index, 1);
         }
 
         assert!(ledger_db
@@ -871,6 +903,41 @@ mod ledger_db_test {
 
         match ledger_db.get_block(out_of_range) {
             Ok(_block) => panic!("Should not return a block."),
+            Err(Error::NotFound) => {
+                // This is expected.
+            }
+            Err(e) => panic!("Unexpected error {:?}", e),
+        }
+    }
+
+    #[test]
+    // Getting a block number by tx out index should return the correct block number, if it exists.
+    fn test_get_block_index_by_tx_out_index() {
+        let mut ledger_db = create_db();
+        let n_blocks = 43;
+        let (_expected_blocks, expected_block_contents) = populate_db(&mut ledger_db, n_blocks, 1);
+
+        for (block_index, block_contents) in expected_block_contents.iter().enumerate() {
+            for tx_out in block_contents.outputs.iter() {
+                let tx_out_index = ledger_db.get_tx_out_index_by_public_key(&tx_out.public_key).expect("Failed getting tx out index");
+
+                let block_index_by_tx_out = ledger_db.get_block_index_by_tx_out_index(tx_out_index).expect("Failed getting block index by tx out index");
+                assert_eq!(block_index as u64, block_index_by_tx_out);
+            }
+        }
+    }
+
+    #[test]
+    // Getting a block index by a tx out index return an error if the tx out index doesn't exist.
+    fn test_get_block_index_by_tx_out_index_doesnt_exist() {
+        let mut ledger_db = create_db();
+        let n_blocks = 43;
+        populate_db(&mut ledger_db, n_blocks, 1);
+
+        let out_of_range = 999;
+
+        match ledger_db.get_block_index_by_tx_out_index(out_of_range) {
+            Ok(_block_index) => panic!("Should not return a block index."),
             Err(Error::NotFound) => {
                 // This is expected.
             }

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -609,7 +609,7 @@ impl LedgerDB {
             let bytes = db_txn.get(tx_outs_by_block_db, &u64_to_key_bytes(block_num))?;
             let tx_outs_by_block: TxOutsByBlockValue = decode(&bytes)?;
 
-            global_log::debug!(
+            global_log::trace!(
                 "Assigning tx outs #{} - #{} to block #{}",
                 tx_outs_by_block.first_tx_out_index,
                 tx_outs_by_block.first_tx_out_index + tx_outs_by_block.num_tx_outs,

--- a/ledger/db/src/metadata.rs
+++ b/ledger/db/src/metadata.rs
@@ -7,7 +7,7 @@ use prost::Message;
 // If this is properly maintained, we could check during ledger db opening for any
 // incompatibilities, and either refuse to open or perform a migration.
 #[allow(clippy::unreadable_literal)]
-pub const LATEST_VERSION: u64 = 20200610;
+pub const LATEST_VERSION: u64 = 20200707;
 
 // Metadata information about the ledger databse.
 #[derive(Clone, Message)]

--- a/ledger/db/src/metadata.rs
+++ b/ledger/db/src/metadata.rs
@@ -25,8 +25,13 @@ pub struct MetadataVersion {
 impl MetadataVersion {
     /// Construct a MetadataVersion instance with the most up to date versioning information.
     pub fn latest() -> Self {
+        Self::with_database_format_version(LATEST_VERSION)
+    }
+
+    /// Construct a MetadataVersion instance with a specific database_format_version.
+    pub fn with_database_format_version(database_format_version: u64) -> Self {
         Self {
-            database_format_version: LATEST_VERSION,
+            database_format_version,
             created_by_crate_version: env!("CARGO_PKG_VERSION").to_owned(),
         }
     }
@@ -92,6 +97,23 @@ impl MetadataStore {
             self.metadata,
             &METADATA_VERSION_KEY,
             &encode(&MetadataVersion::latest()),
+            WriteFlags::empty(),
+        )?)
+    }
+
+    // Set version to a specific version.
+    pub fn set_version(
+        &self,
+        db_txn: &mut RwTransaction,
+        database_format_version: u64,
+    ) -> Result<(), Error> {
+        let metadata_version =
+            MetadataVersion::with_database_format_version(database_format_version);
+
+        Ok(db_txn.put(
+            self.metadata,
+            &METADATA_VERSION_KEY,
+            &encode(&metadata_version),
             WriteFlags::empty(),
         )?)
     }

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -69,7 +69,9 @@ impl MockLedger {
         for tx_out in &block_contents.outputs {
             let tx_out_index = inner.tx_outs.len() as u64;
             inner.tx_outs.insert(tx_out.clone());
-            inner.block_number_by_tx_out_index.insert(tx_out_index, block.index);
+            inner
+                .block_number_by_tx_out_index
+                .insert(tx_out_index, block.index);
         }
 
         let key_images = block_contents.key_images.clone();
@@ -123,7 +125,11 @@ impl Ledger for MockLedger {
 
     /// Gets block index by a TxOut global index.
     fn get_block_index_by_tx_out_index(&self, tx_out_index: u64) -> Result<u64, Error> {
-        self.lock().block_number_by_tx_out_index.get(&tx_out_index).cloned().ok_or(Error::NotFound)
+        self.lock()
+            .block_number_by_tx_out_index
+            .get(&tx_out_index)
+            .cloned()
+            .ok_or(Error::NotFound)
     }
 
     fn get_tx_out_index_by_hash(&self, _tx_out_hash: &[u8; 32]) -> Result<u64, Error> {


### PR DESCRIPTION
Soundtrack of this PR: [King Crimson - Red](https://open.spotify.com/album/13dGZzRzFoejmyVXAbTPAH?si=kIdv2XtaSPm93OCCfRSQ7g)

### Motivation

We'd like to be able to tell which block a certain TxOut belongs to, mainly for having access to signature and timestamp data. Currently, there is no way to do that.

### In this PR
* Add a new database to `LedgerDB` that keeps a mapping of TxOut global index -> Block number.
* Add code to migrate existing LedgerDBs, so that they can be continued to be used without having to recreate them.
