### PR TITLE
Remove redundant filtering and validation from Node

### DIFF
--- a/consensus/scp/play/src/main.rs
+++ b/consensus/scp/play/src/main.rs
@@ -121,7 +121,7 @@ fn main() {
                 cur_slot_index = Some(slot_index);
 
                 if let Some(out_msg) = scp_node
-                    .nominate(slot_index, values)
+                    .propose_values(slot_index, values)
                     .expect("scp nominate failed")
                 {
                     sent_msgs.push_back(out_msg);

--- a/consensus/scp/src/node.rs
+++ b/consensus/scp/src/node.rs
@@ -185,21 +185,8 @@ impl<V: Value, ValidationError: Display> ScpNode<V> for Node<V, ValidationError>
             return Ok(None);
         }
 
-        let valid_values: BTreeSet<V> = values
-            .into_iter()
-            .filter(|value| (self.validity_fn)(&value).is_ok())
-            .collect();
-
-        if valid_values.is_empty() {
-            log::error!(
-                self.logger,
-                "nominate() called with only invalid values. Ignoring."
-            );
-            return Ok(None);
-        }
-
         let slot = self.get_or_create_pending_slot(slot_index);
-        let outbound = slot.propose_values(&valid_values)?;
+        let outbound = slot.propose_values(&values)?;
 
         match &outbound {
             None => Ok(None),

--- a/consensus/scp/src/node.rs
+++ b/consensus/scp/src/node.rs
@@ -174,7 +174,7 @@ impl<V: Value, ValidationError: Display> ScpNode<V> for Node<V, ValidationError>
         self.Q.clone()
     }
 
-    /// Submit a list of values of nomination.
+    /// Propose values for this node to nominate.
     fn propose_values(
         &mut self,
         slot_index: SlotIndex,

--- a/consensus/scp/src/node.rs
+++ b/consensus/scp/src/node.rs
@@ -138,8 +138,8 @@ pub trait ScpNode<V: Value>: Send {
     /// Get local node quorum set.
     fn quorum_set(&self) -> QuorumSet;
 
-    /// Submit a list of values of nomination.
-    fn nominate(
+    /// Propose values for this node to nominate.
+    fn propose_values(
         &mut self,
         slot_index: SlotIndex,
         values: BTreeSet<V>,
@@ -175,7 +175,7 @@ impl<V: Value, ValidationError: Display> ScpNode<V> for Node<V, ValidationError>
     }
 
     /// Submit a list of values of nomination.
-    fn nominate(
+    fn propose_values(
         &mut self,
         slot_index: SlotIndex,
         values: BTreeSet<V>,
@@ -336,7 +336,7 @@ mod tests {
         let slot_index = 1;
         let values = vec![1000, 2000];
         let msg = node2
-            .nominate(slot_index, BTreeSet::from_iter(values.clone()))
+            .propose_values(slot_index, BTreeSet::from_iter(values.clone()))
             .expect("error handling msg")
             .expect("no msg?");
 

--- a/consensus/scp/src/scp_log.rs
+++ b/consensus/scp/src/scp_log.rs
@@ -143,14 +143,14 @@ impl<V: Value, N: ScpNode<V>> ScpNode<V> for LoggingScpNode<V, N> {
         self.node.quorum_set()
     }
 
-    fn nominate(
+    fn propose_values(
         &mut self,
         slot_index: SlotIndex,
         values: BTreeSet<V>,
     ) -> Result<Option<Msg<V>>, String> {
         self.write(LoggedMsg::Nominate(slot_index, values.clone()))?;
 
-        let out_msg = self.node.nominate(slot_index, values)?;
+        let out_msg = self.node.propose_values(slot_index, values)?;
 
         if let Some(ref msg) = out_msg {
             self.write(LoggedMsg::OutgoingMsg(msg.clone()))?;

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -327,21 +327,20 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
             return Err("Message is not for the current slot.".to_string());
         }
 
+        // Ignore the message if it not higher than a previous message from the same peer.
+        if let Some(existing_msg) = self.M.get(&msg.sender_id) {
+            if msg.topic <= existing_msg.topic {
+                return Ok(self.out_msg());
+            }
+        }
+
+        // TODO: Reject messages with incorrectly ordered values.
         // Reject malformed messages.
         msg.validate()?;
 
         // Reject messages with invalid values.
         for value in msg.values() {
             self.is_valid(&value)?;
-        }
-
-        // TODO: Reject messages with incorrectly ordered values.
-
-        // Ignore the message if it not higher than a previous message from the same peer.
-        if let Some(existing_msg) = self.M.get(&msg.sender_id) {
-            if msg.topic <= existing_msg.topic {
-                return Ok(self.out_msg());
-            }
         }
 
         self.M.insert(msg.sender_id.clone(), msg.clone());

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -303,12 +303,14 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
             return Ok(self.out_msg());
         }
 
-        // Reject invalid values.
-        for value in values {
-            self.is_valid(value)?;
-        }
+        // Omit any invalid values.
+        let valid_values: Vec<V> = values
+            .iter()
+            .filter(|value| self.is_valid(value).is_ok())
+            .cloned()
+            .collect();
 
-        self.W.extend(values.iter().cloned());
+        self.W.extend(valid_values.into_iter());
         self.do_nominate_phase();
         self.do_ballot_protocol();
         Ok(self.out_msg())

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -353,7 +353,10 @@ impl SCPNode {
                                 thread_local_node
                                     .lock()
                                     .expect("lock failed on node nominating value")
-                                    .nominate(current_slot as SlotIndex, BTreeSet::from_iter(vals))
+                                    .propose_values(
+                                        current_slot as SlotIndex,
+                                        BTreeSet::from_iter(vals),
+                                    )
                                     .expect("node.nominate() failed")
                             };
 

--- a/consensus/service/src/byzantine_ledger.rs
+++ b/consensus/service/src/byzantine_ledger.rs
@@ -632,7 +632,7 @@ impl<
 
         let outgoing_msg = self
             .scp
-            .nominate(
+            .propose_values(
                 self.cur_slot,
                 BTreeSet::from_iter(
                     self.pending_values


### PR DESCRIPTION
Soundtrack of this PR: [Paid](https://www.youtube.com/watch?v=Df4vDfYxTRk)

### Motivation

Previously, Node and Slot both validated nominated values and filtered out stale or redundant incoming messages, which is confusing and maybe inefficient. This PR makes Slot primarily responsible for "doing the right thing" with proposed values and incoming messages.

This has been slam tested, and seems to have identical performance.