### PR TITLE
[MC-1557] Add building on macOS to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,14 @@ executors:
       - image: *builder-install
     resource_class: large
 
+  macos:
+    macos:
+      xcode: 11.6.0
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_BUNDLE_NO_LOCK: 1
+
 commands:
   print_versions:
     description: Version Info
@@ -62,6 +70,8 @@ commands:
             echo 'export CMAKE_C_COMPILER_LAUNCHER=sccache' >> $BASH_ENV
             echo 'export CMAKE_CXX_COMPILER_LAUNCHER=sccache' >> $BASH_ENV
 
+            # Set cache dir explicitly so that all platforms use the same location
+            echo 'export SCCACHE_DIR=$HOME/.cache/sccache' >> $BASH_ENV
 
   restore-sccache-cache:
     steps:
@@ -167,6 +177,7 @@ commands:
       - run:
           name: Install CI dependencies
           command: |
+            command -v sccache >/dev/null || cargo install sccache
             command -v cargo-cache >/dev/null || cargo install cargo-cache
             command -v cargo2junit >/dev/null || cargo install cargo2junit
 
@@ -391,6 +402,38 @@ jobs:
       - store_artifacts:
           path: /tmp/doc.tgz
 
+  # Build using macOS
+  build-all-macos:
+    executor: macos
+    environment:
+      <<: *default-environment
+      SCCACHE_CACHE_SIZE: 450M
+      RUSTFLAGS: -D warnings -C target-cpu=penryn
+      CONSENSUS_ENCLAVE_CSS: /Users/distiller/project/sgx/css/src/valid.css
+    steps:
+      - prepare-for-build
+      - run:
+          name: Cargo check (SW/IAS dev)
+          command: |
+            cargo check --workspace --frozen \
+              --exclude mc-attest-untrusted \
+              --exclude mc-consensus-enclave \
+              --exclude mc-consensus-service \
+              --exclude mc-sgx-core-types \
+              --exclude mc-sgx-core-types-sys \
+              --exclude mc-sgx-epid \
+              --exclude mc-sgx-epid-sys \
+              --exclude mc-sgx-epid-types \
+              --exclude mc-sgx-epid-types-sys \
+              --exclude mc-sgx-ias-types \
+              --exclude mc-sgx-report-cache-untrusted \
+              --exclude mc-sgx-urts-sys
+      - check-dirty-git
+      - when:
+          condition: { equal: [ << pipeline.git.branch >>, master ] }
+          steps: [ save-cargo-cache, save-sccache-cache ]
+      - post-build
+
 workflows:
   version: 2
   # Build and run tests on a single container
@@ -401,6 +444,9 @@ workflows:
 
       # Build everything in debug
       - build-all-and-lint-debug
+
+      # Build using macOS
+      - build-all-macos
 
   # Build and run tests in parallel - not needed at the moment since the test suite is fast enough.
   # build-and-run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,34 @@ commands:
             cargo cache
             cargo cache local
 
+  restore-homebrew-cache:
+    steps:
+      - restore_cache:
+          name: Restore Homebrew cache
+          key: v0-homebrew-{{ arch }}
+      - run:
+          name: Install Homebrew dependencies
+          command: brew bundle --no-upgrade
+
+  save-homebrew-cache:
+    steps:
+      - run:
+          name: Prepare Homebrew cache for saving
+          command: |
+            # Make sure latest versions are installed
+            time brew bundle
+
+            # Remove all dependencies except those in the Brewfile
+            time brew bundle cleanup --force
+
+            brew info
+      - save_cache:
+          name: Save Homebrew cache
+          # See https://discuss.circleci.com/t/add-mechanism-to-update-existing-cache-key/9014/13
+          key: v0-homebrew-{{ arch }}-{{ .Revision }}
+          paths:
+            - /usr/local/Cellar
+
   install-rust:
     steps:
       - run:
@@ -191,8 +219,16 @@ commands:
             (cd consensus/enclave/trusted && time cargo fetch --locked)
 
   prepare-for-build:
+    parameters:
+      os:
+        type: enum
+        enum: ["linux", "macos", "windows"]
+        default: linux
     steps:
       - checkout
+      - when:
+          condition: { equal: [ << parameters.os >>, macos ] }
+          steps: [ restore-homebrew-cache ]
       - install-rust
       - restore-cargo-cache
       - install-ci-deps
@@ -411,7 +447,8 @@ jobs:
       RUSTFLAGS: -D warnings -C target-cpu=penryn
       CONSENSUS_ENCLAVE_CSS: /Users/distiller/project/sgx/css/src/valid.css
     steps:
-      - prepare-for-build
+      - prepare-for-build:
+          os: macos
       - run:
           name: Cargo check (SW/IAS dev)
           command: |
@@ -433,6 +470,9 @@ jobs:
           condition: { equal: [ << pipeline.git.branch >>, master ] }
           steps: [ save-cargo-cache, save-sccache-cache ]
       - post-build
+      - when:
+          condition: { equal: [ << pipeline.git.branch >>, master ] }
+          steps: [ save-homebrew-cache ]
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
             echo '[net]' >> ~/.cargo/config
             echo 'git-fetch-with-cli = true' >> ~/.cargo/config
             if [ -f ~/.gitconfig ]; then
-              sed -i 's/github/git-non-exist-hub/g' ~/.gitconfig # https://github.com/rust-lang/cargo/issues/3900
+              sed -i -e 's/github/git-non-exist-hub/g' ~/.gitconfig # https://github.com/rust-lang/cargo/issues/3900
             fi
 
   enable_sccache:

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ dist/
 Cargo.lock
 !/Cargo.lock
 
+# Homebrew bundle
+/Brewfile.lock.json
+
 # Python stuff
 __pycache__/
 mobilecoind/clients/python/blockchain_explorer/latest.tar.gz

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,4 @@
+# Build dependencies
+brew 'cmake'
+brew 'go'
+brew 'protobuf'


### PR DESCRIPTION
### Motivation

The TestNet-client is built for macOS as part of the release process. This means it should be under test to avoid unintentional regressions.

### In this PR
* Adds a CircleCI job to build the project on macOS

fixes #MC-1557

