### PR TITLE
Build determinism in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,8 @@
 # Notes:
 # * The new resolver has a bug that causes packages to select features non-deterministically under
 #   certain circumstances. To work around this, `--target` must be specified when using cargo. This
-#   can be removed once the bug is fixed.
+#   can be removed once the bug is fixed. Similarly, `--tests` must be specified when using
+#   `cargo test` so that non-test profile builds don't bleed over.
 #   See: [MC-1731] and https://github.com/rust-lang/cargo/issues/8549
 
 version: 2.1
@@ -265,7 +266,7 @@ commands:
     parameters:
       test_command:
         type: string
-        default: cargo test --frozen --target "$HOST_TARGET_TRIPLE"
+        default: cargo test --frozen --target "$HOST_TARGET_TRIPLE" --tests
     steps:
       - run:
           name: Run all tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 # vim: tabstop=2 softtabstop=2 shiftwidth=2 expandtab:
 
+# Notes:
+# * The new resolver has a bug that causes packages to select features non-deterministically under
+#   certain circumstances. To work around this, `--target` must be specified when using cargo. This
+#   can be removed once the bug is fixed.
+#   See: [MC-1731] and https://github.com/rust-lang/cargo/issues/8549
+
 version: 2.1
 
 defaults:
@@ -59,6 +65,10 @@ commands:
             if [ -f ~/.gitconfig ]; then
               sed -i -e 's/github/git-non-exist-hub/g' ~/.gitconfig # https://github.com/rust-lang/cargo/issues/3900
             fi
+      - run:
+          name: Set utility environment variables
+          command: |
+            echo "export HOST_TARGET_TRIPLE=\"$(rustc -Vv | sed -n 's/^host: //p')\"" >> $BASH_ENV
 
   enable_sccache:
     description: Enabling sccache
@@ -255,7 +265,7 @@ commands:
     parameters:
       test_command:
         type: string
-        default: cargo test --frozen
+        default: cargo test --frozen --target "$HOST_TARGET_TRIPLE"
     steps:
       - run:
           name: Run all tests
@@ -416,14 +426,14 @@ jobs:
       - prepare-for-build
       - run:
           name: Cargo check (SW/IAS dev)
-          command: cargo check --frozen
+          command: cargo check --frozen --target "$HOST_TARGET_TRIPLE"
       - check-dirty-git
       - run:
           name: Cargo check (HW/IAS prod)
           environment:
             SGX_MODE: HW
             IAS_MODE: PROD
-          command: cargo check --frozen
+          command: cargo check --frozen --target "$HOST_TARGET_TRIPLE"
       - check-dirty-git
 
       # The lint and saving of caches happens here since this job is faster than the run-all-tests job.
@@ -458,7 +468,7 @@ jobs:
       - run:
           name: Cargo check (SW/IAS dev)
           command: |
-            cargo check --workspace --frozen \
+            cargo check --frozen --target "$HOST_TARGET_TRIPLE" --workspace \
               --exclude mc-attest-untrusted \
               --exclude mc-consensus-enclave \
               --exclude mc-consensus-service \

--- a/util/build/enclave/src/lib.rs
+++ b/util/build/enclave/src/lib.rs
@@ -347,8 +347,10 @@ impl Builder {
     ///
     /// If an unsigned enclave does not exist, it will build it.
     pub fn build(&mut self) -> Result<Signature, Error> {
+        let mut packages = self.staticlib.packages.clone();
+        packages.sort_by_cached_key(|p| p.name.clone());
         // Emit correct "rerun-if-changed" diagnostics for cargo
-        for package in self.staticlib.packages.iter() {
+        for package in packages.iter() {
             // source.is_none implies a local package not from crates.io
             if package.source.is_none() {
                 // package.manifest_path has form foo/Cargo.toml, we want to take parent


### PR DESCRIPTION
### Motivation

Cargo build caches build artifacts so that successive invocations won't rebuild the parts of the code that haven't changed. Currently our project is experiencing spurious rebuilds even when nothing has changed. This leads to slower development cycles.

On top of the spurious rebuilds, the build is also experience build non-determinism. Crate feature selection doesn't appear to be consistent across multiple successive builds under certain circumstances (e.g. when building more than a single package at a time). This is a problem because it means that we might be encountering bugs related to incorrect feature configuration. This also has the potential to mask bugs for the same reason.

### In this PR

This PR addresses several of the issues causing spurious rebuilds and build non-determinism:

* `mc-util-build-enclave` emits `rerun-if-changed` directives based on files in the filesystem. However, currently the files aren't sorted, leading Cargo to think that the build inputs have changed, thus invoking a rebuild. This PR adds sorting to the file iteration so that they're always printed in the same order.
* Cargo's new resolver feature allows isolating feature unification between build dependencies, target dependencies, and dev dependencies. However, there is a bug within Cargo stemming from overeager caching of feature configuration, leading to incorrect feature selection under certain circumstances. See [MC-1731] and https://github.com/rust-lang/cargo/issues/8549 for more detail. This PR adds the [suggested workaround](https://github.com/rust-lang/cargo/issues/8549#issuecomment-664751530) to our CI builds, which is to add `--target` when invoking cargo.
* Additionally, there is a similar issue when running `cargo test` with the default settings, where feature unification appears to be non-deterministic. A workaround for this is applied to CI, which is to add `--tests` when calling `cargo test`. Typically, when calling `cargo test` with the default settings, cargo will build the project in a number of different ways (see https://doc.rust-lang.org/cargo/commands/cargo-test.html), and then test the tests. By specifying `--tests`, Cargo is instructed to build only the tests, and then run them. This prevents feature configuration from other types of builds from being impacted by this bug and affecting the feature selection of the test build.
### Future Work
* Once https://github.com/rust-lang/cargo/issues/8549 is fixed, then we should be able to remove `--target` and `--tests` from the CircleCI configuration. [MC-1731] has been created to track the status of this bug.

[MC-1731]: https://mobilecoin.atlassian.net/browse/MC-1731