### PR TITLE
fix incorrect versions in a few crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-play"
-version = "0.0.1"
+version = "0.5.0"
 dependencies = [
  "mc-common",
  "mc-consensus-scp",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-from-archive"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "mc-api",
  "mc-common",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "grpcio",
  "hex 0.4.2",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-mirror"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "generic-array 0.13.2",
  "prost",

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
  "mc-crypto-keys 0.5.0",
  "mc-crypto-sig 0.5.0",
  "mc-util-from-random 0.5.0",
- "mc-util-repr-bytes 0.1.0",
+ "mc-util-repr-bytes 0.5.0",
  "mc-util-serial 0.5.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -860,7 +860,7 @@ dependencies = [
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-digestible 0.5.0",
  "mc-util-from-random 0.5.0",
- "mc-util-repr-bytes 0.1.0",
+ "mc-util-repr-bytes 0.5.0",
  "mc-util-serial 0.5.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -896,7 +896,7 @@ dependencies = [
  "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-keys 0.5.0",
  "mc-util-from-random 0.5.0",
- "mc-util-repr-bytes 0.1.0",
+ "mc-util-repr-bytes 0.5.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1078,7 +1078,7 @@ dependencies = [
  "mc-crypto-keys 0.5.0",
  "mc-crypto-rand 0.5.0",
  "mc-util-from-random 0.5.0",
- "mc-util-repr-bytes 0.1.0",
+ "mc-util-repr-bytes 0.5.0",
  "mc-util-serial 0.5.0",
  "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
@@ -1120,7 +1120,7 @@ dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-util-repr-bytes 0.1.0",
+ "mc-util-repr-bytes 0.5.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",

--- a/consensus/scp/play/Cargo.toml
+++ b/consensus/scp/play/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-play"
-version = "0.0.1"
+version = "0.5.0"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/from-archive/Cargo.toml
+++ b/ledger/from-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-from-archive"
-version = "0.1.0"
+version = "0.5.0"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-json"
-version = "0.1.0"
+version = "0.5.0"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/mobilecoind-mirror/Cargo.toml
+++ b/mobilecoind-mirror/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-mirror"
-version = "0.1.0"
+version = "0.5.0"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-repr-bytes"
-version = "0.1.0"
+version = "0.5.0"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
### Motivation

All of our crates' versions should be 0.5.0. That was not the case before this PR.

### In this PR
* Fixing some crates version to be 0.5.0
