### PR TITLE
Slot uses hashset! btreeset! macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,6 +2295,7 @@ version = "0.5.0"
 dependencies = [
  "bigint",
  "crossbeam-channel 0.3.9",
+ "maplit",
  "mc-common",
  "mc-crypto-digestible",
  "mc-crypto-keys",

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -19,6 +19,7 @@ mc-util-metrics = { path = "../../util/metrics" }
 mc-util-serial = { path = "../../util/serial", features = ["std"] }
 
 bigint = "4.4"
+maplit = "1.0.2"
 rand = "0.7"
 rand_hc = "0.2"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -19,12 +19,12 @@ use mc_common::{
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     fmt::Display,
-    iter::FromIterator,
     sync::Arc,
     time::{Duration, Instant},
 };
 
 use core::cmp;
+use maplit::{btreeset, hashset};
 use serde::{Deserialize, Serialize};
 
 /// The various phases of the SCP protocol.
@@ -1352,7 +1352,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
             for value in candidates {
                 // Test if a blocking set has issued "accept nominate(v)".
                 let predicate = ValueSetPredicate::<V> {
-                    values: BTreeSet::from_iter(vec![value.clone()]),
+                    values: btreeset! {value.clone()},
                     test_fn: Arc::new(|msg, values| match msg.accepts_nominated() {
                         None => BTreeSet::default(),
                         Some(values_accepted_nominated) => values
@@ -1437,7 +1437,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
 
             for ballot in candidates.into_iter() {
                 let predicate = BallotSetPredicate::<V> {
-                    ballots: HashSet::from_iter(vec![ballot.clone()]),
+                    ballots: hashset! { ballot.clone()},
                     test_fn: Arc::new(|msg, candidates| {
                         let mut intersections: HashSet<Ballot<V>> = HashSet::default();
 
@@ -1702,6 +1702,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
 mod nominate_protocol_tests {
     use super::*;
     use crate::{core_types::*, quorum_set::*, test_utils::*};
+    use maplit::{btreeset, hashset};
     use mc_common::logger::test_with_logger;
 
     #[test_with_logger]
@@ -1730,7 +1731,7 @@ mod nominate_protocol_tests {
                 node_2.1,
                 slot_index,
                 Topic::Nominate(NominatePayload {
-                    X: BTreeSet::from_iter(vec![1000]),
+                    X: btreeset! {1000},
                     Y: BTreeSet::default(),
                 }),
             );
@@ -1745,7 +1746,7 @@ mod nominate_protocol_tests {
                 node_3.1,
                 slot_index,
                 Topic::Nominate(NominatePayload {
-                    X: BTreeSet::from_iter(vec![1000]),
+                    X: btreeset! {1000},
                     Y: BTreeSet::default(),
                 }),
             );
@@ -1778,12 +1779,12 @@ mod nominate_protocol_tests {
                 slot_index,
                 Topic::Nominate(NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec![2222]),
+                    Y: btreeset! {2222},
                 }),
             );
             slot.M.insert(msg.sender_id.clone(), msg);
 
-            let expected = BTreeSet::from_iter(vec![2222]);
+            let expected = btreeset! {2222};
             assert_eq!(slot.additional_values_accepted_nominated(), expected);
         }
 
@@ -1795,12 +1796,12 @@ mod nominate_protocol_tests {
                 slot_index,
                 Topic::Nominate(NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec![3333]),
+                    Y: btreeset! {3333},
                 }),
             );
             slot.M.insert(msg.sender_id.clone(), msg);
 
-            let expected = BTreeSet::from_iter(vec![2222, 3333]);
+            let expected = btreeset! {2222, 3333};
             assert_eq!(slot.additional_values_accepted_nominated(), expected);
         }
     }
@@ -1827,11 +1828,11 @@ mod nominate_protocol_tests {
             local_node.1,
             slot_index,
             Topic::Nominate(NominatePayload {
-                X: BTreeSet::from_iter(vec![1234, 1111]),
+                X: btreeset! {1234, 1111},
                 Y: BTreeSet::default(),
             }),
         );
-        slot.X = HashSet::from_iter(vec![1234]);
+        slot.X = hashset! { 1234};
         slot.M.insert(msg_1.sender_id.clone(), msg_1);
         let expected = BTreeSet::default();
         assert_eq!(slot.additional_values_accepted_nominated(), expected);
@@ -1844,7 +1845,7 @@ mod nominate_protocol_tests {
                 node.1.clone(),
                 slot_index,
                 Topic::Nominate(NominatePayload {
-                    X: BTreeSet::from_iter(vec![1234, 9999]),
+                    X: btreeset! {1234, 9999},
                     Y: BTreeSet::default(),
                 }),
             );
@@ -1859,13 +1860,13 @@ mod nominate_protocol_tests {
             node_4.1,
             slot_index,
             Topic::Nominate(NominatePayload {
-                X: BTreeSet::from_iter(vec![1234, 4444]),
+                X: btreeset! {1234, 4444},
                 Y: BTreeSet::default(),
             }),
         );
         slot.M.insert(msg_4.sender_id.clone(), msg_4);
         // Only the value "1234" was voted nominated by the quorum:
-        let expected = BTreeSet::from_iter(vec![1234]);
+        let expected = btreeset! {1234};
         assert_eq!(slot.additional_values_accepted_nominated(), expected);
     }
 
@@ -1900,7 +1901,7 @@ mod nominate_protocol_tests {
             Topic::NominatePrepare(
                 NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec!["A", "B", "C", "D"]),
+                    Y: btreeset! {"A", "B", "C", "D"},
                 },
                 PreparePayload {
                     B: Ballot::new(1234, &["A", "B", "C"]),
@@ -1928,7 +1929,7 @@ mod nominate_protocol_tests {
             Topic::NominatePrepare(
                 NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec!["A", "B", "C", "D"]),
+                    Y: btreeset! {"A", "B", "C", "D"},
                 },
                 PreparePayload {
                     B: Ballot::new(1234, &["A", "B", "C", "D"]),
@@ -1956,7 +1957,7 @@ mod nominate_protocol_tests {
             Topic::NominatePrepare(
                 NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec!["A", "B", "C", "D"]),
+                    Y: btreeset! {"A", "B", "C", "D"},
                 },
                 PreparePayload {
                     B: Ballot::new(1234, &["A", "B", "C", "D"]),
@@ -1984,7 +1985,7 @@ mod nominate_protocol_tests {
             Topic::NominatePrepare(
                 NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec!["A", "B", "C", "D"]),
+                    Y: btreeset! {"A", "B", "C", "D"},
                 },
                 PreparePayload {
                     B: Ballot::new(1234, &["A", "B", "C", "D"]),
@@ -2013,8 +2014,8 @@ mod nominate_protocol_tests {
             Arc::new(trivial_combine_fn),
             logger,
         );
-        slot.Y = HashSet::from_iter(vec!["B"]);
-        slot.Z = HashSet::from_iter(vec!["B"]);
+        slot.Y = hashset! { "B"};
+        slot.Z = hashset! { "B"};
         slot.M.insert(msg_2.sender_id.clone(), msg_2);
         slot.M.insert(msg_3.sender_id.clone(), msg_3);
         slot.M.insert(msg_4.sender_id.clone(), msg_4);
@@ -2024,7 +2025,7 @@ mod nominate_protocol_tests {
         // node to update it's accepted nominated (Y) list from what the blocking set has agreed
         // on.
         slot.update_YZ();
-        assert_eq!(slot.Y, HashSet::from_iter(vec!["A", "B", "C", "D"]));
+        assert_eq!(slot.Y, hashset! { "A", "B", "C", "D"});
     }
 
     #[test_with_logger]
@@ -2061,7 +2062,7 @@ mod nominate_protocol_tests {
             Topic::NominatePrepare(
                 NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec!["B"]),
+                    Y: btreeset! { "B"},
                 },
                 PreparePayload {
                     B: Ballot::new(1234, &["B"]),
@@ -2089,7 +2090,7 @@ mod nominate_protocol_tests {
             Topic::NominatePrepare(
                 NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec!["A", "B", "C", "D"]),
+                    Y: btreeset! {"A", "B", "C", "D"},
                 },
                 PreparePayload {
                     B: Ballot::new(1234, &["A", "B", "C", "D"]),
@@ -2117,7 +2118,7 @@ mod nominate_protocol_tests {
             Topic::NominatePrepare(
                 NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec!["A", "B", "C", "D"]),
+                    Y: btreeset! {"A", "B", "C", "D"},
                 },
                 PreparePayload {
                     B: Ballot::new(1234, &["A", "B", "C", "D"]),
@@ -2145,7 +2146,7 @@ mod nominate_protocol_tests {
             Topic::NominatePrepare(
                 NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec!["A", "B", "C", "D"]),
+                    Y: btreeset! {"A", "B", "C", "D"},
                 },
                 PreparePayload {
                     B: Ballot::new(1234, &["A", "B", "C", "D"]),
@@ -2174,8 +2175,8 @@ mod nominate_protocol_tests {
             Arc::new(trivial_combine_fn),
             logger,
         );
-        slot.Y = HashSet::from_iter(vec!["A", "B", "C", "D"]);
-        slot.Z = HashSet::from_iter(vec!["A", "B", "C"]);
+        slot.Y = hashset! { "A", "B", "C", "D"};
+        slot.Z = hashset! { "A", "B", "C"};
         slot.M.insert(msg_1.sender_id.clone(), msg_1);
         slot.M.insert(msg_3.sender_id.clone(), msg_3);
         slot.M.insert(msg_4.sender_id.clone(), msg_4);
@@ -2183,7 +2184,7 @@ mod nominate_protocol_tests {
 
         // Calling updateYZ should add "D" to confirmed nominated (Z) since a quorum (2,3,4,5) have accepted nominated (Y) it.
         slot.update_YZ();
-        assert_eq!(slot.Z, HashSet::from_iter(vec!["A", "B", "C", "D"]));
+        assert_eq!(slot.Z, hashset! { "A", "B", "C", "D"});
     }
 
     #[test_with_logger]
@@ -2205,7 +2206,7 @@ mod nominate_protocol_tests {
         // Ensure that the local node **is not** in max_priority_peers.
         assert!(!slot.max_priority_peers.contains(&local_node.0));
 
-        let values: BTreeSet<u32> = BTreeSet::from_iter(vec![1000, 2000]);
+        let values: BTreeSet<u32> = btreeset! { 1000, 2000};
         let msg_opt = slot
             .propose_values(&values)
             .expect("slot.propose_values failed");
@@ -2233,7 +2234,7 @@ mod nominate_protocol_tests {
 
         {
             // The node should nominate proposed values.
-            let values: BTreeSet<u32> = BTreeSet::from_iter(vec![1000, 2000]);
+            let values: BTreeSet<u32> = btreeset! { 1000, 2000};
             let emitted = slot
                 .propose_values(&values)
                 .expect("slot.propose_values failed")
@@ -2244,7 +2245,7 @@ mod nominate_protocol_tests {
                 local_node.1.clone(),
                 slot_index,
                 Topic::Nominate(NominatePayload {
-                    X: BTreeSet::from_iter(vec![1000, 2000]),
+                    X: btreeset! { 1000, 2000},
                     Y: BTreeSet::default(),
                 }),
             );
@@ -2254,7 +2255,7 @@ mod nominate_protocol_tests {
 
         {
             // The node should continue to nominate new proposed values.
-            let values: BTreeSet<u32> = BTreeSet::from_iter(vec![777, 4242]);
+            let values: BTreeSet<u32> = btreeset! { 777, 4242};
             let emitted = slot
                 .propose_values(&values)
                 .expect("slot.propose_values failed")
@@ -2265,7 +2266,7 @@ mod nominate_protocol_tests {
                 local_node.1.clone(),
                 slot_index,
                 Topic::Nominate(NominatePayload {
-                    X: BTreeSet::from_iter(vec![777, 1000, 2000, 4242]),
+                    X: btreeset! { 777, 1000, 2000, 4242},
                     Y: BTreeSet::default(),
                 }),
             );
@@ -2279,8 +2280,10 @@ mod nominate_protocol_tests {
 mod ballot_protocol_tests {
     use super::*;
     use crate::{core_types::*, quorum_set::*, test_utils::*};
+    use maplit::{btreeset, hashset};
     use mc_common::logger::test_with_logger;
     use pretty_assertions::assert_eq;
+    use std::iter::FromIterator;
 
     // TODO: reject a message if it contains a ballot containing incorrectly ordered values.
 
@@ -2301,7 +2304,7 @@ mod ballot_protocol_tests {
             logger,
         );
 
-        let values = BTreeSet::from_iter(vec![5678, 1234, 1337, 1338]);
+        let values = btreeset! { 5678, 1234, 1337, 1338};
         let emitted_msg = slot
             .propose_values(&values)
             .unwrap()
@@ -2337,7 +2340,7 @@ mod ballot_protocol_tests {
         // Ensure our node id is inside max priority peers list.
         slot.max_priority_peers.insert(node_id.clone());
 
-        let values: BTreeSet<u32> = BTreeSet::from_iter(vec![1000, 2000]);
+        let values: BTreeSet<u32> = btreeset! { 1000, 2000};
         let emitted_msg = slot
             .propose_values(&values)
             .expect("slot.propose_values failed")
@@ -2348,7 +2351,7 @@ mod ballot_protocol_tests {
             quorum_set,
             1,
             Topic::Nominate(NominatePayload {
-                X: BTreeSet::from_iter(vec![1000, 2000]),
+                X: btreeset! { 1000, 2000},
                 Y: BTreeSet::default(),
             }),
         );
@@ -2356,7 +2359,7 @@ mod ballot_protocol_tests {
         assert_eq!(emitted_msg, expected_msg);
         assert_eq!(
             emitted_msg.votes_or_accepts_nominated(),
-            Some(BTreeSet::from_iter(vec![1000, 2000]))
+            Some(btreeset! { 1000, 2000})
         );
         assert_eq!(emitted_msg.accepts_nominated(), Some(&BTreeSet::default()));
     }
@@ -2395,7 +2398,7 @@ mod ballot_protocol_tests {
 
         // Vote nominate on 1337, 1338 and confirm nominate 5678, 1234.
         {
-            let values: BTreeSet<u32> = BTreeSet::<u32>::from_iter(vec![5678, 1234, 1337, 1338]);
+            let values: BTreeSet<u32> = btreeset! {5678, 1234, 1337, 1338};
             let emitted_msg = slot
                 .propose_values(&values)
                 .expect("slot.propose failed")
@@ -2406,7 +2409,7 @@ mod ballot_protocol_tests {
                 node_1.1.clone(),
                 slot_index,
                 Topic::Nominate(NominatePayload {
-                    X: BTreeSet::from_iter(values),
+                    X: values.clone(),
                     Y: BTreeSet::default(),
                 }),
             );
@@ -2421,7 +2424,7 @@ mod ballot_protocol_tests {
                 slot_index,
                 Topic::Nominate(NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec![5678, 1234]),
+                    Y: btreeset! { 1234, 5678},
                 }),
             );
             let emitted_msg = slot
@@ -2435,8 +2438,8 @@ mod ballot_protocol_tests {
                 slot_index,
                 Topic::NominatePrepare(
                     NominatePayload {
-                        X: BTreeSet::from_iter(vec![1337, 1338]),
-                        Y: BTreeSet::from_iter(vec![5678, 1234]),
+                        X: btreeset! { 1337, 1338},
+                        Y: btreeset! { 1234, 5678},
                     },
                     PreparePayload {
                         B: Ballot::new(1, &[1234, 5678]),
@@ -2459,7 +2462,7 @@ mod ballot_protocol_tests {
                 slot_index,
                 Topic::Nominate(NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec![5678, 1234, 1337, 1338]),
+                    Y: btreeset! { 5678, 1234, 1337, 1338},
                 }),
             );
             let emitted_msg = slot
@@ -2473,7 +2476,7 @@ mod ballot_protocol_tests {
                 Topic::NominatePrepare(
                     NominatePayload {
                         X: BTreeSet::default(),
-                        Y: BTreeSet::from_iter(vec![5678, 1234, 1337, 1338]),
+                        Y: btreeset! { 5678, 1234, 1337, 1338},
                     },
                     PreparePayload {
                         B: Ballot::new(1, &[1234, 5678]),
@@ -2502,7 +2505,7 @@ mod ballot_protocol_tests {
                 Topic::NominatePrepare(
                     NominatePayload {
                         X: BTreeSet::default(),
-                        Y: BTreeSet::from_iter(vec![5678, 1234, 1337, 1338]),
+                        Y: btreeset! { 5678, 1234, 1337, 1338},
                     },
                     PreparePayload {
                         B: Ballot::new(2, &[1234, 1337, 1338, 5678]),
@@ -2558,8 +2561,8 @@ mod ballot_protocol_tests {
         // a Prepare message from node 2 as well.
         {
             slot.phase = Phase::NominatePrepare;
-            slot.X = HashSet::from_iter(vec![1337, 1338]);
-            slot.Y = HashSet::from_iter(vec![1234, 5678]);
+            slot.X = hashset! { 1337, 1338};
+            slot.Y = hashset! { 1234, 5678};
             slot.B = Ballot::new(2, &[1234, 5678]);
             slot.P = Some(slot.B.clone());
             slot.last_sent_msg = slot.out_msg();
@@ -2590,7 +2593,7 @@ mod ballot_protocol_tests {
                 slot_index,
                 Topic::Nominate(NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec![5678, 1234, 1337, 1338]),
+                    Y: btreeset! { 5678, 1234, 1337, 1338},
                 }),
             );
             let emitted_msg = slot
@@ -2604,7 +2607,7 @@ mod ballot_protocol_tests {
                 Topic::NominatePrepare(
                     NominatePayload {
                         X: BTreeSet::default(),
-                        Y: BTreeSet::from_iter(vec![5678, 1234, 1337, 1338]),
+                        Y: btreeset! { 5678, 1234, 1337, 1338},
                     },
                     PreparePayload {
                         B: Ballot::new(2, &[1234, 5678]),
@@ -2634,7 +2637,7 @@ mod ballot_protocol_tests {
                 Topic::NominatePrepare(
                     NominatePayload {
                         X: BTreeSet::default(),
-                        Y: BTreeSet::from_iter(vec![5678, 1234, 1337, 1338]),
+                        Y: btreeset! { 5678, 1234, 1337, 1338},
                     },
                     PreparePayload {
                         B: Ballot::new(3, &[1234, 1337, 1338, 5678]),
@@ -2689,8 +2692,8 @@ mod ballot_protocol_tests {
         // Initialize slot so that it has issued "confirm prepare(b)".
         {
             slot.phase = Phase::Prepare;
-            slot.X = HashSet::from_iter(vec![1337, 1338]);
-            slot.Y = HashSet::from_iter(vec![1234, 5678]);
+            slot.X = hashset! { 1337, 1338};
+            slot.Y = hashset! { 1234, 5678};
             slot.B = Ballot::new(3, &[1234, 5678]);
             slot.P = Some(Ballot::new(2, &[1234, 5678]));
             slot.H = slot.P.clone();
@@ -2720,7 +2723,7 @@ mod ballot_protocol_tests {
                 slot_index,
                 Topic::Nominate(NominatePayload {
                     X: BTreeSet::default(),
-                    Y: BTreeSet::from_iter(vec![5678, 1234, 1337, 1338]),
+                    Y: btreeset! { 5678, 1234, 1337, 1338},
                 }),
             );
             let emitted_msg = slot
@@ -3437,7 +3440,7 @@ mod ballot_protocol_tests {
 
         // Node 1 has issued "vote prepare(b)".
         {
-            slot.Y = HashSet::from_iter(vec![1234, 5678]);
+            slot.Y = hashset! { 1234, 5678};
             slot.B = ballot.clone();
             slot.last_sent_msg = slot.out_msg();
 
@@ -3450,7 +3453,7 @@ mod ballot_protocol_tests {
                     Topic::NominatePrepare(
                         NominatePayload {
                             X: BTreeSet::default(),
-                            Y: BTreeSet::from_iter(vec![1234, 5678]),
+                            Y: btreeset! { 1234, 5678},
                         },
                         PreparePayload {
                             B: ballot,
@@ -3644,7 +3647,7 @@ mod ballot_protocol_tests {
                 Topic::NominatePrepare(
                     NominatePayload {
                         X: BTreeSet::default(),
-                        Y: BTreeSet::from_iter(vec![1000]),
+                        Y: btreeset! {1000},
                     },
                     PreparePayload {
                         B: ballot_2_V.clone(),
@@ -3668,7 +3671,7 @@ mod ballot_protocol_tests {
                 Topic::NominatePrepare(
                     NominatePayload {
                         X: BTreeSet::default(),
-                        Y: BTreeSet::from_iter(vec![1000]),
+                        Y: btreeset! {1000},
                     },
                     PreparePayload {
                         B: ballot_2_V.clone(),
@@ -3693,7 +3696,7 @@ mod ballot_protocol_tests {
                 Topic::NominatePrepare(
                     NominatePayload {
                         X: BTreeSet::default(),
-                        Y: BTreeSet::from_iter(vec![2000]),
+                        Y: btreeset! { 2000},
                     },
                     PreparePayload {
                         B: ballot_2_W.clone(),
@@ -3717,7 +3720,7 @@ mod ballot_protocol_tests {
                 Topic::NominatePrepare(
                     NominatePayload {
                         X: BTreeSet::default(),
-                        Y: BTreeSet::from_iter(vec![1000, 2000]),
+                        Y: btreeset! { 1000, 2000},
                     },
                     PreparePayload {
                         B: ballot_2_V,


### PR DESCRIPTION
### In this PR
* Uses the `hashset!` and `btreeset!` macros from the `maplit` crate to replace a number of clumsy declarations like `BTreeSet::from_iter(vec![x, y, z])` with the more concise `btreeset!{ x, y, z}`.

