### PR TITLE
remove confusing log message

### DIFF
--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use failure::Fail;
-use mc_common::logger::global_log;
 
 /// A Ledger error kind.
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Fail)]
@@ -61,10 +60,7 @@ impl From<lmdb::Error> for Error {
         match lmdb_error {
             lmdb::Error::NotFound => Error::NotFound,
             lmdb::Error::BadRslot => Error::BadRslot,
-            err => {
-                global_log::error!("lmdb error: {:?} ", err);
-                Error::LmdbError(err)
-            }
+            err => Error::LmdbError(err),
         }
     }
 }


### PR DESCRIPTION
### Motivation

A ticket (MC-1649) was submitted for the following error:
`2020-07-08 17:11:08.542491691 UTC ERRO lmdb error: Other(2) , mc.app: mobilecoind, mc.module: mc_ledger_db::error, mc.src: ledger/db/src/error.rs:62`

However, this isn't actually a problem - it happens when the database doesn't exist which is a legitimate case that is properly handled by the application that printed this log message. There's no need for it, and it can be surfaced to the user as part of standardized error handling. We don't globally log error messages in other places and there's no need for this to exist here either.

### In this PR
* Removal of the confusing log message.
