### PR TITLE
MC-1626 Log target features of enclave, enable LVI mitigations for enclave builds #in-review

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -8,7 +8,7 @@ rustflags = ["-D", "warnings"]
 # ...so instead we list all target triples (Tier 1 64-bit platforms)
 
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]
+rustflags = ["-D", "warnings", "-C", "target-cpu=skylake", "-C", "target-feature=+sha"]
 
 [target.x86_64-pc-windows-gnu]
 rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,6 +2206,7 @@ dependencies = [
  "mc-sgx-slog",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
+ "mc-util-build-script",
  "mc-util-from-random",
  "mc-util-serial",
  "prost",

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -11,7 +11,7 @@ mod messages;
 
 pub use crate::{error::Error, messages::EnclaveCall};
 
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use core::{cmp::Ordering, hash::Hash, result::Result as StdResult};
 use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, VerificationReport};
 use mc_attest_enclave_api::{
@@ -197,7 +197,7 @@ pub trait ConsensusEnclave {
         self_peer_id: &ResponderId,
         self_client_id: &ResponderId,
         sealed_key: &Option<SealedBlockSigningKey>,
-    ) -> Result<SealedBlockSigningKey>;
+    ) -> Result<(SealedBlockSigningKey, Vec<String>)>;
 
     /// Retrieve the public identity of the enclave.
     fn get_identity(&self) -> Result<X25519Public>;

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -54,3 +54,6 @@ rand = "0.7"
 rand_hc = "0.2"
 mc-ledger-db = { path = "../../../ledger/db" }
 mc-transaction-core-test-utils = { path = "../../../transaction/core/test-utils" }
+
+[build-dependencies]
+mc-util-build-script = { path = "../../../util/build/script" }

--- a/consensus/enclave/impl/build.rs
+++ b/consensus/enclave/impl/build.rs
@@ -1,0 +1,28 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! Bake the compile-time target features into the enclave.
+
+use mc_util_build_script::Environment;
+use std::fs;
+
+fn main() {
+    let env = Environment::default();
+
+    let mut target_features = env
+        .target_features()
+        .iter()
+        .map(ToOwned::to_owned)
+        .collect::<Vec<String>>();
+    target_features.sort();
+
+    let mut contents = String::from("const TARGET_FEATURES: &[&str] = &[\n");
+    for feature in target_features {
+        contents.push_str("    \"");
+        contents.push_str(&feature);
+        contents.push_str("\",\n");
+    }
+    contents.push_str("];\n\n");
+
+    fs::write(&env.out_dir().join("target_features.rs"), &contents)
+        .expect("Could not write target feature array");
+}

