### PR TITLE
Watcher: u64::MAX is also OutOfBounds

### DIFF
--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -226,7 +226,7 @@ impl WatcherDB {
         &self,
         block_index: u64,
     ) -> Result<(u64, TimestampResultCode), WatcherDBError> {
-        if block_index == 0 {
+        if block_index == 0 || block_index == u64::MAX {
             return Ok((u64::MAX, TimestampResultCode::BlockIndexOutOfBounds));
         }
         let sigs = self.get_block_signatures(block_index)?;
@@ -620,6 +620,12 @@ mod test {
             // Verify that block index 0 is out of bounds
             assert_eq!(
                 watcher_db.get_block_timestamp(0).unwrap(),
+                (u64::MAX, TimestampResultCode::BlockIndexOutOfBounds)
+            );
+
+            // Verify that u64::MAX is out of bounds
+            assert_eq!(
+                watcher_db.get_block_timestamp(u64::MAX).unwrap(),
                 (u64::MAX, TimestampResultCode::BlockIndexOutOfBounds)
             );
         });


### PR DESCRIPTION
Soundtrack of this PR: [Working on a Dream](https://www.youtube.com/watch?v=R3ZMfPXgd_M)

### Motivation

u64::MAX is used as a sentinel value for key image results, and if passed to the watcher to get a timestamp, should be treated as OutOfBounds.

### In this PR
* Adds u64::MAX to IndexOutOfBounds evaluation.
* Adds case to test

[FOG-131](https://mobilecoin.atlassian.net/browse/FOG-131)
