### PR TITLE
Update Homebrew in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,13 @@ commands:
           key: v0-homebrew-{{ arch }}
       - run:
           name: Install Homebrew dependencies
-          command: brew bundle --no-upgrade
+          # Update Homebrew before running `brew bundle` to fix a bug in the
+          # version of Homebrew that comes preinstalled on CircleCI's macOS
+          # image. Once the CircleCI macOS image comes preinstalled with the
+          # updated version, then we should be able to remove `brew update`
+          # from this step.
+          # See: https://github.com/Homebrew/homebrew-bundle/issues/751
+          command: brew update --preinstall && brew bundle --no-upgrade
 
   save-homebrew-cache:
     steps:


### PR DESCRIPTION
### Motivation

Homebrew recently shipped with a bug that causes a crash when running `brew bundle`. They've since fixed the bug, but the CircleCI macOS image currently comes pre-installed with the older version of Homebrew that includes the bug.

The issue can be seen here: https://app.circleci.com/pipelines/github/mobilecoinofficial/mobilecoin/1714/workflows/537a2357-c4ed-4428-a25b-7543ae89e322/jobs/3303/parallel-runs/0/steps/0-103

In order to get around this, this PR adds the command `brew update` so that Homebrew gets updated before running `brew bundle`.

This issue has more info: https://github.com/Homebrew/homebrew-bundle/issues/751

Note: the `--preinstall` flag is specified, since it is recommended in the issue to do so, as it is faster.

### In this PR
* Adds a command to update Homebrew in CI

### Future Work
* Eventually, once CircleCI's macOS image comes preinstalled with the newer version of Homebrew, the `brew update` command should be able to be removed. The reason to do so would be solely for the purpose of saving time, since at that point it will no longer be necessary to update Homebrew every run of CI.
