### PR TITLE
SCP Slot State debugging

### DIFF
--- a/consensus/scp/src/lib.rs
+++ b/consensus/scp/src/lib.rs
@@ -12,6 +12,7 @@ pub mod predicates;
 pub mod quorum_set;
 pub mod scp_log;
 pub mod slot;
+pub mod slot_state;
 pub mod test_utils;
 mod utils;
 

--- a/consensus/scp/src/node.rs
+++ b/consensus/scp/src/node.rs
@@ -5,7 +5,7 @@ use crate::{
     core_types::{CombineFn, SlotIndex, ValidityFn, Value},
     msg::{ExternalizePayload, Msg, Topic},
     quorum_set::QuorumSet,
-    slot::{Slot, SlotMetrics},
+    slot::{Slot, SlotMetrics, SlotState},
 };
 use mc_common::{
     logger::{log, Logger},
@@ -150,6 +150,9 @@ pub trait ScpNode<V: Value>: Send {
     /// Get metrics for a specific slot.
     fn get_slot_metrics(&mut self, slot_index: SlotIndex) -> Option<SlotMetrics>;
 
+    /// Get the slot internal state (for debug purposes).
+    fn get_slot_state(&mut self, slot_index: SlotIndex) -> Option<SlotState<V>>;
+
     /// Clear the list of pending slots. This is useful if the user of this object realizes they
     /// have fallen behind their peers, and as such they want to abort processing of current slots.
     fn clear_pending_slots(&mut self);
@@ -262,6 +265,13 @@ impl<V: Value, ValidationError: Display> ScpNode<V> for Node<V, ValidationError>
     /// Get metrics for a specific slot.
     fn get_slot_metrics(&mut self, slot_index: SlotIndex) -> Option<SlotMetrics> {
         self.pending.get(&slot_index).map(|slot| slot.get_metrics())
+    }
+
+    /// Get the slot internal state (for debug purposes).
+    fn get_slot_state(&mut self, slot_index: SlotIndex) -> Option<SlotState<V>> {
+        self.pending
+            .get(&slot_index)
+            .map(|slot| SlotState::from(slot))
     }
 
     /// Clear the list of pending slots. This is useful if the user of this object realizes they

--- a/consensus/scp/src/node.rs
+++ b/consensus/scp/src/node.rs
@@ -5,7 +5,8 @@ use crate::{
     core_types::{CombineFn, SlotIndex, ValidityFn, Value},
     msg::{ExternalizePayload, Msg, Topic},
     quorum_set::QuorumSet,
-    slot::{Slot, SlotMetrics, SlotState},
+    slot::{Slot, SlotMetrics},
+    slot_state::SlotState,
 };
 use mc_common::{
     logger::{log, Logger},

--- a/consensus/scp/src/node.rs
+++ b/consensus/scp/src/node.rs
@@ -269,9 +269,7 @@ impl<V: Value, ValidationError: Display> ScpNode<V> for Node<V, ValidationError>
 
     /// Get the slot internal state (for debug purposes).
     fn get_slot_state(&mut self, slot_index: SlotIndex) -> Option<SlotState<V>> {
-        self.pending
-            .get(&slot_index)
-            .map(|slot| SlotState::from(slot))
+        self.pending.get(&slot_index).map(SlotState::from)
     }
 
     /// Clear the list of pending slots. This is useful if the user of this object realizes they

--- a/consensus/scp/src/scp_log.rs
+++ b/consensus/scp/src/scp_log.rs
@@ -84,7 +84,7 @@ impl<V: Value, N: ScpNode<V>> LoggingScpNode<V, N> {
         create_dir_all(cur_slot_out_path.clone())
             .map_err(|e| format!("Failed creating directory {:?}: {:?}", cur_slot_out_path, e))?;
 
-        let mut slot_states_out_path = out_path.clone();
+        let mut slot_states_out_path = out_path;
         slot_states_out_path.push("slot-states");
         create_dir_all(slot_states_out_path.clone()).map_err(|e| {
             format!(

--- a/consensus/scp/src/scp_log.rs
+++ b/consensus/scp/src/scp_log.rs
@@ -1,10 +1,7 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 //! This crate provides a logging framework for recording and replaying SCP messages.
-use crate::{
-    slot::{SlotMetrics, SlotState},
-    Msg, QuorumSet, ScpNode, SlotIndex, Value,
-};
+use crate::{slot::SlotMetrics, slot_state::SlotState, Msg, QuorumSet, ScpNode, SlotIndex, Value};
 use mc_common::NodeID;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/consensus/scp/src/scp_log.rs
+++ b/consensus/scp/src/scp_log.rs
@@ -1,7 +1,10 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 //! This crate provides a logging framework for recording and replaying SCP messages.
-use crate::{slot::SlotMetrics, Msg, QuorumSet, ScpNode, SlotIndex, Value};
+use crate::{
+    slot::{SlotMetrics, SlotState},
+    Msg, QuorumSet, ScpNode, SlotIndex, Value,
+};
 use mc_common::NodeID;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -16,8 +19,11 @@ use std::time::Instant;
 
 /// A node specifically for logging SCP messages.
 pub struct LoggingScpNode<V: Value, N: ScpNode<V>> {
-    /// Output path.
-    out_path: PathBuf,
+    /// Output path for current slot log files.
+    cur_slot_out_path: PathBuf,
+
+    /// Output path for slot state files.
+    slot_states_out_path: PathBuf,
 
     /// Highest slot number we've encountered so far.
     highest_slot_index: SlotIndex,
@@ -73,12 +79,24 @@ impl<V: Value, N: ScpNode<V>> LoggingScpNode<V, N> {
             return Err(format!("{:?} already exists, refusing to re-use", out_path));
         }
 
-        create_dir_all(out_path.clone())
-            .map_err(|e| format!("Failed creating directory {:?}: {:?}", out_path, e))?;
+        let mut cur_slot_out_path = out_path.clone();
+        cur_slot_out_path.push("cur-slot");
+        create_dir_all(cur_slot_out_path.clone())
+            .map_err(|e| format!("Failed creating directory {:?}: {:?}", cur_slot_out_path, e))?;
+
+        let mut slot_states_out_path = out_path.clone();
+        slot_states_out_path.push("slot-states");
+        create_dir_all(slot_states_out_path.clone()).map_err(|e| {
+            format!(
+                "Failed creating directory {:?}: {:?}",
+                slot_states_out_path, e
+            )
+        })?;
 
         Ok(Self {
             node,
-            out_path,
+            cur_slot_out_path,
+            slot_states_out_path,
             highest_slot_index: 0,
             msg_count: 0,
             slot_start_time: Instant::now(),
@@ -95,10 +113,14 @@ impl<V: Value, N: ScpNode<V>> LoggingScpNode<V, N> {
 
         if msg_slot_index > self.highest_slot_index {
             // Switched to a newer slot, clean the output directory.
-            remove_dir_all(&self.out_path)
-                .map_err(|e| format!("failed emptying {:?}: {:?}", self.out_path, e))?;
-            create_dir_all(&self.out_path)
-                .map_err(|e| format!("Failed creating directory {:?}: {:?}", self.out_path, e))?;
+            remove_dir_all(&self.cur_slot_out_path)
+                .map_err(|e| format!("failed emptying {:?}: {:?}", self.cur_slot_out_path, e))?;
+            create_dir_all(&self.cur_slot_out_path).map_err(|e| {
+                format!(
+                    "Failed creating directory {:?}: {:?}",
+                    self.cur_slot_out_path, e
+                )
+            })?;
 
             self.highest_slot_index = msg_slot_index;
             self.msg_count = 0;
@@ -121,7 +143,7 @@ impl<V: Value, N: ScpNode<V>> LoggingScpNode<V, N> {
         let bytes =
             mc_util_serial::serialize(&data).map_err(|e| format!("failed serialize: {:?}", e))?;
 
-        let mut file_path = self.out_path.clone();
+        let mut file_path = self.cur_slot_out_path.clone();
         file_path.push(format!("{:08}", self.msg_count));
         self.msg_count += 1;
 
@@ -129,6 +151,20 @@ impl<V: Value, N: ScpNode<V>> LoggingScpNode<V, N> {
             .map_err(|e| format!("failed creating {:?}: {:?}", file_path, e))?;
         file.write_all(&bytes)
             .map_err(|e| format!("failed writing {:?}: {:?}", file_path, e))?;
+
+        // Write slot state into a file.
+        if let Some(slot_state) = self.get_slot_state(msg_slot_index) {
+            let slot_as_json = serde_json::to_vec(&slot_state)
+                .map_err(|e| format!("failed serializing slot state: {:?}", e))?;
+
+            let mut file_path = self.slot_states_out_path.clone();
+            file_path.push(format!("{:08}.json", msg_slot_index));
+
+            let mut file = File::create(&file_path)
+                .map_err(|e| format!("failed creating {:?}: {:?}", file_path, e))?;
+            file.write_all(&slot_as_json)
+                .map_err(|e| format!("failed writing {:?}: {:?}", file_path, e))?;
+        }
 
         Ok(())
     }
@@ -192,6 +228,10 @@ impl<V: Value, N: ScpNode<V>> ScpNode<V> for LoggingScpNode<V, N> {
 
     fn get_slot_metrics(&mut self, slot_index: SlotIndex) -> Option<SlotMetrics> {
         self.node.get_slot_metrics(slot_index)
+    }
+
+    fn get_slot_state(&mut self, slot_index: SlotIndex) -> Option<SlotState<V>> {
+        self.node.get_slot_state(slot_index)
     }
 
     fn clear_pending_slots(&mut self) {

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -227,7 +227,7 @@ impl<V: Value, ValidationError: Display> From<&Slot<V, ValidationError>> for Slo
             PP: src.PP.clone(),
             H: src.H.clone(),
             C: src.C.clone(),
-            phase: src.phase.clone(),
+            phase: src.phase,
             last_sent_msg: src.last_sent_msg.clone(),
             max_priority_peers: src.max_priority_peers.clone(),
             nominate_round: src.nominate_round,

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -150,6 +150,88 @@ pub struct SlotMetrics {
     pub bN: u32,
 }
 
+/// Serializable slot state used for debugging purposes.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SlotState<V: Value> {
+    /// Current slot number.
+    slot_index: SlotIndex,
+
+    /// List of highest messages from each node.
+    /// This is not stored as a HashMap since it simplifies serialization. The node id is part of
+    /// the message so that can be derived.
+    M: Vec<Msg<V>>,
+
+    /// Set of values that have been proposed, but not yet voted for.
+    W: HashSet<V>,
+
+    /// Set of values we have voted to nominate.
+    X: HashSet<V>,
+
+    /// Set of values we have accepted as nominated.
+    Y: HashSet<V>,
+
+    /// Set of values we have confirmed as nominated.
+    Z: HashSet<V>,
+
+    /// Current ballot we are trying to pass.
+    B: Ballot<V>,
+
+    /// The highest accepted prepared ballot, if any.
+    P: Option<Ballot<V>>,
+
+    /// The highest accepted prepared ballot that is less-than-and-incompatible with P.
+    PP: Option<Ballot<V>>,
+
+    /// In Prepare: the highest ballot that this node confirms prepared, if any.
+    /// In Commit: the highest ballot that this node accepts committed, if any.
+    /// In Externalize: The highest ballot that this node confirms committed.
+    H: Option<Ballot<V>>,
+
+    /// In Prepare: The lowest ballot that this node votes to commit, if any.
+    /// In Commit: The lowest ballot that this node accepts committed, if any.
+    /// In Externalize: The lowest ballot that this node confirms committed.
+    /// Invariant: if C is Some, C \lesssim H \lesssim B
+    C: Option<Ballot<V>>,
+
+    /// Current phase of the protocol.
+    phase: Phase,
+
+    /// Last message sent by us.
+    last_sent_msg: Option<Msg<V>>,
+
+    /// Max priority peers - nodes from which we listen to value nominations.
+    max_priority_peers: HashSet<NodeID>,
+
+    /// Current nomination round number.
+    nominate_round: u32,
+
+    /// List of values that have been checked to be valid for the current slot.
+    /// We can cache this and save on validation calls since the ledger doesn't change during a slot.
+    valid_values: BTreeSet<V>,
+}
+impl<V: Value, ValidationError: Display> From<&Slot<V, ValidationError>> for SlotState<V> {
+    fn from(src: &Slot<V, ValidationError>) -> Self {
+        Self {
+            slot_index: src.slot_index,
+            M: src.M.values().cloned().collect(),
+            W: src.W.clone(),
+            X: src.X.clone(),
+            Y: src.Y.clone(),
+            Z: src.Z.clone(),
+            B: src.B.clone(),
+            P: src.P.clone(),
+            PP: src.PP.clone(),
+            H: src.H.clone(),
+            C: src.C.clone(),
+            phase: src.phase.clone(),
+            last_sent_msg: src.last_sent_msg.clone(),
+            max_priority_peers: src.max_priority_peers.clone(),
+            nominate_round: src.nominate_round,
+            valid_values: src.valid_values.clone(),
+        }
+    }
+}
+
 impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
     ///////////////////////////////////////////////////////////////////////////
     // Public methods (how the Slot interfaces with the Node)

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -156,6 +156,9 @@ pub struct SlotState<V: Value> {
     /// Current slot number.
     slot_index: SlotIndex,
 
+    /// Local node ID.
+    node_id: NodeID,
+
     /// List of highest messages from each node.
     /// This is not stored as a HashMap since it simplifies serialization. The node id is part of
     /// the message so that can be derived.
@@ -213,6 +216,7 @@ impl<V: Value, ValidationError: Display> From<&Slot<V, ValidationError>> for Slo
     fn from(src: &Slot<V, ValidationError>) -> Self {
         Self {
             slot_index: src.slot_index,
+            node_id: src.node_id.clone(),
             M: src.M.values().cloned().collect(),
             W: src.W.clone(),
             X: src.X.clone(),

--- a/consensus/scp/src/slot_state.rs
+++ b/consensus/scp/src/slot_state.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! The state held by a single slot. Currently this duplicates the state inside `Slot` and is only
+//! used for debug/serialization purposes but a future change might embed a `SlotIndex` directly
+//! inside a `Slot`.
+
+use crate::{
+    core_types::{Ballot, SlotIndex, Value},
+    msg::*,
+    slot::{Phase, Slot},
+};
+use mc_common::NodeID;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeSet, HashSet},
+    fmt::Display,
+};
+
+/// Serializable slot state used for debugging purposes.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SlotState<V: Value> {
+    /// Current slot number.
+    slot_index: SlotIndex,
+
+    /// Local node ID.
+    node_id: NodeID,
+
+    /// List of highest messages from each node.
+    /// This is not stored as a HashMap since it simplifies serialization. The node id is part of
+    /// the message so that can be derived.
+    M: Vec<Msg<V>>,
+
+    /// Set of values that have been proposed, but not yet voted for.
+    W: HashSet<V>,
+
+    /// Set of values we have voted to nominate.
+    X: HashSet<V>,
+
+    /// Set of values we have accepted as nominated.
+    Y: HashSet<V>,
+
+    /// Set of values we have confirmed as nominated.
+    Z: HashSet<V>,
+
+    /// Current ballot we are trying to pass.
+    B: Ballot<V>,
+
+    /// The highest accepted prepared ballot, if any.
+    P: Option<Ballot<V>>,
+
+    /// The highest accepted prepared ballot that is less-than-and-incompatible with P.
+    PP: Option<Ballot<V>>,
+
+    /// In Prepare: the highest ballot that this node confirms prepared, if any.
+    /// In Commit: the highest ballot that this node accepts committed, if any.
+    /// In Externalize: The highest ballot that this node confirms committed.
+    H: Option<Ballot<V>>,
+
+    /// In Prepare: The lowest ballot that this node votes to commit, if any.
+    /// In Commit: The lowest ballot that this node accepts committed, if any.
+    /// In Externalize: The lowest ballot that this node confirms committed.
+    /// Invariant: if C is Some, C \lesssim H \lesssim B
+    C: Option<Ballot<V>>,
+
+    /// Current phase of the protocol.
+    phase: Phase,
+
+    /// Last message sent by us.
+    last_sent_msg: Option<Msg<V>>,
+
+    /// Max priority peers - nodes from which we listen to value nominations.
+    max_priority_peers: HashSet<NodeID>,
+
+    /// Current nomination round number.
+    nominate_round: u32,
+
+    /// List of values that have been checked to be valid for the current slot.
+    /// We can cache this and save on validation calls since the ledger doesn't change during a slot.
+    valid_values: BTreeSet<V>,
+}
+impl<V: Value, ValidationError: Display> From<&Slot<V, ValidationError>> for SlotState<V> {
+    fn from(src: &Slot<V, ValidationError>) -> Self {
+        Self {
+            slot_index: src.slot_index,
+            node_id: src.node_id.clone(),
+            M: src.M.values().cloned().collect(),
+            W: src.W.clone(),
+            X: src.X.clone(),
+            Y: src.Y.clone(),
+            Z: src.Z.clone(),
+            B: src.B.clone(),
+            P: src.P.clone(),
+            PP: src.PP.clone(),
+            H: src.H.clone(),
+            C: src.C.clone(),
+            phase: src.phase,
+            last_sent_msg: src.last_sent_msg.clone(),
+            max_priority_peers: src.max_priority_peers.clone(),
+            nominate_round: src.nominate_round,
+            valid_values: src.valid_values.clone(),
+        }
+    }
+}

--- a/consensus/scp/viewer/.gitignore
+++ b/consensus/scp/viewer/.gitignore
@@ -1,0 +1,2 @@
+env
+__pycache__

--- a/consensus/scp/viewer/README.md
+++ b/consensus/scp/viewer/README.md
@@ -1,0 +1,11 @@
+## Intro
+
+This directory contains a simple Python-based (Flash) tool that can be used to view SCP debug dumps that are generated when the `--scp-debug-dump` flag is passed to `consensus-service`.
+Currently, only slot state viewing is implemented.
+
+To use this you would need to grab a copy of the SCP debug dump directory from one or more nodes, and then:
+1. Create a Python virtual env: `python3 -m venv env`
+1. Activate it: `. ./env/bin/activate`
+1. Install dependencies: `pip install -r requirements.txt`
+1. Start the web server: `FLASK_ENV=development python viewer.py <directory containing SCP dump files>`
+1. Point a browser at http://127.0.0.1:5000/ and begin exploring.

--- a/consensus/scp/viewer/requirements.txt
+++ b/consensus/scp/viewer/requirements.txt
@@ -1,0 +1,6 @@
+click==7.1.2
+Flask==1.1.2
+itsdangerous==1.1.0
+Jinja2==2.11.2
+MarkupSafe==1.1.1
+Werkzeug==1.0.1

--- a/consensus/scp/viewer/templates/slot.html
+++ b/consensus/scp/viewer/templates/slot.html
@@ -1,0 +1,215 @@
+<html>
+    <head>
+        <style>
+            .values-list {
+                white-space: nowrap;
+                width: 100%;
+                padding: 0 0 0 15px;
+                margin: 0;
+            }
+            .values-list li {
+                display: inline;
+                padding-right: 5px;
+            }
+        </style>
+        <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+        <script>
+            let slot = {{ slot|tojson }};
+            let available_nodes = {{ available_nodes|tojson }};
+
+            $(function() {
+                let nodes_nav = $('<ul class="values-list"></ul>');
+                $.each(available_nodes, function(idx, node_id) {
+                    console.log(node_id, slot.node_id.responder_id)
+                    if (node_id == slot.node_id.responder_id) {
+                        nodes_nav.append($('<li style="font-weight: bold"></li>').text(node_id));
+                    } else {
+                        nodes_nav.append($('<li><a href="/slot/' + slot.slot_index + '/' + node_id + '">' + node_id + '</a></li>'))
+                    }
+                });
+                $('#nodes-nav').html(nodes_nav);
+
+
+                $('#node-id').text(slot.node_id.responder_id);
+                $('#slot-index').text(slot.slot_index);
+                $('#phase').text(slot.phase);
+                $('#nominate-round').text(slot.nominate_round);
+                if (slot.last_sent_msg) {
+                    $('#last-sent-msg').html(format_msg(slot.last_sent_msg));
+                }
+
+                var max_priority_peers = $('<ul class="values-list"></ul>');
+                $.each(slot.max_priority_peers, function(idx, val) {
+                    $(max_priority_peers).append($('<li></li>').text(val.responder_id));
+                });
+                $('#max-priority-peers').html(max_priority_peers);
+
+                slot.M.sort(function(a, b) { return a.sender_id.responder_id > b.sender_id.responder_id; });
+                $.each(slot.M, function(idx, msg) {
+                    $('#M').append(format_msg(msg));
+                    $('#M').append($('<hr>'));
+                });
+
+                $('#nominate > #W').html(format_values(slot.W));
+                $('#nominate > #X').html(format_values(slot.X));
+                $('#nominate > #Y').html(format_values(slot.Y));
+                $('#nominate > #Z').html(format_values(slot.Z));
+
+                $('#prepare-commit > #B').html(format_ballot(slot.B));
+                $('#prepare-commit > #P').html(format_ballot(slot.P));
+                $('#prepare-commit > #PP').html(format_ballot(slot.PP));
+                $('#prepare-commit > #H').html(format_ballot(slot.H));
+                $('#prepare-commit > #C').html(format_ballot(slot.C));
+            });
+
+            function format_msg(msg) {
+                console.log(msg);
+
+                var template = $($('script[data-template="msg"]').text());
+                $('#sender', template).text(msg.sender_id.responder_id);
+                $('#slot-index', template).text(msg.slot_index);
+
+                if (msg.topic.Externalize) {
+                    $('#topic', template).text("Externalize");
+
+                    var t = msg.topic.Externalize;
+                    $('#C', template).html(format_ballot(t.C)).parent().show();
+                    $('#HN', template).text(t.HN).parent().show();
+                } else if (msg.topic.Commit) {
+                    $('#topic', template).text("Commit");
+
+                    var t = msg.topic.Commit;
+                    $('#B', template).html(format_ballot(t.B)).parent().show();
+                    $('#PN', template).text(t.PN).parent().show();
+                    $('#CN', template).text(t.CN).parent().show();
+                    $('#HN', template).text(t.HN).parent().show();
+                } else if (msg.topic.Prepare && msg.topic.Nominate) {
+                    $('#topic', template).text("Prepare/Nominate");
+
+                    var t = msg.topic.Nominate;
+                    $('#X', template).html(format_values(t.X)).parent().show();
+                    $('#Y', template).html(format_values(t.Y)).parent().show();
+
+                    var t = msg.topic.Prepare;
+                    $('#B', template).html(format_ballot(t.B)).parent().show();
+                    $('#P', template).html(format_ballot(t.P)).parent().show();
+                    $('#PP', template).html(format_ballot(t.PP)).parent().show();
+                    $('#CN', template).text(t.CN).parent().show();
+                    $('#HN', template).text(t.HN).parent().show();
+                } else if (msg.topic.Prepare) {
+                    $('#topic', template).text("Prepare");
+
+                    var t = msg.topic.Prepare;
+                    $('#B', template).html(format_ballot(t.B)).parent().show();
+                    $('#P', template).html(format_ballot(t.P)).parent().show();
+                    $('#PP', template).html(format_ballot(t.PP)).parent().show();
+                    $('#CN', template).text(t.CN).parent().show();
+                    $('#HN', template).text(t.HN).parent().show();
+                } else if (msg.topic.Nominate) {
+                    $('#topic', template).text("Nominate");
+
+                    var t = msg.topic.Nominate;
+                    $('#X', template).html(format_values(t.X)).parent().show();
+                    $('#Y', template).html(format_values(t.Y)).parent().show();
+                } else {
+                    $('#topic', template).html('<span style="color: red">Unknown</span>');
+                }
+
+                return template;
+            }
+
+            function format_ballot(b) {
+                if (!b) {
+                    return $('<span>None</span><br>');
+                }
+                var template = $($('script[data-template="ballot"]').text());
+                $('#N', template).text(b.N);
+                $('#count', template).text(b.X.length);
+                $.each(b.X, function(idx, val) {
+                    $('#values', template).append($('<li></li>').text(to_hex_str(val).substr(0, 12)));
+                })
+                return template;
+            }
+
+            function format_values(list) {
+                var template = $($('script[data-template="values"]').text());
+                $('#count', template).text(list.length);
+                $.each(list, function(idx, val) {
+                    $('#values', template).append($('<li></li>').text(to_hex_str(val).substr(0, 12)));
+                })
+                return template;
+            }
+
+            function to_hex_str(byteArray) {
+                return Array.from(byteArray, function(byte) {
+                    return ('0' + (byte & 0xFF).toString(16)).slice(-2);
+                }).join('');
+            }
+        </script>
+
+        <script type="text/template" data-template="msg">
+            <div>
+                Sender: <span id="sender"></span><br>
+                Slot index: <span id="slot-index"></span><br>
+                Topic: <span id="topic"></span><br>
+                <div style="display: none">X: <span id="X"></span></div>
+                <div style="display: none">Y: <span id="Y"></span></div>
+                <div style="display: none">B: <span id="B"></span></div>
+                <div style="display: none">P: <span id="P"></span></div>
+                <div style="display: none">PP: <span id="PP"></span></div>
+                <div style="display: none">C: <span id="C"></span></div>
+                <div style="display: none">PN: <span id="PN"></span></div>
+                <div style="display: none">CN: <span id="CN"></span></div>
+                <div style="display: none">HN: <span id="HN"></span></div>
+            </div>
+        </script>
+
+        <script type="text/template" data-template="ballot">
+            <span>
+                Ballot #<span id="N"></span> with <span id="count"></span> values.
+                <ul id="values" class="values-list"></ul>
+            </span>
+        </script>
+
+        <script type="text/template" data-template="values">
+            <span>
+                <span id="count"></span> values:
+                <ul id="values" class="values-list"></ul>
+            </span>
+        </script>
+
+    </head>
+    <body>
+        <div id="nodes-nav"></div>
+        <hr>
+        <h1>General Information</h1>
+        Node: <span id="node-id"></span><br>
+        Slot index: <span id="slot-index"></span><br>
+        Phase: <span id="phase"></span><br>
+        Nominate round: <span id="nominate-round"></span><br>
+        Max priority peers: <span id="max-priority-peers"></span><br>
+
+        <h1>M (message map)</h1>
+        <div id="M"></div>
+
+        <h1>Last issued message</h1>
+        <div id="last-sent-msg">None</div>
+
+        <h1>Nominate-related</h1>
+        <div id="nominate">
+            W: <span id="W"></span>
+            X: <span id="X"></span>
+            Y: <span id="Y"></span>
+            Z: <span id="Z"></span>
+        </div>
+
+        <h1>Prepare and/or Commit related</h1>
+        <div id="prepare-commit">
+            B: <span id="B"></span>
+            P: <span id="P"></span>
+            PP: <span id="PP"></span>
+            H: <span id="H"></span>
+            C: <span id="C"></span>
+        </div>
+    </body>
+</html>

--- a/consensus/scp/viewer/viewer.py
+++ b/consensus/scp/viewer/viewer.py
@@ -1,0 +1,57 @@
+import glob
+import json
+import os
+import sys
+from collections import defaultdict
+from flask import Flask, render_template, redirect, url_for
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    last_slot_index = list(reversed(sorted(app.config['slots_by_index'].keys())))[0]
+    return redirect(url_for('slot', slot_index=last_slot_index))
+
+
+@app.route('/slot/<int:slot_index>')
+def slot(slot_index):
+    available_nodes = list(sorted(app.config['slots_by_index'].get(slot_index, {})))
+    if not available_nodes:
+        return 'No data for slot'
+    return redirect(url_for('slot_node', slot_index=slot_index, node_id=available_nodes[0]))
+
+
+@app.route('/slot/<int:slot_index>/<node_id>')
+def slot_node(slot_index, node_id):
+    slot = app.config['slots_by_index'][slot_index][node_id]
+    return render_template(
+        'slot.html',
+        slot=slot,
+        available_nodes=list(sorted(app.config['slots_by_index'][slot_index].keys())),
+    )
+
+
+if __name__ == '__main__':
+    try:
+        state_jsons_dir = sys.argv[1]
+    except IndexError:
+        print(f'Usage: {sys.argv[0]} [state jsons directory]')
+        sys.exit(1)
+
+    slots_by_node_id = defaultdict(dict)
+    slots_by_index = defaultdict(dict)
+    num_slots = 0
+    for filename in glob.glob(os.path.join(state_jsons_dir, '**/*.json'), recursive=True):
+        data = json.load(open(filename))
+        node_id = data['node_id']['responder_id']
+        slot_index = data['slot_index']
+
+        slots_by_node_id[node_id][slot_index] = data
+        slots_by_index[slot_index][node_id] = data
+        num_slots += 1
+
+    print(f'Loaded total of {num_slots} slot states from {len(slots_by_node_id)} nodes')
+
+    app.config['slots_by_node_id'] = slots_by_node_id
+    app.config['slots_by_index'] = slots_by_index
+    app.run()


### PR DESCRIPTION
Soundtrack of this PR: https://www.youtube.com/watch?v=gVbQrn5BoA4

### Motivation

Yesterday during one of my attempts at running #247 locally the network stopped processing transactions, and ballot numbers were increasing without completing. At that point I believe it would've been useful for me to see the state of each scp `Slot` for all of the nodes to try and make sense as to why they are not moving to externalize a slot. This PR is an attempt at providing a solution for this debugging challenge.

### In this PR
* We already have code that writes each processed message a node goes through in a given slot to a file that can then be looked at. This PR adds a per-slot file that contains all the state inside a given `Slot`. Hopefully this would help with understanding network stalls in the future.
* In addition to the per-slot state file I have included a simple tool to view the data, otherwise it is impossible to get anything useful out of it. Here's an example screenshot of it:
![image](https://user-images.githubusercontent.com/1485066/88862762-ec2ed780-d1b5-11ea-8f92-6fbec8cc64dd.png)

If we find this to be useful we could improve on it.

I have not tried slamming this on a k8 network, but it slams fine locally.

### Future Work
* Writing the slot state currently involves some liberal usage of `.clone()` which is sub-optimal. We could change `scp::Slot` to simply store a `scp::SlotState` object and operate on that, which would prevent a bunch of these clone operations. Its unclear if this is going to make any noticeable difference, or if long-term we'd want to continue maintaining any of the functionality in this PR at all so for now I think this is good enough.

