### PR TITLE
Zeroize some select secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3056,6 +3056,7 @@ dependencies = [
  "subtle 2.2.3",
  "tempdir",
  "time",
+ "zeroize 1.1.0",
 ]
 
 [[package]]
@@ -3094,6 +3095,7 @@ dependencies = [
  "rand_core 0.5.1",
  "serde",
  "yaml-rust",
+ "zeroize 1.1.0",
 ]
 
 [[package]]

--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -36,6 +36,7 @@ use blake2::{Blake2b, Digest};
 use curve25519_dalek::scalar::Scalar;
 use prost::Message;
 use rand_core::{CryptoRng, RngCore};
+use zeroize::Zeroize;
 
 /// An account's "default address" is its zero^th subaddress.
 pub const DEFAULT_SUBADDRESS_INDEX: u64 = 0;
@@ -173,7 +174,8 @@ impl PublicAddress {
 /// Complete AccountKey, containing the pair of secret keys, which can be used
 /// for spending, and optionally some fog-related info,
 /// can be used for spending. This should only ever be present in client code.
-#[derive(Clone, Message)]
+#[derive(Clone, Message, Zeroize)]
+#[zeroize(drop)]
 pub struct AccountKey {
     /// Private key 'a' used for view-key matching.
     #[prost(message, required, tag = "1")]

--- a/account-keys/src/identity.rs
+++ b/account-keys/src/identity.rs
@@ -32,6 +32,7 @@ use zeroize::Zeroize;
 
 /// A secret value used as input key material to derive private keys.
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash, Zeroize)]
+#[zeroize(drop)]
 pub struct RootEntropy {
     /// 32 bytes of input key material.
     /// Should be e.g. RDRAND, /dev/random/, or from properly seeded CSPRNG.

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -1075,6 +1075,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 /// A Ristretto-format private scalar
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Zeroize)]
 pub struct RistrettoPrivate(pub(crate) Scalar);
 
 impl AsRef<[u8; 32]> for RistrettoPrivate {
@@ -133,13 +133,9 @@ impl KexPrivate for RistrettoPrivate {
 
 /// A private ristretto key which is ephemeral, should never be copied,
 /// and should be zeroized
+#[derive(Zeroize)]
+#[zeroize(drop)]
 pub struct RistrettoEphemeralPrivate(Scalar);
-
-impl Drop for RistrettoEphemeralPrivate {
-    fn drop(&mut self) {
-        self.0.zeroize();
-    }
-}
 
 impl PrivateKey for RistrettoEphemeralPrivate {
     type Public = RistrettoPublic;

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -25,6 +25,7 @@ rand_core = { version = "0.5", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 sha2 = { version = "0.8", default-features = false }
 subtle = { version = "2.2", default-features = false, features = ["i128"] }
+zeroize = { version = "1", default-features = false }
 
 # MobileCoin dependencies
 mc-account-keys = { path = "../../account-keys" }

--- a/transaction/core/src/ring_signature/curve_scalar.rs
+++ b/transaction/core/src/ring_signature/curve_scalar.rs
@@ -16,8 +16,9 @@ use mc_util_repr_bytes::{
 };
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
-#[derive(Copy, Clone, Default, Eq, Serialize, Deserialize, Digestible)]
+#[derive(Copy, Clone, Default, Eq, Serialize, Deserialize, Digestible, Zeroize)]
 pub struct CurveScalar {
     pub scalar: Scalar,
 }

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -13,6 +13,7 @@ rand_core = { version = "0.5", default-features = false }
 blake2 = { version = "0.8.1", default-features = false, features = ["simd"] }
 hkdf = { version = "0.8.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+zeroize = "1"
 
 # MobileCoin dependencies
 mc-account-keys = { path = "../../account-keys" }

--- a/transaction/std/src/input_credentials.rs
+++ b/transaction/std/src/input_credentials.rs
@@ -88,7 +88,6 @@ impl InputCredentials {
 
 impl Zeroize for InputCredentials {
     fn zeroize(&mut self) {
-        self.real_index.zeroize();
         self.onetime_private_key.zeroize();
         self.view_private_key.zeroize();
     }

--- a/transaction/std/src/input_credentials.rs
+++ b/transaction/std/src/input_credentials.rs
@@ -4,6 +4,7 @@ use crate::TxBuilderError;
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use mc_transaction_core::tx::{TxOut, TxOutMembershipProof};
 use std::convert::TryFrom;
+use zeroize::Zeroize;
 
 /// Credentials required to construct a ring signature for an input.
 #[derive(Clone, Debug)]
@@ -82,5 +83,19 @@ impl InputCredentials {
             real_output_public_key,
             view_private_key,
         })
+    }
+}
+
+impl Zeroize for InputCredentials {
+    fn zeroize(&mut self) {
+        self.real_index.zeroize();
+        self.onetime_private_key.zeroize();
+        self.view_private_key.zeroize();
+    }
+}
+
+impl Drop for InputCredentials {
+    fn drop(&mut self) {
+        self.zeroize();
     }
 }


### PR DESCRIPTION
### Motivation

* In order to reduce the risk of potential secrets leakage, it is a good idea to zero the memory they are stored in when they are no longer needed.

### In this PR
* Changes to signature generation code, transaction builder, account identity and root entropy that result in the sensitive parts being automatically zeroed when they go out of scope.
