### PR TITLE
Used fixed64 in transaction amount

### DIFF
--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -173,7 +173,7 @@ message Amount {
     CompressedRistretto commitment = 1;
 
     // `masked_value = value XOR_8 Blake2B("value_mask" || shared_secret)`
-    uint64 masked_value = 2;
+    fixed64 masked_value = 2;
 }
 
 message EncryptedFogHint {

--- a/transaction/core/src/amount.rs
+++ b/transaction/core/src/amount.rs
@@ -39,7 +39,7 @@ pub struct Amount {
     pub commitment: CompressedCommitment,
 
     /// `masked_value = value XOR_8 Blake2B(value_mask | shared_secret)`
-    #[prost(uint64, required, tag = "2")]
+    #[prost(fixed64, required, tag = "2")]
     pub masked_value: u64,
 }
 


### PR DESCRIPTION
(1) Using variable size fields in transaction data means that the
protobuf size reflects something about the numbers in the data,
or which transaction it is, even in encrypted form.
(2) This data is uniformly distributed 64 bit numbers, but the varint
encoding is optimized for small numbers, and is less efficient for
uniformly distributed u64's than the fixed64 encoding. It pays on the
representation size of the large u64's to make the small u64 values
have a shorter representation. But that isn't beneficial for this
data.