### PR TITLE
Fix instructions for generate-sample-ledger

### DIFF
--- a/util/generate-sample-ledger/README.md
+++ b/util/generate-sample-ledger/README.md
@@ -15,9 +15,10 @@ cargo run --release -p mc-util-keyfile --bin sample-keys -- --num 10
 
 ### Usage
 
-Next, generate the ledger, with `--num` specifying the number of transactions per account to create.
+Next, generate the ledger.
 
 ```
-mkdir ledger
-cargo run --release -p mc-util-generate-sample-ledger --bin generate-sample-ledger -- --num 1000
+cargo run --release -p mc-util-generate-sample-ledger --bin generate-sample-ledger
 ```
+
+This will generate 100 transactions for each account, placing the database in the `ledger` directory.


### PR DESCRIPTION

### Motivation

The instructions here are not quite right.

Firstly, the `--num` parameter no longer exists, and seems to have a reasonable default, so I removed it.

Secondly, the `ledger` directory _does_ exist, so `mkdir ledger` will fail. It seems like something is a bit wonky here because `ledger` contains source code, and the end result of following these instructions is to create a database in that directory. I'm not sure how to reconcile that, so I just updated the instructions to reflect what happens.

### In this PR

Make instructions reflect current master.

### Future Work

None.
