### PR TITLE
add processed block endpoint to mobilecoind-json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3537,7 +3537,6 @@ dependencies = [
  "mc-api",
  "mc-common",
  "mc-mobilecoind-api",
- "mc-util-grpc",
  "protobuf",
  "rocket",
  "rocket_contrib",
@@ -4332,12 +4331,12 @@ checksum = "5510dbde48c4c37bf69123b1f636b6dd5f8dffe1f4e358af03c46a4947dca219"
 
 [[package]]
 name = "rocket"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e20afbad214b001cabbe31dd270b48b3be980a7153ee2ed8392e241f856d651b"
+checksum = "6130967b369cfb8411b0b73e96fcba1229c32a9cc6f295d144f879bfced13c6e"
 dependencies = [
  "atty",
- "base64 0.10.1",
+ "base64 0.12.1",
  "log 0.4.8",
  "memchr",
  "num_cpus",
@@ -4353,9 +4352,9 @@ dependencies = [
 
 [[package]]
 name = "rocket_codegen"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2108b35e2c3a35759d3f16cc3002ece05523191d884d3ad6523693fd43324dde"
+checksum = "cb852e6da168fb948a8f2b798ba2e2f0e4fc860eae0efa9cf2bf0f5466bb0425"
 dependencies = [
  "devise",
  "glob 0.3.0",
@@ -4368,9 +4367,9 @@ dependencies = [
 
 [[package]]
 name = "rocket_contrib"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10e7471279bc2d4a21b6fddd9589016bb119e6fbb547b216dd54ef237f28341"
+checksum = "e3946ca815127041d8f64455561031d058c22ae1b135251502c5ea523cf9e14b"
 dependencies = [
  "log 0.4.8",
  "notify",

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -19,6 +19,6 @@ structopt = "0.3"
 protobuf = "2.12"
 
 [build-dependencies]
-# Even this is unused, it needs to be here otherwise Cargo brings in some weird mixture of packages/features that refuses to compile.
+# Even though this is unused, it needs to be here otherwise Cargo brings in some weird mixture of packages/features that refuses to compile.
 # Go figure ¯\_(ツ)_/¯
 serde = { version = "1", default-features = false, features = ["alloc", "derive"] }

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -5,15 +5,20 @@ authors = ["MobileCoin"]
 edition = "2018"
 
 [dependencies]
-grpcio = "0.5.1"
-rocket = { version = "0.4.4", default-features = false }
-rocket_contrib = { version = "0.4.4", default-features = false, features = ["json"] }
-hex = "0.4"
 mc-api = { path = "../api" }
 mc-common = { path = "../common", features = ["loggers"] }
-mc-util-grpc = { path = "../util/grpc" }
 mc-mobilecoind-api = { path = "../mobilecoind/api" }
-protobuf = "2.12"
+
+grpcio = "0.5.1"
+hex = "0.4"
+rocket = { version = "0.4.5", default-features = false }
+rocket_contrib = { version = "0.4.5", default-features = false, features = ["json"] }
 serde = "1.0"
 serde_derive = "1.0"
 structopt = "0.3"
+protobuf = "2.12"
+
+[build-dependencies]
+# Even this is unused, it needs to be here otherwise Cargo brings in some weird mixture of packages/features that refuses to compile.
+# Go figure ¯\_(ツ)_/¯
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }


### PR DESCRIPTION
### Motivation

* `mobilecoind-json` exposes a bunch of the `mobilecoind` API as a JSON API over HTTP. #300 added a new and useful API call that we'd like to expose as well.

### In this PR
* The new `/processed-block/` endpoint.
* Cleanup of `mobilecoind-json` dependencies so that it could be built without caring about an enclave (since there's no need for it to care).
