### PR TITLE
Sorted tx inputs

### DIFF
--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -66,6 +66,7 @@ enum ProposeTxResult {
     MembershipProofValidationError = 36;
     TxFeeError = 37;
     KeyError = 38;
+    UnsortedInputs = 39;
 }
 
 /// Response from TxPropose RPC call.

--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -60,6 +60,7 @@ impl From<TransactionValidationError> for ProposeTxResult {
             }
             TransactionValidationError::TxFeeError => Self::TxFeeError,
             TransactionValidationError::KeyError => Self::KeyError,
+            TransactionValidationError::UnsortedInputs => Self::UnsortedInputs,
         }
     }
 }
@@ -120,6 +121,7 @@ impl TryInto<TransactionValidationError> for ProposeTxResult {
             }
             Self::TxFeeError => Ok(TransactionValidationError::TxFeeError),
             Self::KeyError => Ok(TransactionValidationError::KeyError),
+            Self::UnsortedInputs => Ok(TransactionValidationError::UnsortedInputs),
         }
     }
 }

--- a/transaction/core/src/validation/error.rs
+++ b/transaction/core/src/validation/error.rs
@@ -75,6 +75,10 @@ pub enum TransactionValidationError {
     #[fail(display = "UnequalRingSizes")]
     UnequalRingSizes,
 
+    /// Inputs must be sorted by the public key of the first ring element of each input.
+    #[fail(display = "UnsortedInputs")]
+    UnsortedInputs,
+
     /// Key Images must be sorted.
     #[fail(display = "UnsortedKeyImages")]
     UnsortedKeyImages,

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -150,11 +150,12 @@ fn validate_ring_elements_are_sorted(tx_prefix: &TxPrefix) -> TransactionValidat
 
 /// Inputs must be sorted by the public key of the first ring element of each input.
 fn validate_inputs_are_sorted(tx_prefix: &TxPrefix) -> TransactionValidationResult<()> {
-    if !tx_prefix.inputs.windows(2).all(|w| {
+    let inputs_are_sorted = tx_prefix.inputs.windows(2).all(|w| {
         !w[0].ring.is_empty()
             && !w[1].ring.is_empty()
             && w[0].ring[0].public_key < w[1].ring[0].public_key
-    }) {
+    });
+    if !inputs_are_sorted {
         return Err(TransactionValidationError::UnsortedInputs);
     }
 

--- a/transaction/std/src/input_credentials.rs
+++ b/transaction/std/src/input_credentials.rs
@@ -45,7 +45,7 @@ impl InputCredentials {
     ) -> Result<Self, TxBuilderError> {
         debug_assert_eq!(ring.len(), membership_proofs.len());
 
-        if real_index > ring.len() {
+        if real_index > ring.len() || ring.is_empty() {
             return Err(TxBuilderError::InvalidRingSize);
         }
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -109,6 +109,12 @@ impl TransactionBuilder {
             }
         }
 
+        // Construct a list of sorted inputs.
+        // Inputs are sorted by the first ring element's public key. Note that each ring is also
+        // sorted.
+        self.input_credentials
+            .sort_by(|a, b| a.ring[0].public_key.cmp(&b.ring[0].public_key));
+
         let inputs: Vec<TxIn> = self
             .input_credentials
             .iter()
@@ -532,5 +538,21 @@ pub mod transaction_builder_tests {
         let mut expected_outputs = outputs.clone();
         expected_outputs.sort_by(|a, b| a.public_key.cmp(&b.public_key));
         assert_eq!(outputs, expected_outputs);
+    }
+
+    #[test]
+    // Transaction inputs should be sorted by the public key of the first ring element.
+    fn test_inputs_are_sorted() {
+        let mut rng: StdRng = SeedableRng::from_seed([92u8; 32]);
+        let sender = AccountKey::random(&mut rng);
+        let recipient = AccountKey::random(&mut rng);
+        let num_inputs = 3;
+        let num_outputs = 11;
+        let tx = get_transaction(num_inputs, num_outputs, &sender, &recipient, &mut rng).unwrap();
+
+        let inputs = tx.prefix.inputs;
+        let mut expected_inputs = inputs.clone();
+        expected_inputs.sort_by(|a, b| a.ring[0].public_key.cmp(&b.ring[0].public_key));
+        assert_eq!(inputs, expected_inputs);
     }
 }


### PR DESCRIPTION
Soundtrack of this PR: https://soundcloud.com/yaron-sobel/set-425

### Motivation

Enforcing transaction inputs to be sorted  prevents the ordering of inputs within a transaction from leaking information, for example, if a client always adds larger-valued inputs before smaller-valued inputs.

This fixes MC-1472 and MC-1473.

### In this PR
* `TransactionBuilder` changed to sort inputs when constructing the `Tx`.
* Enclave validation code changed to enforce this new requirement.
