### PR TITLE
Watcherdb configured URL storage

### DIFF
--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -10,7 +10,7 @@ use mc_ledger_sync::{LedgerSyncServiceThread, PollingNetworkState, ReqwestTransa
 use mc_mobilecoind::{
     config::Config, database::Database, payments::TransactionsManager, service::Service,
 };
-use mc_watcher::{watcher::WatcherSyncThread, watcher_db::create_or_open_watcher_db};
+use mc_watcher::{watcher::WatcherSyncThread, watcher_db::create_or_open_rw_watcher_db};
 
 use std::{
     convert::TryFrom,
@@ -65,7 +65,7 @@ fn main() {
                     .expect("Failed creating ReqwestTransactionsFetcher");
 
             log::info!(logger, "Opening watcher db at {:?}.", watcher_db_path);
-            let watcher_db = create_or_open_watcher_db(
+            let watcher_db = create_or_open_rw_watcher_db(
                 watcher_db_path,
                 &watcher_transactions_fetcher.source_urls,
                 logger.clone(),

--- a/watcher/src/bin/main.rs
+++ b/watcher/src/bin/main.rs
@@ -6,7 +6,9 @@
 //! This is a test utility for the watcher, to sync block signatures and stop once all
 //! blocks are synced.
 
-use mc_watcher::{config::WatcherConfig, watcher::Watcher, watcher_db::create_or_open_watcher_db};
+use mc_watcher::{
+    config::WatcherConfig, watcher::Watcher, watcher_db::create_or_open_rw_watcher_db,
+};
 
 use mc_common::logger::{create_app_logger, o};
 use mc_ledger_sync::ReqwestTransactionsFetcher;
@@ -22,7 +24,7 @@ fn main() {
         ReqwestTransactionsFetcher::new(config.tx_source_urls.clone(), logger.clone())
             .expect("Failed creating ReqwestTransactionsFetcher");
 
-    let watcher_db = create_or_open_watcher_db(
+    let watcher_db = create_or_open_rw_watcher_db(
         config.watcher_db,
         &transactions_fetcher.source_urls,
         logger.clone(),

--- a/watcher/src/error.rs
+++ b/watcher/src/error.rs
@@ -47,6 +47,9 @@ pub enum WatcherDBError {
 
     #[fail(display = "Error managing IO")]
     IO,
+
+    #[fail(display = "Database was opened in read-only mode")]
+    ReadOnly,
 }
 
 impl From<lmdb::Error> for WatcherDBError {

--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -238,12 +238,12 @@ impl WatcherDB {
 
     /// Get the highest block that all currently-configured urls have synced.
     /// Note: In the case where one watched consensus validator dies and is no longer
-    ///       reporting blocks to S3, this will cause the highest_synced_block to
+    ///       reporting blocks to S3, this will cause the highest_common_block to
     ///       always remain at the lowest common denominator, so in the case where the
-    ///       the highest_synced_block is being used to determine if the watcher is
+    ///       the highest_common_block is being used to determine if the watcher is
     ///       behind, the watcher will need to be restarted with the dead node removed
     ///       from the set of watched URLs.
-    pub fn highest_synced_block(&self) -> Result<u64, WatcherDBError> {
+    pub fn highest_common_block(&self) -> Result<u64, WatcherDBError> {
         let db_txn = self.env.begin_ro_txn()?;
 
         let last_synced_map = self.get_url_to_last_synced(&db_txn)?;
@@ -461,7 +461,7 @@ mod test {
                 .add_block_signature(&urls[1], 1, signed_block_b1, filename1)
                 .unwrap();
 
-            assert_eq!(watcher_db.highest_synced_block().unwrap(), 1);
+            assert_eq!(watcher_db.highest_common_block().unwrap(), 1);
 
             let filename2 = String::from("00/02");
 
@@ -471,7 +471,7 @@ mod test {
                 .add_block_signature(&urls[0], 2, signed_block_a2, filename2.clone())
                 .unwrap();
 
-            assert_eq!(watcher_db.highest_synced_block().unwrap(), 1);
+            assert_eq!(watcher_db.highest_common_block().unwrap(), 1);
 
             let signed_block_b2 =
                 BlockSignature::from_block_and_keypair(&blocks[2].0, &signing_key_b).unwrap();
@@ -479,7 +479,7 @@ mod test {
                 .add_block_signature(&urls[1], 2, signed_block_b2, filename2)
                 .unwrap();
 
-            assert_eq!(watcher_db.highest_synced_block().unwrap(), 2);
+            assert_eq!(watcher_db.highest_common_block().unwrap(), 2);
         });
     }
 


### PR DESCRIPTION
### Motivation

* The functionality of the watcher db is tightly coupled with the list of URLs being polled by a given `mobilecoind` instance (or standalone `watcher` instance). Code that reads data from the watcher database needs to be aware which URLs are being polled, so that it can only take data from them into account. This is particularly important for some timestamp code such as the work done in #304 

### In this PR
* Add a configuration database to `WatcherDB` that stores the list of "active" URLs. This is updated when the watcher database is opened.
* The watcher database can now be opened either in read-only mode (used by processes needed read-only access to watched data), or in read-write mode (when it is used to update the data, such as from `mobilecoind`). When opened in rw mode, the list of URLs is passed to it and is stored in the DB.
* The API calls exposed by `WatcherDB` no longer receive the list of URLs since that is stored in the DB.
