### PR TITLE
Add fog params to account key generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3293,7 +3293,7 @@ version = "0.5.0"
 name = "mc-util-keyfile"
 version = "0.5.0"
 dependencies = [
- "hex 0.3.2",
+ "hex 0.4.2",
  "mc-account-keys",
  "mc-crypto-rand",
  "mc-util-from-random",

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -25,7 +25,7 @@ mc-crypto-rand = { path = "../../crypto/rand" }
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-serial = { path = "../../util/serial", features = ["std"] }
 
-hex = "0.3"
+hex = "0.4"
 rand = "0.7"
 rand_hc = "0.2.0"
 serde = "1.0"

--- a/util/keyfile/src/bin/sample_keys_main.rs
+++ b/util/keyfile/src/bin/sample_keys_main.rs
@@ -36,7 +36,7 @@ struct Config {
 
 fn parse_hex_to_vec(src: &str) -> Result<VecBytes, String> {
     let v: Vec<u8> = Vec::from_hex(src)
-        .map_err(|e| format!("Could not get Vec from hex {}: {:?}", src))
+        .map_err(|e| format!("Could not get Vec from hex {}: {:?}", src, e))
         .into_iter()
         .flatten()
         .collect();

--- a/util/keyfile/src/bin/sample_keys_main.rs
+++ b/util/keyfile/src/bin/sample_keys_main.rs
@@ -1,13 +1,25 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
-use std::path::PathBuf;
+use hex::FromHex;
+use std::{path::PathBuf, vec::Vec};
 use structopt::StructOpt;
+
+// Hack to work around Vec special handling in structopt
+type VecBytes = Vec<u8>;
 
 #[derive(Debug, StructOpt)]
 struct Config {
-    /// FogURL
-    #[structopt(short, long)]
-    pub acct: Option<String>,
+    /// Fog Report URL
+    #[structopt(long)]
+    pub fog_report_url: Option<String>,
+
+    /// Fog Report ID
+    #[structopt(long)]
+    pub fog_report_id: Option<String>,
+
+    /// Fog Authority Fingerprint, hex encoded
+    #[structopt(long, parse(try_from_str=parse_hex_to_vec))]
+    pub fog_authority_fingerprint: Option<VecBytes>,
 
     /// Number of user keys to generate.
     #[structopt(short, long, default_value = "10")]
@@ -22,6 +34,16 @@ struct Config {
     pub seed: Option<[u8; 32]>,
 }
 
+fn parse_hex_to_vec(src: &str) -> Result<VecBytes, String> {
+    let v: Vec<u8> = Vec::from_hex(src)
+        .map_err(|_e| format!("Could not get Vec from hex {}", src))
+        .into_iter()
+        .flatten()
+        .collect();
+
+    Ok(v)
+}
+
 fn main() {
     let config = Config::from_args();
 
@@ -30,12 +52,14 @@ fn main() {
         .clone()
         .unwrap_or_else(|| std::env::current_dir().unwrap().join("keys"));
 
-    println!("Writing to {:?}", path);
+    println!("Writing {} keys to {:?}", config.num, path);
 
     mc_util_keyfile::keygen::write_default_keyfiles(
         path,
         config.num,
-        config.acct.as_deref(),
+        config.fog_report_url.as_deref(),
+        config.fog_report_id.as_deref(),
+        config.fog_authority_fingerprint.as_deref(),
         config.seed.unwrap_or(mc_util_keyfile::keygen::DEFAULT_SEED),
     )
     .unwrap();

--- a/util/keyfile/src/bin/sample_keys_main.rs
+++ b/util/keyfile/src/bin/sample_keys_main.rs
@@ -36,7 +36,7 @@ struct Config {
 
 fn parse_hex_to_vec(src: &str) -> Result<VecBytes, String> {
     let v: Vec<u8> = Vec::from_hex(src)
-        .map_err(|_e| format!("Could not get Vec from hex {}", src))
+        .map_err(|e| format!("Could not get Vec from hex {}: {:?}", src))
         .into_iter()
         .flatten()
         .collect();

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -42,6 +42,8 @@ pub fn write_default_keyfiles<P: AsRef<Path>>(
     path: P,
     num_accounts: usize,
     fog_url: Option<&str>,
+    fog_report_id: Option<&str>,
+    fog_authority_fingerprint: Option<&[u8]>,
     seed: [u8; 32],
 ) -> Result<(), std::io::Error> {
     let mut keys_rng: FixedRng = SeedableRng::from_seed(seed);
@@ -51,8 +53,8 @@ pub fn write_default_keyfiles<P: AsRef<Path>>(
         let root_id = RootIdentity::random_with_fog(
             &mut keys_rng,
             fog_url.unwrap_or(&""),
-            Default::default(),
-            Default::default(),
+            fog_report_id.unwrap_or(Default::default()),
+            fog_authority_fingerprint.unwrap_or(Default::default()),
         );
 
         write_keyfiles(path.as_ref(), &keyfile_name(i), &root_id)?;
@@ -110,8 +112,26 @@ mod testing {
         let dir2 = TempDir::new("test").unwrap();
 
         let fqdn = "example.com".to_string();
-        write_default_keyfiles(&dir1, 10, Some(&fqdn), DEFAULT_SEED).unwrap();
-        write_default_keyfiles(&dir2, 10, Some(&fqdn), DEFAULT_SEED).unwrap();
+        let fog_report_id = ""; // FIXME
+        let fog_authority_fingerprint = "test"; // FIXME
+        write_default_keyfiles(
+            &dir1,
+            10,
+            Some(&fqdn),
+            fog_report_id,
+            fog_authority_fingerprint,
+            DEFAULT_SEED,
+        )
+        .unwrap();
+        write_default_keyfiles(
+            &dir2,
+            10,
+            Some(&fqdn),
+            fog_report_id,
+            fog_authority_fingerprint,
+            DEFAULT_SEED,
+        )
+        .unwrap();
 
         {
             let pub1 = read_default_pubfiles(&dir1).unwrap();
@@ -132,12 +152,12 @@ mod testing {
     }
 
     #[test]
-    fn test_default_generation_no_acct() {
+    fn test_default_generation_no_fog_url() {
         let dir1 = TempDir::new("test").unwrap();
         let dir2 = TempDir::new("test").unwrap();
 
-        write_default_keyfiles(&dir1, 10, None, DEFAULT_SEED).unwrap();
-        write_default_keyfiles(&dir2, 10, None, DEFAULT_SEED).unwrap();
+        write_default_keyfiles(&dir1, 10, None, None, None, DEFAULT_SEED).unwrap();
+        write_default_keyfiles(&dir2, 10, None, None, None, DEFAULT_SEED).unwrap();
 
         {
             let pub1 = read_default_pubfiles(&dir1).unwrap();
@@ -161,7 +181,7 @@ mod testing {
     fn test_hard_coded_root_entropy() {
         let dir1 = TempDir::new("test").unwrap();
 
-        write_default_keyfiles(&dir1, 10, None, DEFAULT_SEED).unwrap();
+        write_default_keyfiles(&dir1, 10, None, None, None, DEFAULT_SEED).unwrap();
 
         {
             let bin1 = read_default_root_entropies(&dir1).unwrap();

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -53,8 +53,8 @@ pub fn write_default_keyfiles<P: AsRef<Path>>(
         let root_id = RootIdentity::random_with_fog(
             &mut keys_rng,
             fog_url.unwrap_or(&""),
-            fog_report_id.unwrap_or(Default::default()),
-            fog_authority_fingerprint.unwrap_or(Default::default()),
+            fog_report_id.unwrap_or_default(),
+            fog_authority_fingerprint.unwrap_or_default(),
         );
 
         write_keyfiles(path.as_ref(), &keyfile_name(i), &root_id)?;

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -112,14 +112,14 @@ mod testing {
         let dir2 = TempDir::new("test").unwrap();
 
         let fqdn = "example.com".to_string();
-        let fog_report_id = ""; // FIXME
-        let fog_authority_fingerprint = "test"; // FIXME
+        let fog_report_id = "1";
+        let fog_authority_fingerprint = [18, 52, 18, 52];
         write_default_keyfiles(
             &dir1,
             10,
             Some(&fqdn),
-            fog_report_id,
-            fog_authority_fingerprint,
+            Some(fog_report_id),
+            Some(&fog_authority_fingerprint),
             DEFAULT_SEED,
         )
         .unwrap();
@@ -127,8 +127,8 @@ mod testing {
             &dir2,
             10,
             Some(&fqdn),
-            fog_report_id,
-            fog_authority_fingerprint,
+            Some(fog_report_id),
+            Some(&fog_authority_fingerprint),
             DEFAULT_SEED,
         )
         .unwrap();


### PR DESCRIPTION
Soundtrack of this PR: [Dark Trance Cello](https://www.youtube.com/watch?v=5FT5jodwq6U)

### Motivation

We added additional fog params to the Account Key, and this PR plumbs them into our CD tools.

### In this PR
* Updates mc-util-keyfile sample-keys to take fog params as configs and write keyfiles with this data.

[FOG-138](https://mobilecoin.atlassian.net/browse/FOG-138) 
