### PR TITLE
MC-1626 Remove trusted enclave cargo config

### DIFF
--- a/consensus/enclave/trusted/.cargo/config
+++ b/consensus/enclave/trusted/.cargo/config
@@ -1,5 +1,0 @@
-[build]
-rustflags = ["-D", "warnings"]
-
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake", "-C", "target-feature=+lvi-cfi,+lvi-load-hardening"]


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR](https://www.youtube.com/watch?v=xwhBRJStz7w)

### Motivation

Additional work is needed to turn on LVI mitigations in the consensus enclave.

### In this PR
* Revert #270, consensus enclave cargo config, pending successful build cycle on an actual network.

### Future Work
* Make this stuff go.

