### PR TITLE
mobilecoind ProcessedTxOut direction field

### DIFF
--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -519,9 +519,6 @@ message GetProcessedBlockRequest {
 message GetProcessedBlockResponse {
     // Processed tx output information that belongs to the requested monitor_id/block.
     repeated ProcessedTxOut tx_outs = 1;
-
-    // All key images in the requested block (not monitor_id-specific).
-    repeated external.KeyImage spent_key_images = 2;
 }
 
 //

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -187,6 +187,21 @@ message MonitorStatus {
     string name = 6;
 }
 
+// Enum used to indicate whetehr a ProcessedTxOut is a sent one or a received one.
+enum ProcessedTxOutDirection {
+    // This should never happen, but is available here as an option to catch uninitialized data.
+    // The name "Unknown" cannot be used because, quoting the protobuf compiler:
+    // Note that enum values use C++ scoping rules, meaning that enum values are siblings of their type, not children of it.  Therefore, "Unknown" must be unique within "mobilecoind_api", not just within "ProcessedTxOutDirection".
+    Invalid = 0;
+
+    // The ProcessedTxOut has been received at the block queried for.
+    Received = 1;
+
+    // The ProcessedTxOut has been spent at the block queried for.
+    Spent = 2;
+}
+
+
 // Structure used to report tx outs received in a given processed block.
 message ProcessedTxOut {
     // The monitor id that received the transaction.
@@ -203,6 +218,9 @@ message ProcessedTxOut {
 
     // The value of the TxOut.
     uint64 value = 5;
+
+    // Whether this ProcessedTxOut was received at this block or spent at this block.
+    ProcessedTxOutDirection direction = 6;
 }
 
 //*********************************

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -187,7 +187,7 @@ message MonitorStatus {
     string name = 6;
 }
 
-// Enum used to indicate whetehr a ProcessedTxOut is a sent one or a received one.
+// Enum used to indicate whether a ProcessedTxOut is a sent one or a received one.
 enum ProcessedTxOutDirection {
     // This should never happen, but is available here as an option to catch uninitialized data.
     // The name "Unknown" cannot be used because, quoting the protobuf compiler:

--- a/mobilecoind/src/database.rs
+++ b/mobilecoind/src/database.rs
@@ -195,7 +195,7 @@ impl Database {
         }
 
         // Remove spent utxos
-        let removed_key_images = self.utxo_store.remove_utxos_by_key_images(
+        let removed_utxos = self.utxo_store.remove_utxos_by_key_images(
             &mut db_txn,
             monitor_id,
             spent_key_images,
@@ -218,12 +218,12 @@ impl Database {
         db_txn.commit()?;
 
         // Success.
-        if discovered_utxos.is_empty() && removed_key_images.is_empty() {
+        if discovered_utxos.is_empty() && removed_utxos.is_empty() {
             log::debug!(
                 self.logger,
                 "Processed {} utxos and {} key images in block {} for monitor id {}",
                 discovered_utxos.len(),
-                removed_key_images.len(),
+                removed_utxos.len(),
                 block_num,
                 monitor_id
             )
@@ -232,7 +232,7 @@ impl Database {
                 self.logger,
                 "Processed {} utxos and {} key images in block {} for monitor id {}",
                 discovered_utxos.len(),
-                removed_key_images.len(),
+                removed_utxos.len(),
                 block_num,
                 monitor_id
             )

--- a/mobilecoind/src/database.rs
+++ b/mobilecoind/src/database.rs
@@ -212,6 +212,7 @@ impl Database {
             monitor_id,
             block_num,
             discovered_utxos,
+            &removed_utxos,
         )?;
 
         // Commit.

--- a/mobilecoind/src/processed_block_store.rs
+++ b/mobilecoind/src/processed_block_store.rs
@@ -227,7 +227,6 @@ impl ProcessedBlockStore {
         for utxo in spent_utxos.iter() {
             let processed_tx_out = ProcessedTxOut::from_spent_utxo(utxo);
             let processed_tx_out_bytes = mc_util_serial::encode(&processed_tx_out);
-            println!("store {:?}", utxo.key_image);
             db_txn.put(
                 self.processed_block_key_to_processed_tx_outs,
                 &key_bytes,

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -30,7 +30,7 @@ use mc_transaction_std::identity::RootIdentity;
 use mc_util_b58_payloads::payloads::{AddressRequestPayload, RequestPayload, TransferPayload};
 use mc_util_grpc::{rpc_internal_error, rpc_logger, send_result, BuildInfoService};
 use mc_watcher::watcher_db::WatcherDB;
-use protobuf::RepeatedField;
+use protobuf::{ProtobufEnum, RepeatedField};
 use std::{
     convert::TryFrom,
     sync::{Arc, Mutex},
@@ -1080,6 +1080,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                 dst.set_public_key((&src.public_key).into());
                 dst.set_key_image((&src.key_image).into());
                 dst.set_value(src.value);
+                dst.set_direction(
+                    mc_mobilecoind_api::ProcessedTxOutDirection::from_i32(src.direction)
+                        .unwrap_or(mc_mobilecoind_api::ProcessedTxOutDirection::Invalid),
+                );
                 dst
             })
             .collect();
@@ -2092,6 +2096,10 @@ mod test {
             );
             assert_eq!(tx_out.get_key_image(), &(&expected_utxo.key_image).into());
             assert_eq!(tx_out.value, expected_utxo.value);
+            assert_eq!(
+                tx_out.get_direction(),
+                mc_mobilecoind_api::ProcessedTxOutDirection::Received,
+            );
         }
 
         // Query a block that will never get processed since its before the monitor's first block.

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2006,7 +2006,7 @@ mod test {
 
         let account_key = AccountKey::random(&mut rng);
         // Note: we skip the first block to test what happens when we try and query a block that will never get processed.
-        let data = MonitorData::new(
+        let monitor_data = MonitorData::new(
             account_key.clone(),
             0,  // first_subaddress
             20, // num_subaddresses
@@ -2016,7 +2016,7 @@ mod test {
         .unwrap();
 
         // 1 known recipient, 3 random recipients and no monitors.
-        let (ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
+        let (mut ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
             get_testing_environment(
                 3,
                 &vec![account_key.default_subaddress()],
@@ -2026,7 +2026,7 @@ mod test {
             );
 
         // Insert into database.
-        let monitor_id = mobilecoind_db.add_monitor(&data).unwrap();
+        let monitor_id = mobilecoind_db.add_monitor(&monitor_data).unwrap();
 
         // Allow the new monitor to process the ledger.
         wait_for_monitors(&mobilecoind_db, &ledger_db, &logger);
@@ -2102,6 +2102,67 @@ mod test {
             );
         }
 
+        // Add a block with a key images that spend the first two utxos and see that we get the
+        // data we expect.
+        {
+            let recipient = AccountKey::random(&mut rng).default_subaddress();
+            add_block_to_ledger_db(
+                &mut ledger_db,
+                &[recipient],
+                &[
+                    expected_utxos[monitor_data.first_block as usize].key_image,
+                    expected_utxos[monitor_data.first_block as usize + 1].key_image,
+                ],
+                &mut rng,
+            );
+
+            wait_for_monitors(&mobilecoind_db, &ledger_db, &logger);
+
+            let mut request = mc_mobilecoind_api::GetProcessedBlockRequest::new();
+            request.set_monitor_id(monitor_id.to_vec());
+            request.set_block(num_blocks);
+
+            let response = client
+                .get_processed_block(&request)
+                .expect("failed to get processed block");
+
+            let tx_outs = response.get_tx_outs();
+            assert_eq!(tx_outs.len(), 2);
+
+            let expected_utxos_by_key_image = HashMap::from_iter(
+                expected_utxos
+                    .iter()
+                    .skip(monitor_data.first_block as usize)
+                    .take(2)
+                    .map(|utxo| (utxo.key_image, utxo.clone())),
+            );
+
+            for tx_out in tx_outs.iter() {
+                let expected_utxo = expected_utxos_by_key_image
+                    .get(
+                        &KeyImage::try_from(tx_out.get_key_image().get_data())
+                            .expect("failed constructing key image"),
+                    )
+                    .expect("failed getting expected utxo");
+
+                assert_eq!(tx_out.get_monitor_id().to_vec(), monitor_id.to_vec());
+                assert_eq!(
+                    tx_out.get_subaddress_index(),
+                    expected_utxo.subaddress_index
+                );
+                assert_eq!(
+                    tx_out.get_public_key(),
+                    &(&expected_utxo.tx_out.public_key).into(),
+                );
+                assert_eq!(tx_out.get_key_image(), &(&expected_utxo.key_image).into());
+                assert_eq!(tx_out.value, expected_utxo.value);
+                assert_eq!(
+                    tx_out.get_direction(),
+                    mc_mobilecoind_api::ProcessedTxOutDirection::Spent,
+                );
+            }
+        }
+
         // Query a block that will never get processed since its before the monitor's first block.
         let mut request = mc_mobilecoind_api::GetProcessedBlockRequest::new();
         request.set_monitor_id(monitor_id.to_vec());
@@ -2112,7 +2173,7 @@ mod test {
         // Query a block that hasn't been processed yet.
         let mut request = mc_mobilecoind_api::GetProcessedBlockRequest::new();
         request.set_monitor_id(monitor_id.to_vec());
-        request.set_block(num_blocks);
+        request.set_block(num_blocks + 1);
 
         assert!(client.get_processed_block(&request).is_err());
 


### PR DESCRIPTION
### Motivation

We received a request to have mobilecoind support reporting of both the received transactions per block (which it already did) as well as ones that were successfully spent. This PR addresses that request.

### In this PR
* Adding a new `direction` field to `ProcessedTxOut`, indicating whether a given entry has been received at the queried block or confirmed spent (via key image matching).
* Update the `mobilecoind-json` utility to support the new API.
