### PR TITLE
add missing tx_source_urls to consensus service README (fix #288)

### DIFF
--- a/consensus/service/README.md
+++ b/consensus/service/README.md
@@ -133,11 +133,16 @@ Follow the steps below:
 
     quorum_set = { threshold = 2, members = [
         # Node 1
-        { type = "Node", args = "peer2.test.mobilecoin.com:443" },
+        { type = "Node", args = "peer1.test.mobilecoin.com:443" },
 
         # Node 2
         { type = "Node", args = "peer2.test.mobilecoin.com:443" },
     ] }
+
+    tx_source_urls = [
+        "https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/",
+        "https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/",
+    ]
     ```
 
 #### Run


### PR DESCRIPTION
### Motivation

#288 correctly points out the example in the README is missing a required field in the `network.toml` example.

### In this PR
* Adding the missing field and fixing a typo
