### PR TITLE
Mobilecoind processed block

### DIFF
--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -141,8 +141,8 @@ impl TryFrom<&external::CompressedRistretto> for RistrettoPublic {
 }
 
 /// Convert CompressedRistrettoPublic --> external::CompressedRistretto
-impl From<CompressedRistrettoPublic> for external::CompressedRistretto {
-    fn from(other: CompressedRistrettoPublic) -> Self {
+impl From<&CompressedRistrettoPublic> for external::CompressedRistretto {
+    fn from(other: &CompressedRistrettoPublic) -> Self {
         let mut key = external::CompressedRistretto::new();
         key.set_data(other.as_bytes().to_vec());
         key

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -510,10 +510,17 @@ message GetTxStatusAsReceiverResponse {
 
 // Get the contents of a processed block.
 message GetProcessedBlockRequest {
-    uint64 block = 1;
+    // Monitor id to query data for.
+    bytes monitor_id = 1;
+
+    // Block number to query.
+    uint64 block = 2;
 }
 message GetProcessedBlockResponse {
+    // Processed tx output information that belongs to the requested monitor_id/block.
     repeated ProcessedTxOut tx_outs = 1;
+
+    // All key images in the requested block (not monitor_id-specific).
     repeated external.KeyImage spent_key_images = 2;
 }
 

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -46,6 +46,7 @@ service MobilecoindAPI {
     rpc GetBlock (GetBlockRequest) returns (GetBlockResponse) {}
     rpc GetTxStatusAsSender (GetTxStatusAsSenderRequest) returns (GetTxStatusAsSenderResponse) {}
     rpc GetTxStatusAsReceiver (GetTxStatusAsReceiverRequest) returns (GetTxStatusAsReceiverResponse) {}
+    rpc GetProcessedBlock (GetProcessedBlockRequest) returns (GetProcessedBlockResponse) {}
 
     // Convenience calls
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceResponse) {}
@@ -186,6 +187,23 @@ message MonitorStatus {
     string name = 6;
 }
 
+// Structure used to report tx outs received in a given processed block.
+message ProcessedTxOut {
+    // The monitor id that received the transaction.
+    bytes monitor_id = 1;
+
+    // The subaddress the transaction was sent to.
+    uint64 subaddress_index = 2;
+
+    // The public key of the received TxOut.
+    external.CompressedRistretto public_key = 3;
+
+    // The key image of the TxOut.
+    external.KeyImage key_image = 4;
+
+    // The value of the TxOut.
+    uint64 value = 5;
+}
 
 //*********************************
 //*
@@ -488,6 +506,15 @@ message GetTxStatusAsReceiverRequest {
 }
 message GetTxStatusAsReceiverResponse {
     TxStatus status = 1;
+}
+
+// Get the contents of a processed block.
+message GetProcessedBlockRequest {
+    uint64 block = 1;
+}
+message GetProcessedBlockResponse {
+    repeated ProcessedTxOut tx_outs = 1;
+    repeated external.KeyImage spent_key_images = 2;
 }
 
 //

--- a/mobilecoind/src/database.rs
+++ b/mobilecoind/src/database.rs
@@ -96,6 +96,8 @@ impl Database {
             self.utxo_store.remove_utxos(&mut db_txn, id, index)?;
         }
 
+        self.processed_block_store.remove(&mut db_txn, id)?;
+
         self.monitor_store.remove(&mut db_txn, id)?;
 
         db_txn.commit()?;

--- a/mobilecoind/src/database.rs
+++ b/mobilecoind/src/database.rs
@@ -251,7 +251,10 @@ impl Database {
         // Get monitor data to see if the monitor has synced this block.
         let monitor_data = self.monitor_store.get_data(&db_txn, monitor_id)?;
         if block_num < monitor_data.first_block {
-            return Err(Error::BlockIdTooSmall(block_num, monitor_data.first_block));
+            return Err(Error::BlockIndexTooSmall(
+                block_num,
+                monitor_data.first_block,
+            ));
         }
         if block_num >= monitor_data.next_block {
             return Err(Error::BlockNotYetProcessed(

--- a/mobilecoind/src/error.rs
+++ b/mobilecoind/src/error.rs
@@ -96,7 +96,7 @@ pub enum Error {
         display = "Block index {} is lower than the monitor's first block {}",
         _0, _1
     )]
-    BlockIdTooSmall(u64, u64),
+    BlockIndexTooSmall(u64, u64),
 
     #[fail(
         display = "Block index {} is equal or bigger than the monitor's next block {}",

--- a/mobilecoind/src/error.rs
+++ b/mobilecoind/src/error.rs
@@ -91,6 +91,18 @@ pub enum Error {
 
     #[fail(display = "The ledger does not contain enough tx outs for rings")]
     InsufficientTxOuts,
+
+    #[fail(
+        display = "Block index {} is lower than the monitor's first block {}",
+        _0, _1
+    )]
+    BlockIdTooSmall(u64, u64),
+
+    #[fail(
+        display = "Block index {} is equal or bigger than the monitor's next block {}",
+        _0, _1
+    )]
+    BlockNotYetProcessed(u64, u64),
 }
 
 impl From<RetryError<ConnectionError>> for Error {

--- a/mobilecoind/src/lib.rs
+++ b/mobilecoind/src/lib.rs
@@ -13,6 +13,7 @@ mod conversions;
 mod database_key;
 mod error;
 mod monitor_store;
+mod processed_block_store;
 mod subaddress_store;
 mod sync;
 mod utxo_store;

--- a/mobilecoind/src/processed_block_store.rs
+++ b/mobilecoind/src/processed_block_store.rs
@@ -203,3 +203,318 @@ impl ProcessedBlockStore {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        monitor_store::MonitorData,
+        test_utils::{get_test_databases, PER_RECIPIENT_AMOUNT},
+    };
+    use mc_account_keys::AccountKey;
+    use mc_common::{
+        logger::{test_with_logger, Logger},
+        HashSet,
+    };
+    use mc_crypto_keys::RistrettoPublic;
+    use mc_crypto_rand::{CryptoRng, RngCore};
+    use mc_ledger_db::{Ledger, LedgerDB};
+    use mc_transaction_core::{onetime_keys::recover_onetime_private_key, tx::TxOut};
+    use rand::{rngs::StdRng, SeedableRng};
+    use std::iter::FromIterator;
+    use tempdir::TempDir;
+
+    const TEST_SUBADDRESS: u64 = 10;
+
+    fn setup_test_processed_block_store(
+        mut rng: &mut (impl CryptoRng + RngCore),
+        logger: &Logger,
+    ) -> (LedgerDB, ProcessedBlockStore, AccountKey, Vec<UnspentTxOut>) {
+        let account_key = AccountKey::random(&mut rng);
+
+        // Set up a db with a known recipient, 3 random recipients and 10 blocks.
+        let (ledger_db, _mobilecoind_db) = get_test_databases(
+            3,
+            &vec![account_key.subaddress(TEST_SUBADDRESS)],
+            10,
+            logger.clone(),
+            &mut rng,
+        );
+
+        // Get all utxos belonging to the test account. This assumes knowledge about how the test
+        // ledger is constructed by the test utils.
+        let num_blocks = ledger_db.num_blocks().expect("failed getting num blocks");
+        let account_tx_outs: Vec<TxOut> = (0..num_blocks)
+            .map(|idx| {
+                let block_contents = ledger_db.get_block_contents(idx as u64).unwrap();
+                // We grab the 4th tx out in each block since the test ledger had 3 random
+                // recipients, followed by our known recipient.
+                // See the call to `get_testing_environment` at the beginning of the test.
+                block_contents.outputs[3].clone()
+            })
+            .collect();
+
+        let account_utxos: Vec<UnspentTxOut> = account_tx_outs
+            .iter()
+            .map(|tx_out| {
+                // Calculate the key image for this tx out.
+                let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
+                let onetime_private_key = recover_onetime_private_key(
+                    &tx_public_key,
+                    account_key.view_private_key(),
+                    &account_key.subaddress_spend_private(TEST_SUBADDRESS),
+                );
+                let key_image = KeyImage::from(&onetime_private_key);
+
+                // Craft the expected UnspentTxOut
+                UnspentTxOut {
+                    tx_out: tx_out.clone(),
+                    subaddress_index: TEST_SUBADDRESS,
+                    key_image,
+                    value: PER_RECIPIENT_AMOUNT,
+                    attempted_spend_height: 0,
+                    attempted_spend_tombstone: 0,
+                }
+            })
+            .collect();
+
+        // The instance to test.
+        let db_tmp =
+            TempDir::new("utxo_store_db").expect("Could not make tempdir for utxo store db");
+        let db_path = db_tmp
+            .path()
+            .to_str()
+            .expect("Could not get path as string");
+
+        let env = Arc::new(
+            Environment::new()
+                .set_max_dbs(10)
+                .set_map_size(10000000)
+                .open(db_path.as_ref())
+                .unwrap(),
+        );
+
+        let processed_block_store = ProcessedBlockStore::new(env, logger.clone()).unwrap();
+
+        // Return
+        (ledger_db, processed_block_store, account_key, account_utxos)
+    }
+
+    // ProcessedBlockStore basic functionality tests
+    #[test_with_logger]
+    fn test_processed_block_store(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
+        let (ledger_db, store, account, utxos) =
+            setup_test_processed_block_store(&mut rng, &logger);
+
+        let num_blocks = ledger_db
+            .num_blocks()
+            .expect("failed getting number of blocks in ledger");
+        assert_eq!(num_blocks, utxos.len() as u64);
+
+        // Create a monitor id for our account.
+        let monitor_data = MonitorData::new(
+            account.clone(),
+            0,  // first_subaddress
+            20, // num_subaddresses
+            0,  // first_block
+            "", // name
+        )
+        .expect("failed to create data");
+
+        let monitor_id = MonitorId::from(&monitor_data);
+
+        // Initially, we should have no data for any of our blocks.
+        {
+            let db_txn = store.env.begin_ro_txn().unwrap();
+            for block_index in 0..num_blocks + 10 {
+                let tx_outs = store
+                    .get_processed_block(&db_txn, &monitor_id, block_index)
+                    .expect("get_processed_block failed");
+                assert!(tx_outs.is_empty());
+            }
+        }
+
+        // Associate the first 3 utxos with the first block and the rest into the second block.
+        {
+            let mut db_txn = store.env.begin_rw_txn().unwrap();
+
+            // Add in two chunks
+            store
+                .block_processed(&mut db_txn, &monitor_id, 0, &utxos[..2])
+                .expect("block_processed failed");
+            store
+                .block_processed(&mut db_txn, &monitor_id, 0, &utxos[2..3])
+                .expect("block_processed failed");
+
+            store
+                .block_processed(&mut db_txn, &monitor_id, 1, &utxos[3..])
+                .expect("block_processed failed");
+
+            db_txn.commit().unwrap();
+        }
+
+        // Query the data to ensure it got properly stored.
+        {
+            let db_txn = store.env.begin_ro_txn().unwrap();
+
+            // First block
+            let processed_tx_outs = store
+                .get_processed_block(&db_txn, &monitor_id, 0)
+                .expect("get_processed_block failed");
+            assert_eq!(processed_tx_outs.len(), 3);
+
+            let expected_processed_tx_outs: HashSet<_> =
+                utxos.iter().take(3).map(ProcessedTxOut::from).collect();
+            assert_eq!(
+                expected_processed_tx_outs,
+                HashSet::from_iter(processed_tx_outs)
+            );
+
+            // Second block
+            let processed_tx_outs = store
+                .get_processed_block(&db_txn, &monitor_id, 1)
+                .expect("get_processed_block failed");
+            assert_eq!(processed_tx_outs.len(), utxos.len() - 3);
+
+            let expected_processed_tx_outs: HashSet<_> =
+                utxos.iter().skip(3).map(ProcessedTxOut::from).collect();
+            assert_eq!(
+                expected_processed_tx_outs,
+                HashSet::from_iter(processed_tx_outs)
+            );
+        }
+
+        // Querying with a different monitor id should return no results.
+        {
+            let monitor_data = MonitorData::new(
+                account.clone(),
+                30, // first_subaddress
+                20, // num_subaddresses
+                0,  // first_block
+                "", // name
+            )
+            .expect("failed to create data");
+
+            let monitor_id = MonitorId::from(&monitor_data);
+
+            let mut db_txn = store.env.begin_rw_txn().unwrap();
+
+            let processed_tx_outs = store
+                .get_processed_block(&db_txn, &monitor_id, 0)
+                .expect("get_processed_block failed");
+            assert!(processed_tx_outs.is_empty());
+
+            // Removing monitor id with no data should not result in an error.
+            store
+                .remove(&mut db_txn, &monitor_id)
+                .expect("remove failed");
+        }
+
+        // Remove the monitor id and ensure data has been removed
+        {
+            let mut db_txn = store.env.begin_rw_txn().unwrap();
+
+            let processed_tx_outs = store
+                .get_processed_block(&db_txn, &monitor_id, 0)
+                .expect("get_processed_block failed");
+            assert!(!processed_tx_outs.is_empty());
+
+            let processed_tx_outs = store
+                .get_processed_block(&db_txn, &monitor_id, 1)
+                .expect("get_processed_block failed");
+            assert!(!processed_tx_outs.is_empty());
+
+            store
+                .remove(&mut db_txn, &monitor_id)
+                .expect("remove failed");
+
+            let processed_tx_outs = store
+                .get_processed_block(&db_txn, &monitor_id, 0)
+                .expect("get_processed_block failed");
+            assert!(processed_tx_outs.is_empty());
+
+            let processed_tx_outs = store
+                .get_processed_block(&db_txn, &monitor_id, 1)
+                .expect("get_processed_block failed");
+            assert!(processed_tx_outs.is_empty());
+
+            db_txn.commit().unwrap();
+        }
+
+        // Re-add utxos and verify correct behavior.
+        {
+            let mut db_txn = store.env.begin_rw_txn().unwrap();
+
+            // Add in two chunks for the original monitor id and one chunk for a new monitor id.
+            store
+                .block_processed(&mut db_txn, &monitor_id, 0, &utxos[1..5])
+                .expect("block_processed failed");
+
+            store
+                .block_processed(&mut db_txn, &monitor_id, 1, &utxos[5..])
+                .expect("block_processed failed");
+
+            let monitor_data2 = MonitorData::new(
+                account.clone(),
+                30, // first_subaddress
+                20, // num_subaddresses
+                0,  // first_block
+                "", // name
+            )
+            .expect("failed to create data");
+
+            let monitor_id2 = MonitorId::from(&monitor_data2);
+
+            store
+                .block_processed(&mut db_txn, &monitor_id2, 0, &utxos[0..1])
+                .expect("block_processed failed");
+
+            // First block - original monitor id
+            let processed_tx_outs = store
+                .get_processed_block(&db_txn, &monitor_id, 0)
+                .expect("get_processed_block failed");
+            assert_eq!(processed_tx_outs.len(), 4);
+
+            let expected_processed_tx_outs: HashSet<_> = utxos
+                .iter()
+                .skip(1)
+                .take(4)
+                .map(ProcessedTxOut::from)
+                .collect();
+            assert_eq!(
+                expected_processed_tx_outs,
+                HashSet::from_iter(processed_tx_outs)
+            );
+
+            // First block - second monitor id
+            let processed_tx_outs = store
+                .get_processed_block(&db_txn, &monitor_id2, 0)
+                .expect("get_processed_block failed");
+            assert_eq!(processed_tx_outs.len(), 1);
+
+            assert_eq!(vec![ProcessedTxOut::from(&utxos[0])], processed_tx_outs);
+
+            // Second block - origianl monitor id
+            let processed_tx_outs = store
+                .get_processed_block(&db_txn, &monitor_id, 1)
+                .expect("get_processed_block failed");
+            assert_eq!(processed_tx_outs.len(), utxos.len() - 5);
+
+            let expected_processed_tx_outs: HashSet<_> =
+                utxos.iter().skip(5).map(ProcessedTxOut::from).collect();
+            assert_eq!(
+                expected_processed_tx_outs,
+                HashSet::from_iter(processed_tx_outs)
+            );
+
+            // Second block - second monitor id
+            let processed_tx_outs = store
+                .get_processed_block(&db_txn, &monitor_id2, 1)
+                .expect("get_processed_block failed");
+            assert!(processed_tx_outs.is_empty());
+
+            db_txn.commit().unwrap();
+        }
+    }
+}

--- a/mobilecoind/src/processed_block_store.rs
+++ b/mobilecoind/src/processed_block_store.rs
@@ -495,7 +495,7 @@ mod test {
 
             assert_eq!(vec![ProcessedTxOut::from(&utxos[0])], processed_tx_outs);
 
-            // Second block - origianl monitor id
+            // Second block - original monitor id
             let processed_tx_outs = store
                 .get_processed_block(&db_txn, &monitor_id, 1)
                 .expect("get_processed_block failed");

--- a/mobilecoind/src/processed_block_store.rs
+++ b/mobilecoind/src/processed_block_store.rs
@@ -1,0 +1,157 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! Database storage for data obtained by processing blocks.
+//! * Stores a map of (monitor id, block number) -> list of transactions that
+//!   appeared in the given block number and belong to a given monitor id.
+
+use crate::{error::Error, monitor_store::MonitorId, utxo_store::UnspentTxOut};
+use lmdb::{Database, DatabaseFlags, Environment, RwTransaction, WriteFlags};
+use mc_common::logger::Logger;
+use mc_crypto_keys::CompressedRistrettoPublic;
+use mc_transaction_core::ring_signature::KeyImage;
+use prost::Message;
+use std::{convert::TryFrom, sync::Arc};
+
+// LMDB Database Names
+pub const PROCESSED_BLOCK_KEY_TO_PROCESSED_TX_OUTS_DB_NAME: &str =
+    "mobilecoind_db:processed_block_store:processed_block_key_to_processed_tx_outs";
+
+/// Type used as the key in the databases managed by the processed block store.
+#[derive(Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct ProcessedBlockKey {
+    /// The monitor_id for which the data belongs to.
+    pub monitor_id: MonitorId,
+
+    /// The block index.
+    pub block_index: u64,
+}
+impl ProcessedBlockKey {
+    pub fn new(monitor_id: &MonitorId, block_index: u64) -> Self {
+        Self {
+            monitor_id: *monitor_id,
+            block_index,
+        }
+    }
+
+    // 40 bytes: 32 for MonitorId, 8 for block index.
+    pub fn to_bytes(&self) -> [u8; 40] {
+        let mut buf = [0u8; 40];
+        buf[0..32].copy_from_slice(self.monitor_id.as_bytes());
+        buf[32..40].copy_from_slice(&self.block_index.to_be_bytes());
+        buf
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.to_bytes().to_vec()
+    }
+}
+
+impl TryFrom<&[u8]> for ProcessedBlockKey {
+    type Error = Error;
+
+    fn try_from(src: &[u8]) -> Result<Self, Self::Error> {
+        if src.len() != 40 {
+            return Err(Error::InvalidArgument(
+                "src".to_string(),
+                "src length must be exactly 40".to_string(),
+            ));
+        }
+
+        let monitor_id = MonitorId::try_from(&src[0..32])?;
+
+        let mut index_bytes = [0u8; 8];
+        index_bytes.copy_from_slice(&src[32..40]);
+        let block_index = u64::from_be_bytes(index_bytes);
+
+        Ok(Self {
+            monitor_id,
+            block_index,
+        })
+    }
+}
+
+/// Type used as the stored data in the processed_block_id_to_processed_tx_outs database.
+/// Note that this is different than `mobilecoind_api::ProcessedTxOut`, as that one contains some
+/// extra data that can be derived upon construction.
+#[derive(Clone, Eq, Hash, PartialEq, Message)]
+pub struct ProcessedTxOut {
+    /// The subaddress index the tx out belongs to/
+    #[prost(uint64, tag = "1")]
+    pub subaddress_index: u64,
+
+    /// The public key of the TxOut.
+    #[prost(message, required, tag = "2")]
+    pub public_key: CompressedRistrettoPublic,
+
+    /// Key image of the TxOut.
+    #[prost(message, required, tag = "3")]
+    pub key_image: KeyImage,
+
+    /// Value of this TxOut.
+    #[prost(uint64, tag = "4")]
+    pub value: u64,
+}
+
+impl From<&UnspentTxOut> for ProcessedTxOut {
+    fn from(src: &UnspentTxOut) -> Self {
+        Self {
+            subaddress_index: src.subaddress_index,
+            public_key: src.tx_out.public_key,
+            key_image: src.key_image,
+            value: src.value,
+        }
+    }
+}
+
+/// the processed blocks database.
+#[derive(Clone)]
+pub struct ProcessedBlockStore {
+    /// LMDB Environment.
+    env: Arc<Environment>,
+
+    /// Mapping of ProcessedBlockKey -> [ProcessedTxOut].
+    processed_block_key_to_processed_tx_outs: Database,
+
+    /// Logger.
+    logger: Logger,
+}
+
+impl ProcessedBlockStore {
+    pub fn new(env: Arc<Environment>, logger: Logger) -> Result<Self, Error> {
+        let processed_block_key_to_processed_tx_outs = env.create_db(
+            Some(PROCESSED_BLOCK_KEY_TO_PROCESSED_TX_OUTS_DB_NAME),
+            DatabaseFlags::DUP_SORT,
+        )?;
+
+        Ok(Self {
+            env,
+            processed_block_key_to_processed_tx_outs,
+            logger,
+        })
+    }
+
+    /// Feed data processed from a given block.
+    pub fn block_processed<'env>(
+        &self,
+        db_txn: &mut RwTransaction<'env>,
+        monitor_id: &MonitorId,
+        block_index: u64,
+        discovered_utxos: &[UnspentTxOut],
+    ) -> Result<(), Error> {
+        let key = ProcessedBlockKey::new(monitor_id, block_index);
+        let key_bytes = key.to_vec();
+
+        for utxo in discovered_utxos.iter() {
+            let processed_tx_out = ProcessedTxOut::from(utxo);
+            let processed_tx_out_bytes = mc_util_serial::encode(&processed_tx_out);
+            db_txn.put(
+                self.processed_block_key_to_processed_tx_outs,
+                &key_bytes,
+                &processed_tx_out_bytes,
+                WriteFlags::empty(),
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -744,7 +744,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
 
                 let mut receiver_tx_receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
                 receiver_tx_receipt.set_recipient((&outlay.receiver).into());
-                receiver_tx_receipt.set_tx_public_key(tx_out.public_key.into());
+                receiver_tx_receipt.set_tx_public_key((&tx_out.public_key).into());
                 receiver_tx_receipt.set_tx_out_hash(tx_out.hash().to_vec());
                 receiver_tx_receipt.set_tombstone(tx_proposal.tx.prefix.tombstone_block);
 
@@ -1929,7 +1929,7 @@ mod test {
 
             let mut receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
             receipt.set_tx_public_key(mc_mobilecoind_api::external::CompressedRistretto::from(
-                tx_out.public_key,
+                &tx_out.public_key,
             ));
             receipt.set_tx_out_hash(hash.to_vec());
             receipt.set_tombstone(10);
@@ -1952,7 +1952,7 @@ mod test {
 
             let mut receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
             receipt.set_tx_public_key(mc_mobilecoind_api::external::CompressedRistretto::from(
-                tx_out.public_key,
+                &tx_out.public_key,
             ));
             receipt.set_tx_out_hash(hash.to_vec());
             receipt.set_tombstone(10);

--- a/mobilecoind/src/subaddress_store.rs
+++ b/mobilecoind/src/subaddress_store.rs
@@ -45,7 +45,7 @@ impl SubaddressId {
     pub fn to_bytes(&self) -> [u8; 40] {
         let mut buf = [0u8; 40];
         buf[0..32].copy_from_slice(self.monitor_id.as_bytes());
-        buf[32..40].copy_from_slice(&self.index.to_le_bytes());
+        buf[32..40].copy_from_slice(&self.index.to_be_bytes());
         buf
     }
 
@@ -69,7 +69,7 @@ impl TryFrom<&[u8]> for SubaddressId {
 
         let mut index_bytes = [0u8; 8];
         index_bytes.copy_from_slice(&src[32..40]);
-        let index = u64::from_le_bytes(index_bytes);
+        let index = u64::from_be_bytes(index_bytes);
 
         Ok(Self { monitor_id, index })
     }

--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -85,10 +85,7 @@ impl WatcherDB {
                 .open(path.as_ref())?,
         );
 
-        env.create_db(
-            Some(BLOCK_SIGNATURES_DB_NAME),
-            DatabaseFlags::DUP_SORT | DatabaseFlags::DUP_FIXED,
-        )?;
+        env.create_db(Some(BLOCK_SIGNATURES_DB_NAME), DatabaseFlags::DUP_SORT)?;
         env.create_db(Some(LAST_SYNCED_DB_NAME), DatabaseFlags::empty())?;
 
         Ok(())


### PR DESCRIPTION
### Motivation

To ease potential integrations the need for an API that exposes view-scanned transactions on a per-block was brought up. This PR adds an API endpoint and associated plumbing to `mobilecoind` to support that.

### In this PR
* A new `GetProcessedBlock` API endpoint for `mobilecoind` and the associated `ProcessedBlockStore` that stores the backing data.

### Future Work
* Add this to `mobilecoind-json`.

