### PR TITLE
Adds get_network_status() to mob_client.py

### DIFF
--- a/mobilecoind/clients/python/mob_client/mob_client.py
+++ b/mobilecoind/clients/python/mob_client/mob_client.py
@@ -255,3 +255,15 @@ class mob_client:
         request = api.GetTxStatusAsReceiverRequest(receipt=receiver_tx_receipt)
         response = self.stub.GetTxStatusAsReceiver(request)
         return response.status
+
+    #
+    # Blockchain and network info
+    # 
+
+    def get_network_status(self):
+        """ Returns the total network height and our current sync height
+        """
+        response = self.stub.GetNetworkStatus(empty_pb2.Empty())
+        return (response.network_highest_block_index,
+                response.local_block_index,
+                response.is_behind)


### PR DESCRIPTION
Soundtrack of this PR: [Trust in me](https://www.youtube.com/watch?v=fZY8jUuEzJQ)

### Motivation

Some of our scripts need to check if mobilecoind is fully synchronized with the network

### In this PR
```
In [1]: from mob_client import mob_client                                                                                                 

In [2]: cli = mob_client("localhost:4444", False)                                                                                         

In [3]: cli.get_network_status()                                                                                                          
Out[3]: (2278, 2278, False)
```