--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -71,7 +71,11 @@ fn main() {
 
     builder
         .cargo_builder
-        .target_dir(env.target_dir().join(CONSENSUS_ENCLAVE_NAME));
+        .target("x86_64-unknown-linux-gnu") // Keep rustflags off build scripts
+        .target_dir(env.target_dir().join(CONSENSUS_ENCLAVE_NAME))
+        .add_rust_flags(&["-D", "warnings"])
+        .add_rust_flags(&["-C", "target-cpu=skylake"])
+        .add_rust_flags(&["-C", "target-feature=+lvi-cfi,+lvi-load-hardening,+sha"]);
 
     builder
         .config_builder

--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -70,12 +70,10 @@ fn main() {
     }
 
     builder
-        .cargo_builder
-        .target("x86_64-unknown-linux-gnu") // Keep rustflags off build scripts
-        .target_dir(env.target_dir().join(CONSENSUS_ENCLAVE_NAME))
+        .target_dir(env.target_dir().join(CONSENSUS_ENCLAVE_NAME).as_path())
         .add_rust_flags(&["-D", "warnings"])
         .add_rust_flags(&["-C", "target-cpu=skylake"])
-        .add_rust_flags(&["-C", "target-feature=+lvi-cfi,+lvi-load-hardening,+sha"]);
+        .add_rust_flags(&["-C", "target-feature=+sha"]);
 
     builder
         .config_builder
@@ -94,5 +92,5 @@ fn main() {
 
     let _sig = builder
         .build()
-        .expect("Failed to extract consensus-enclave signature");
+        .expect("Failed to get consensus-enclave sigstruct from build");
 }

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -63,8 +63,8 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
         _self_peer_id: &ResponderId,
         _self_client_id: &ResponderId,
         _sealed_key: &Option<SealedBlockSigningKey>,
-    ) -> Result<SealedBlockSigningKey> {
-        Ok(vec![])
+    ) -> Result<(SealedBlockSigningKey, Vec<String>)> {
+        Ok((vec![], vec![]))
     }
 
     fn get_identity(&self) -> Result<X25519Public> {

--- a/consensus/enclave/src/lib.rs
+++ b/consensus/enclave/src/lib.rs
@@ -42,7 +42,11 @@ impl ConsensusServiceSgxEnclave {
         self_peer_id: &ResponderId,
         self_client_id: &ResponderId,
         sealed_key: &Option<SealedBlockSigningKey>,
-    ) -> (ConsensusServiceSgxEnclave, SealedBlockSigningKey) {
+    ) -> (
+        ConsensusServiceSgxEnclave,
+        SealedBlockSigningKey,
+        Vec<String>,
+    ) {
         let mut launch_token: sgx_launch_token_t = [0; 1024];
         let mut launch_token_updated: i32 = 0;
         // FIXME: this must be filled in from the build.rs
@@ -63,11 +67,11 @@ impl ConsensusServiceSgxEnclave {
             enclave: Arc::new(enclave),
         };
 
-        let sealed_key = sgx_enclave
+        let (sealed_key, features) = sgx_enclave
             .enclave_init(self_peer_id, self_client_id, &sealed_key)
             .expect("enclave_init failed");
 
-        (sgx_enclave, sealed_key)
+        (sgx_enclave, sealed_key, features)
     }
 
     /// Takes serialized data, and fires to the corresponding ECALL.
@@ -89,7 +93,7 @@ impl ConsensusEnclave for ConsensusServiceSgxEnclave {
         self_peer_id: &ResponderId,
         self_client_id: &ResponderId,
         sealed_key: &Option<SealedBlockSigningKey>,
-    ) -> Result<SealedBlockSigningKey> {
+    ) -> Result<(SealedBlockSigningKey, Vec<String>)> {
         let inbuf = mc_util_serial::serialize(&EnclaveCall::EnclaveInit(
             self_peer_id.clone(),
             self_client_id.clone(),

--- a/consensus/enclave/trusted/.cargo/config
+++ b/consensus/enclave/trusted/.cargo/config
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["-D", "warnings"]
-
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake", "-C", "target-feature=+lvi-cfi,+lvi-load-hardening,+sha", "-C", "llvm-args=--x86-experimental-lvi-inline-asm-hardening"]

--- a/consensus/enclave/trusted/.cargo/config
+++ b/consensus/enclave/trusted/.cargo/config
@@ -2,4 +2,4 @@
 rustflags = ["-D", "warnings"]
 
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake", "-C", "target-feature=+lvi-cfi,+lvi-load-hardening"]
+rustflags = ["-D", "warnings", "-C", "target-cpu=skylake", "-C", "target-feature=+lvi-cfi,+lvi-load-hardening,+sha", "-C", "llvm-args=--x86-experimental-lvi-inline-asm-hardening"]

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -721,6 +721,7 @@ dependencies = [
  "mc-sgx-compat 0.5.0",
  "mc-sgx-slog 0.5.0",
  "mc-transaction-core 0.5.0",
+ "mc-util-build-script 0.5.0",
  "mc-util-from-random 0.5.0",
  "mc-util-serial 0.5.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",

--- a/consensus/service/src/bin/main.rs
+++ b/consensus/service/src/bin/main.rs
@@ -49,12 +49,14 @@ fn main() -> Result<(), ConsensusServiceError> {
     let enclave_path = env::current_exe()
         .expect("Could not get the path of our executable")
         .with_file_name(ENCLAVE_FILE);
-    let (enclave, sealed_key) = ConsensusServiceSgxEnclave::new(
+    let (enclave, sealed_key, features) = ConsensusServiceSgxEnclave::new(
         enclave_path,
         &config.peer_responder_id,
         &config.client_responder_id,
         &cached_key,
     );
+
+    log::info!(logger, "Enclave target features: {}", features.join(", "));
 
     // write the sealed block signing key
     let mut sealed_key_file =

--- a/util/build/enclave/src/lib.rs
+++ b/util/build/enclave/src/lib.rs
@@ -220,11 +220,7 @@ impl Builder {
         let mut cargo_builder = CargoBuilder::new(&env, staticlib_dir, false);
         cargo_builder
             .target(ENCLAVE_TARGET_TRIPLE)
-            .add_rust_flags(&["-C", "target-feature=+lvi-cfi,+lvi-load-hardening"])
-            .add_rust_flags(&[
-                "-C",
-                "llvm-args=--x86-experimental-lvi-inline-asm-hardening",
-            ]);
+            .add_rust_flags(&["-C", "target-feature=+lvi-cfi,+lvi-load-hardening"]);
 
         Ok(Self {
             cargo_builder,

--- a/util/build/enclave/src/lib.rs
+++ b/util/build/enclave/src/lib.rs
@@ -598,6 +598,7 @@ impl Builder {
         let mut static_archive_name = "lib".to_owned();
         // libnames are not kebab, crate names are
         static_archive_name.push_str(&staticlib_crate_name.replace("-", "_"));
+        // FIXME: need to add the cargo_builder's target value here, if it's set.
         let mut static_archive = staticlib_target_dir.join(&self.profile);
         static_archive.push(static_archive_name);
         static_archive.set_extension("a");

--- a/util/build/enclave/src/lib.rs
+++ b/util/build/enclave/src/lib.rs
@@ -220,6 +220,7 @@ impl Builder {
         let mut cargo_builder = CargoBuilder::new(&env, staticlib_dir, false);
         cargo_builder.target(ENCLAVE_TARGET_TRIPLE);
         cargo_builder.add_rust_flags(&["-C", "target-feature=+lvi-cfi,+lvi-load-hardening"]);
+        cargo_builder.add_rust_flags(&["-C", "llvm-args=--x86-experimental-lvi-inline-asm-hardening"])
 
         Ok(Self {
             cargo_builder,

--- a/util/build/enclave/src/lib.rs
+++ b/util/build/enclave/src/lib.rs
@@ -218,9 +218,13 @@ impl Builder {
             .exec()?;
 
         let mut cargo_builder = CargoBuilder::new(&env, staticlib_dir, false);
-        cargo_builder.target(ENCLAVE_TARGET_TRIPLE);
-        cargo_builder.add_rust_flags(&["-C", "target-feature=+lvi-cfi,+lvi-load-hardening"]);
-        cargo_builder.add_rust_flags(&["-C", "llvm-args=--x86-experimental-lvi-inline-asm-hardening"])
+        cargo_builder
+            .target(ENCLAVE_TARGET_TRIPLE)
+            .add_rust_flags(&["-C", "target-feature=+lvi-cfi,+lvi-load-hardening"])
+            .add_rust_flags(&[
+                "-C",
+                "llvm-args=--x86-experimental-lvi-inline-asm-hardening",
+            ]);
 
         Ok(Self {
             cargo_builder,

--- a/util/build/script/src/cargo_build.rs
+++ b/util/build/script/src/cargo_build.rs
@@ -381,38 +381,38 @@ impl CargoBuilder {
     }
 
     /// Set the path to the cargo executable
-    pub fn cargo_path(&mut self, cargo: PathBuf) -> &mut Self {
-        self.cargo_path = cargo;
+    pub fn cargo_path(&mut self, cargo: &Path) -> &mut Self {
+        self.cargo_path = cargo.to_owned();
         self
     }
 
     /// Set the CARGO_HOME variable for invoking cargo
-    pub fn home(&mut self, home: PathBuf) -> &mut Self {
-        self.home = Some(home);
+    pub fn home(&mut self, home: &Path) -> &mut Self {
+        self.home = Some(home.to_owned());
         self
     }
 
     /// Set the CARGO_TARGET_DIR variable for invoking cargo
-    pub fn target_dir(&mut self, target_dir: PathBuf) -> &mut Self {
-        self.target_dir = Some(target_dir);
+    pub fn target_dir(&mut self, target_dir: &Path) -> &mut Self {
+        self.target_dir = Some(target_dir.to_owned());
         self
     }
 
     /// Set the RUSTC variable for invoking cargo
-    pub fn rustc(&mut self, rustc: PathBuf) -> &mut Self {
-        self.rustc = Some(rustc);
+    pub fn rustc(&mut self, rustc: &Path) -> &mut Self {
+        self.rustc = Some(rustc.to_owned());
         self
     }
 
     /// Set the RUSTC_WRAPPER variable for invoking cargo
-    pub fn rustc_wrapper(&mut self, rustc_wrapper: PathBuf) -> &mut Self {
-        self.rustc_wrapper = Some(rustc_wrapper);
+    pub fn rustc_wrapper(&mut self, rustc_wrapper: &Path) -> &mut Self {
+        self.rustc_wrapper = Some(rustc_wrapper.to_owned());
         self
     }
 
     /// Set the RUSTDOC variable when invoking cargo
-    pub fn rustdoc(&mut self, rustdoc: PathBuf) -> &mut Self {
-        self.rustdoc = Some(rustdoc);
+    pub fn rustdoc(&mut self, rustdoc: &Path) -> &mut Self {
+        self.rustdoc = Some(rustdoc.to_owned());
         self
     }
 

--- a/util/build/script/src/cargo_build.rs
+++ b/util/build/script/src/cargo_build.rs
@@ -46,6 +46,7 @@ fn strv_env(command: &mut Command, clean_env: bool, values: &[String], env: &str
         str_env(command, clean_env, None as Option<&String>, env);
     } else {
         let v = values.join(sep);
+        eprintln!("Setting {}=\"{}\"", env, &v);
         str_env(command, clean_env, Some(&v), env);
     }
 }
@@ -367,7 +368,7 @@ impl CargoBuilder {
             ENV_CARGO_TERM_COLOR,
         );
 
-        command.arg("build");
+        command.arg("build").arg("-vv");
 
         if self.profile == "release" {
             command.arg("--release");
@@ -422,9 +423,25 @@ impl CargoBuilder {
         self
     }
 
+    /// Add multiple items to the RUSTDOCFLAGS environment string
+    pub fn add_rustdoc_flags(&mut self, rustdoc_flags: &[&str]) -> &mut Self {
+        for flag in rustdoc_flags {
+            self.rustdocflags.push((*flag).to_owned());
+        }
+        self
+    }
+
     /// Add an item to the RUSTFLAGS environment string
     pub fn add_rust_flag(&mut self, rust_flag: &str) -> &mut Self {
         self.rustflags.push(rust_flag.to_owned());
+        self
+    }
+
+    /// Add multiple items to the RUSTFLAGS environment string
+    pub fn add_rust_flags(&mut self, rust_flags: &[&str]) -> &mut Self {
+        for flag in rust_flags {
+            self.rustflags.push((*flag).to_owned());
+        }
         self
     }
 

--- a/util/build/script/src/cargo_build.rs
+++ b/util/build/script/src/cargo_build.rs
@@ -46,7 +46,6 @@ fn strv_env(command: &mut Command, clean_env: bool, values: &[String], env: &str
         str_env(command, clean_env, None as Option<&String>, env);
     } else {
         let v = values.join(sep);
-        eprintln!("Setting {}=\"{}\"", env, &v);
         str_env(command, clean_env, Some(&v), env);
     }
 }
@@ -458,8 +457,8 @@ impl CargoBuilder {
     }
 
     /// Set the terminal environment variable.
-    pub fn term(&mut self, term: String) -> &mut Self {
-        self.term = Some(term);
+    pub fn term(&mut self, term: &str) -> &mut Self {
+        self.term = Some(term.to_owned());
         self
     }
 
@@ -470,14 +469,14 @@ impl CargoBuilder {
     }
 
     /// Override the `build.target` configuration option
-    pub fn target(&mut self, target: String) -> &mut Self {
-        self.target = Some(target);
+    pub fn target(&mut self, target: &str) -> &mut Self {
+        self.target = Some(target.to_owned());
         self
     }
 
     /// Override the `build.dep-info-basedir` configuration option
-    pub fn dep_info_basedir(&mut self, dep_info_basedir: PathBuf) -> &mut Self {
-        self.dep_info_basedir = Some(dep_info_basedir);
+    pub fn dep_info_basedir(&mut self, dep_info_basedir: &Path) -> &mut Self {
+        self.dep_info_basedir = Some(dep_info_basedir.to_owned());
         self
     }
 
@@ -494,8 +493,8 @@ impl CargoBuilder {
     }
 
     /// Override the `http.proxy` configuration option
-    pub fn http_proxy(&mut self, http_proxy: String) -> &mut Self {
-        self.http_proxy = Some(http_proxy);
+    pub fn http_proxy(&mut self, http_proxy: &str) -> &mut Self {
+        self.http_proxy = Some(http_proxy.to_owned());
         self
     }
 
@@ -506,8 +505,8 @@ impl CargoBuilder {
     }
 
     /// Override the `http.cainfo` file configuration option
-    pub fn http_cainfo(&mut self, http_cainfo: PathBuf) -> &mut Self {
-        self.http_cainfo = Some(http_cainfo);
+    pub fn http_cainfo(&mut self, http_cainfo: &Path) -> &mut Self {
+        self.http_cainfo = Some(http_cainfo.to_owned());
         self
     }
 
@@ -518,8 +517,8 @@ impl CargoBuilder {
     }
 
     /// Override the `http.ssl-version` configuration option
-    pub fn http_ssl_version(&mut self, http_ssl_version: String) -> &mut Self {
-        self.http_ssl_version = Some(http_ssl_version);
+    pub fn http_ssl_version(&mut self, http_ssl_version: &str) -> &mut Self {
+        self.http_ssl_version = Some(http_ssl_version.to_owned());
         self
     }
 

--- a/util/build/script/src/env.rs
+++ b/util/build/script/src/env.rs
@@ -225,12 +225,14 @@ impl Environment {
         let out_dir = PathBuf::from(
             var(ENV_OUT_DIR).map_err(|e| EnvironmentError::Var(ENV_OUT_DIR.to_owned(), e))?,
         );
+        let target =
+            var(ENV_TARGET).map_err(|e| EnvironmentError::Var(ENV_TARGET.to_owned(), e))?;
         let profile =
             var(ENV_PROFILE).map_err(|e| EnvironmentError::Var(ENV_PROFILE.to_owned(), e))?;
         let profile_target_dir = out_dir
             .as_path()
             .ancestors()
-            .find(|path| path.ends_with(&profile))
+            .find(|path| path.ends_with(&target) || path.ends_with(&profile))
             .ok_or_else(|| EnvironmentError::OutDir(out_dir.clone()))?
             .to_owned();
         let target_dir = profile_target_dir

--- a/util/build/sgx/src/edger8r.rs
+++ b/util/build/sgx/src/edger8r.rs
@@ -178,8 +178,6 @@ impl Edger8r {
         }
         command.arg(&self.out_dir.to_str().expect("Invalid UTF-8 in out dir"));
 
-        eprintln!("command: {:?}", &command);
-
         let output = command.output()?;
 
         if output.status.success() {


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR](https://www.youtube.com/watch?v=n4RjJKxsamQ)

### Motivation

With #270, the LVI mitigations were never deployed, and failed to build in release mode. This fixes those issues and runs with LVI hardening enabled, at noticeable (-25%) reduction in tx/s.

### In this PR
* Bakes the compile-time features into a string array in the enclave impl, and outputs them as a `Vec<String>` via `enclave_init()`, and logs them.
* Adds the necessary hardening features to the enclave builder.
* Adds warnings and CPU selection to the measurement builder.
* Adds a "-vv" logging to the cargo invocation (this will be hidden if "-vv" is not also provided at the top-level)

