### PR TITLE
Revert "Used fixed64 in transaction amount (#333)"

### DIFF
--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -173,7 +173,7 @@ message Amount {
     CompressedRistretto commitment = 1;
 
     // `masked_value = value XOR_8 Blake2B("value_mask" || shared_secret)`
-    fixed64 masked_value = 2;
+    uint64 masked_value = 2;
 }
 
 message EncryptedFogHint {

--- a/transaction/core/src/amount.rs
+++ b/transaction/core/src/amount.rs
@@ -39,7 +39,7 @@ pub struct Amount {
     pub commitment: CompressedCommitment,
 
     /// `masked_value = value XOR_8 Blake2B(value_mask | shared_secret)`
-    #[prost(fixed64, required, tag = "2")]
+    #[prost(uint64, required, tag = "2")]
     pub masked_value: u64,
 }
 


### PR DESCRIPTION
This reverts commit ec42f1008f9aa45c3db85b2404369a4a5157cdd4.

This avoids a breaking ledger change which would be annoying to deal with right now