### PR TITLE
wait for mobilecoind to start

### DIFF
--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -316,6 +316,11 @@ class Mobilecoind:
         self.process = subprocess.Popen(cmd, shell=True)
         print()
 
+        print('Waiting for watcher db to become available')
+        while not os.path.exists(os.path.join(self.watcher_db, 'data.mdb')):
+            print('Waiting for watcher db to become available')
+            time.sleep(1)
+
     def stop(self):
         if self.process:
             if self.process.poll() is None:


### PR DESCRIPTION
### Motivation

While attempting to fix some internal tools I tried using the watcher database too early. It takes mobilecoind a few seconds to get to the point it creates it. Since this logic is likely to repeat itself, I figured the correct place for waiting for it is right after it's started.

### In this PR
* A loop that waits until the watcher db has been created on disk.
