### PR TITLE
downgrade noisy log message

### DIFF
--- a/consensus/service/src/byzantine_ledger.rs
+++ b/consensus/service/src/byzantine_ledger.rs
@@ -487,7 +487,7 @@ impl<
                     .ledger_sync_service
                     .attempt_ledger_sync(&self.network_state, blocks_per_attempt)
                 {
-                    log::error!(self.logger, "Could not sync ledger: {:?}", err);
+                    log::warn!(self.logger, "Could not sync ledger: {:?}", err);
 
                     // The next time we attempt to sync is a linear back-off based on how many
                     // attempts we've done so far, capped at 60 seconds.

--- a/ledger/sync/src/ledger_sync_service.rs
+++ b/ledger/sync/src/ledger_sync_service.rs
@@ -609,7 +609,7 @@ fn get_block_contents<TF: TransactionsFetcher + 'static>(
 
                                 Err(err) => {
                                     // Log
-                                    log::error!(
+                                    log::info!(
                                         thread_logger,
                                         "Worker {} failed getting transactions for block {}: {}",
                                         worker_num,


### PR DESCRIPTION
### Motivation

We currently have two noisy log messages:
![image](https://user-images.githubusercontent.com/1485066/89221842-cecc8580-d588-11ea-81d3-a250b86f0f61.png)

The first one happens once a minute as ByzantineLedger tries to perform catch up. If the network has been upgraded to a new version and a node wasn't, that node is going to stay behind indefinitely. Since the code will keep retrying once a minute, there's no reason for this to reach Sentry.

The second one is an intermittent failure when trying to fetch transactions from S3. Since the code that tries to fetches them retries fetching until it succeeds (or a timeout is exceeded), there's no need to treat these intermittent failures as errors. It's nice to know they happen, but they should not find their way to Sentry.
221336-f66f1e00-d587-11ea-8218-ecb96d91811c.png)


### In this PR
* Downgrading a noisy log messages from error to info and warning based on their actual severity.
