### PR TITLE
Test reporting in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ commands:
             cargo --version
             rustup --version
             sccache --version
+            command -v jq >/dev/null && jq --version
 
   env_setup:
     description: Environment Setup
@@ -251,6 +252,7 @@ commands:
       - restore-cargo-cache
       - install-ci-deps
       - env_setup
+      - print_versions
       - enable_sccache
       # Cache is only saved when building from master. We don't restore sccache on
       # master so that the cache is clean when saved.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ version: 2.1
 
 defaults:
   builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_12
+
   default-environment: &default-environment
     IAS_MODE: DEV
     SGX_MODE: SW
@@ -258,10 +259,6 @@ commands:
           steps: [ restore-sccache-cache ]
       - prefetch-cargo-deps
 
-  post-build:
-    steps:
-      - record-sccache-cache-stats
-
   run-tests:
     parameters:
       test_command:
@@ -274,6 +271,10 @@ commands:
             << parameters.test_command >> -- -Z unstable-options --format json --report-time \
               | tee /tmp/test-results.json
             cat /tmp/test-results.json | cargo2junit > /tmp/test-results.xml || true
+
+  post-build:
+    steps:
+      - record-sccache-cache-stats
 
   post-test:
     steps:
@@ -467,7 +468,7 @@ jobs:
       - prepare-for-build:
           os: macos
       - run:
-          name: Cargo check (SW/IAS dev)
+          name: Cargo check
           command: |
             cargo check --frozen --target "$HOST_TARGET_TRIPLE" --workspace \
               --exclude mc-attest-untrusted \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,19 +277,18 @@ commands:
             # Note: Using curly braces ensures that the conversion is run even if the tests fail,
             # while still allowing the exit code from the tests to be propagated. Using `tee` to
             # pipe the output to a file before converting ensures that the tests are not
-            # interrupted if conversion fails. The last statement in the curly braces is `true` so
-            # that if the conversion can fails, the step as a whole does not fail. This is
-            # necessary because the conversion tool must parse all test output, including log
-            # output, in order to parse the test results, and unfortunately Cargo does not always
-            # output the test results in such a way that is cleanly parsable.
+            # interrupted if conversion fails. `|| true` is added so that the test as a whole does
+            # not fail even if conversion fails. This is especially necessary because the
+            # conversion tool must parse all test output, including log output, in order to parse
+            # the test results, and unfortunately Cargo does not always output the test results in
+            # such a way that is cleanly parsable.
             << parameters.test_command >> -- \
                 -Z unstable-options --format json --report-time \
               | {
                   tee /tmp/test-results/output.log
                   cat /tmp/test-results/output.log \
-                    | cargo2junit \
-                    > /tmp/test-results/results.xml
-                  true
+                    | cargo2junit > /tmp/test-results/results.xml \
+                    || true
                 }
 
   post-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ commands:
     parameters:
       test_command:
         type: string
-        default: cargo test --frozen --target "$HOST_TARGET_TRIPLE" --tests
+        default: cargo test --frozen --target "$HOST_TARGET_TRIPLE" --no-fail-fast --tests
     steps:
       - run:
           name: Run all tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,9 +268,27 @@ commands:
       - run:
           name: Run all tests
           command: |
-            << parameters.test_command >> -- -Z unstable-options --format json --report-time \
-              | tee /tmp/test-results.json
-            cat /tmp/test-results.json | cargo2junit > /tmp/test-results.xml || true
+            mkdir -p /tmp/test-results
+
+            # Run tests, then convert the cargo json results into junit xml format.
+            #
+            # Note: Using curly braces ensures that the conversion is run even if the tests fail,
+            # while still allowing the exit code from the tests to be propagated. Using `tee` to
+            # pipe the output to a file before converting ensures that the tests are not
+            # interrupted if conversion fails. The last statement in the curly braces is `true` so
+            # that if the conversion can fails, the step as a whole does not fail. This is
+            # necessary because the conversion tool must parse all test output, including log
+            # output, in order to parse the test results, and unfortunately Cargo does not always
+            # output the test results in such a way that is cleanly parsable.
+            << parameters.test_command >> -- \
+                -Z unstable-options --format json --report-time \
+              | {
+                  tee /tmp/test-results/output.log
+                  cat /tmp/test-results/output.log \
+                    | cargo2junit \
+                    > /tmp/test-results/results.xml
+                  true
+                }
 
   post-build:
     steps:
@@ -279,9 +297,9 @@ commands:
   post-test:
     steps:
       - store_test_results:
-          path: /tmp/test-results.xml
+          path: /tmp/test-results
       - store_artifacts:
-          path: /tmp/test-results.xml
+          path: /tmp/test-results
 
   check-dirty-git:
     steps:


### PR DESCRIPTION
### Motivation

CircleCI has a feature that allows a project to display test results in the Tests tab for a given CI run. We're reporting our test results, but not doing so in the way that CircleCI expects. This PR addresses that, as well as a number of edge cases that cause the tests to not be fully reported.

### In this PR
* Calls `store_test_results` with the directory containing the tests results, instead of the test result file itself. See https://support.circleci.com/hc/en-us/articles/360021624194-Test-summary-troubleshooting
* Ensures that test results get converted to junit format on test failure (the bash script that runs the tests is configured with `-e`, so curly brackets have been added to make sure the command for converting gets executed prior to bash exiting the script early)
* Version printing of various tools during CI was mistakenly removed. This adds it back in, along with printing the jq version.
* Fail-fast is now disabled for tests during CI so that CI can report all the failed tests, not just the first one. There is a tradeoff between showing the test failure sooner and showing all the test failures. In my opinion, fail fast is most useful for local development, where development speed is more important, and that showing all failed tests during CI runs is more important than showing that the CI run has failed sooner.

### Future Work
* There is currently a bug with Rust's libtest where log output that gets printed to stdout from a thread other than the main thread is not captured by libtest's stdout log capturing mechanism. This causes a problem with test reporting because the logs are not saved by Rust in a way that allows them to be show later as part of a particular test run, and additionally, it makes it so that the test report parsing tool has to separate out the json log results from the application log printing, which is prone to error. Additionally, sometimes stdout flushing can cause the json log results to get intermingled with the application log output, thus resulting in corrupted test reports. The bug report for this issue can be found here: https://github.com/rust-lang/rust/issues/42474. At present the only easy workaround is to disable all application logging, but this is not a viable solution since it would make debugging failed tests on CI significantly more difficult.

### Demo

Here is what the Tests tab of a CI run currently looks like:

<img width="520" alt="Screen Shot 2020-07-31 at 11 41 22 AM" src="https://user-images.githubusercontent.com/192120/89066867-0cc87000-d323-11ea-8e39-01960eae7375.png">

Here is what the Tests tab of a successful CI run will look like after this PR:

<img width="510" alt="Screen Shot 2020-07-31 at 11 41 04 AM" src="https://user-images.githubusercontent.com/192120/89066819-f6baaf80-d322-11ea-9ae8-6e020ab21286.png">

Here is what the Tests tab of a failed CI run will look like after this PR:

<img width="1044" alt="Screen Shot 2020-07-31 at 11 42 18 AM" src="https://user-images.githubusercontent.com/192120/89066831-fb7f6380-d322-11ea-8ea8-6bf3c7152ebf.png">
