### PR TITLE
WIP: Try to make an aes-gcm that is constant time with respect to mac check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array 0.14.3",
+]
+
+[[package]]
 name = "aes"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,11 +41,23 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54e6fb62c3640759142eb73015f57eece23832fde0a7ccd8be17d7ccbd01f21c"
 dependencies = [
- "aead",
+ "aead 0.2.0",
  "aes",
- "ghash",
+ "ghash 0.2.3",
  "subtle 2.2.3",
  "zeroize 1.1.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
+dependencies = [
+ "aead 0.3.2",
+ "block-cipher",
+ "ghash 0.3.0",
+ "subtle 2.2.3",
 ]
 
 [[package]]
@@ -303,6 +324,15 @@ dependencies = [
  "byte-tools",
  "byteorder",
  "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-cipher"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
+dependencies = [
+ "generic-array 0.14.3",
 ]
 
 [[package]]
@@ -1202,6 +1232,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
+dependencies = [
+ "typenum",
+ "version_check 0.9.1",
+]
+
+[[package]]
 name = "genio"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,7 +1267,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f0930ed19a7184089ea46d2fedead2f6dc2b674c5db4276b7da336c7cd83252"
 dependencies = [
- "polyval",
+ "polyval 0.3.3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
+dependencies = [
+ "polyval 0.4.0",
 ]
 
 [[package]]
@@ -1946,8 +1995,8 @@ dependencies = [
 name = "mc-attest-ake"
 version = "0.5.0"
 dependencies = [
- "aead",
- "aes-gcm",
+ "aead 0.2.0",
+ "aes-gcm 0.3.2",
  "digest",
  "failure",
  "mc-attest-core",
@@ -1969,7 +2018,7 @@ dependencies = [
 name = "mc-attest-api"
 version = "0.5.0"
 dependencies = [
- "aead",
+ "aead 0.2.0",
  "cargo-emit",
  "digest",
  "futures",
@@ -2111,7 +2160,7 @@ dependencies = [
 name = "mc-connection"
 version = "0.5.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.3.2",
  "failure",
  "grpcio",
  "mc-attest-ake",
@@ -2384,8 +2433,8 @@ dependencies = [
 name = "mc-crypto-ake-enclave"
 version = "0.5.0"
 dependencies = [
- "aead",
- "aes-gcm",
+ "aead 0.2.0",
+ "aes-gcm 0.3.2",
  "digest",
  "failure",
  "mc-attest-ake",
@@ -2409,16 +2458,26 @@ dependencies = [
 name = "mc-crypto-box"
 version = "0.5.0"
 dependencies = [
- "aead",
- "aes-gcm",
+ "aead 0.2.0",
+ "aes-gcm 0.3.2",
  "blake2",
  "digest",
  "failure",
  "hkdf",
+ "mc-crypto-ct-aead",
  "mc-crypto-keys",
  "mc-util-from-random",
  "mc-util-test-helper",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "mc-crypto-ct-aead"
+version = "0.5.0"
+dependencies = [
+ "aes-gcm 0.6.0",
+ "block-cipher",
+ "subtle 2.2.3",
 ]
 
 [[package]]
@@ -2489,7 +2548,7 @@ dependencies = [
 name = "mc-crypto-message-cipher"
 version = "0.5.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.3.2",
  "failure",
  "generic-array 0.12.3",
  "mc-util-serial",
@@ -2503,8 +2562,8 @@ dependencies = [
 name = "mc-crypto-noise"
 version = "0.5.0"
 dependencies = [
- "aead",
- "aes-gcm",
+ "aead 0.2.0",
+ "aes-gcm 0.3.2",
  "digest",
  "failure",
  "generic-array 0.12.3",
@@ -2722,31 +2781,6 @@ dependencies = [
  "mc-common",
  "mc-mobilecoind-api",
  "protobuf",
- "rocket",
- "rocket_contrib",
- "serde",
- "serde_derive",
- "structopt",
-]
-
-[[package]]
-name = "mc-mobilecoind-mirror"
-version = "0.5.0"
-dependencies = [
- "cargo-emit",
- "futures",
- "grpcio",
- "hex 0.4.2",
- "mc-api",
- "mc-common",
- "mc-mobilecoind-api",
- "mc-mobilecoind-json",
- "mc-util-build-grpc",
- "mc-util-build-script",
- "mc-util-grpc",
- "mc-util-uri",
- "protobuf",
- "rand 0.7.3",
  "rocket",
  "rocket_contrib",
  "serde",
@@ -3852,7 +3886,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec3341498978de3bfd12d1b22f1af1de22818f5473a11e8a6ef997989e3a212"
 dependencies = [
  "cfg-if",
- "universal-hash",
+ "universal-hash 0.3.0",
+]
+
+[[package]]
+name = "polyval"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
+dependencies = [
+ "cfg-if",
+ "universal-hash 0.4.0",
 ]
 
 [[package]]
@@ -5724,6 +5768,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df0c900f2f9b4116803415878ff48b63da9edb268668e08cf9292d7503114a01"
 dependencies = [
  "generic-array 0.12.3",
+ "subtle 2.2.3",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+dependencies = [
+ "generic-array 0.14.3",
  "subtle 2.2.3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "consensus/scp/play",
     "consensus/service",
     "crypto/box",
+    "crypto/ct-aead",
     "crypto/digestible",
     "crypto/keys",
     "crypto/noise",

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -9,6 +9,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "aes"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +36,17 @@ dependencies = [
  "ghash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ghash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -157,6 +176,14 @@ dependencies = [
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-cipher"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -409,6 +436,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "genio"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +468,14 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "polyval 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ghash"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "polyval 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -813,8 +857,18 @@ dependencies = [
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mc-crypto-ct-aead 0.5.0",
  "mc-crypto-keys 0.5.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mc-crypto-ct-aead"
+version = "0.5.0"
+dependencies = [
+ "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1229,6 +1283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "universal-hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1636,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "url"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1662,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "version_check"
 version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1683,8 +1760,10 @@ dependencies = [
 
 [metadata]
 "checksum aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4cf01b9b56e767bb57b94ebf91a58b338002963785cdd7013e21c0d4679471e4"
+"checksum aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 "checksum aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
 "checksum aes-gcm 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4001f31800fc9b8c774728f82c7348f4f91474afd38c12a0e7dfa8303ae2dbd6"
+"checksum aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
 "checksum aes-soft 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
 "checksum aesni 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
 "checksum aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
@@ -1701,6 +1780,7 @@ dependencies = [
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+"checksum block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum bulletproofs 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "69e6731420b125f0300427b4f7d146a7c161b02801c126bed8b66c8e1340f574"
@@ -1730,9 +1810,11 @@ dependencies = [
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
+"checksum generic-array 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)" = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
 "checksum genio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4e26859a808ffa83a83f20c7e3c9366afea91edae637a6ac203051885882dc8"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum ghash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0930ed19a7184089ea46d2fedead2f6dc2b674c5db4276b7da336c7cd83252"
+"checksum ghash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum half 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20d6a47d6e4b8559729f58287efa8e6f767e603c068fea7a5e4d9f1cebe2bebb"
 "checksum hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
@@ -1763,6 +1845,7 @@ dependencies = [
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum polyval 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ec3341498978de3bfd12d1b22f1af1de22818f5473a11e8a6ef997989e3a212"
+"checksum polyval 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
 "checksum prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)" = "<none>"
@@ -1808,9 +1891,11 @@ dependencies = [
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum universal-hash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df0c900f2f9b4116803415878ff48b63da9edb268668e08cf9292d7503114a01"
+"checksum universal-hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -5,13 +5,15 @@ authors = ["MobileCoin"]
 edition = "2018"
 
 [dependencies]
+mc-crypto-keys = { path = "../keys", default-features = false }
+mc-crypto-ct-aead = { path = "../ct-aead" }
+
 aead = "0.2"
 aes-gcm = { version = "0.3.0", default-features = false }
 blake2 = { version = "0.8", default-features = false }
 digest = { version = "0.8" }
 failure = { version = "0.1.5", default-features = false }
 hkdf = { version = "0.8.0", default-features = false }
-mc-crypto-keys = { path = "../keys", default-features = false }
 rand_core = { version = "0.5", default-features = false }
 
 [dev_dependencies]

--- a/crypto/box/src/traits.rs
+++ b/crypto/box/src/traits.rs
@@ -52,16 +52,24 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
     ///
     /// Meant to mirror aead::decrypt_in_place_detached
     ///
+    /// NOTE: Meant to run in constant-time even if the mac-check fails.
+    ///
     /// Fails if:
     /// - Curvepoint cannot be decoded
     /// - MAC check fails
     /// - Anything is wrong with the footer (magic bytes? version code?)
+    ///
+    /// Returns:
+    /// - true if decryption succeeded, buffer contains plaintext
+    /// - false if mac check failed, buffer contains failed plaintext.
+    ///   Buffer SHOULD be zeroized to avoid attacks
+    /// - error if anything else is wrong
     fn decrypt_in_place_detached(
         &self,
         key: &KexAlgo::Private,
         footer: &GenericArray<u8, Self::FooterSize>,
         buffer: &mut [u8],
-    ) -> Result<(), Error>;
+    ) -> Result<bool, Error>;
 
     // Provided functions
     // These functions consume and produce "cryptograms" where the footer bytes
@@ -82,13 +90,14 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
         Ok(result)
     }
 
-    /// Decrypt a slice pointing to the cryptogram, returning a Vec<u8> plaintext.
+    /// Decrypt a slice pointing to the cryptogram, returning a status and a Vec<u8> plaintext.
+    /// If status is false then mac check failed and plaintext should be discarded.
     ///
     /// Meant to mirror aead::decrypt
-    fn decrypt(&self, key: &KexAlgo::Private, cryptogram: &[u8]) -> Result<Vec<u8>, Error> {
+    fn decrypt(&self, key: &KexAlgo::Private, cryptogram: &[u8]) -> Result<(bool, Vec<u8>), Error> {
         let mut result = cryptogram.to_vec();
-        self.decrypt_in_place(key, &mut result)?;
-        Ok(result)
+        let status = self.decrypt_in_place(key, &mut result)?;
+        Ok((status, result))
     }
 
     /// Encrypt a buffer, extending the buffer to place the footer at the end.
@@ -115,6 +124,12 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
     /// - The buffer is too short to be interpretted
     /// - The curvepoint cannot be deserialized
     /// - The mac check fails
+    ///
+    /// Returns:
+    /// - true if decryption succeeded, buffer contains plaintext
+    /// - false if mac check failed, buffer contains failed plaintext.
+    ///   Buffer SHOULD be zeroized to avoid attacks
+    /// - error if anything else is wrong
     fn decrypt_in_place(
         &self,
         key: &KexAlgo::Private,
@@ -127,9 +142,10 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
         let footer_pos = cryptogram.len() - Self::FooterSize::USIZE;
         let (ciphertext, footer) = cryptogram.as_mut().split_at_mut(footer_pos);
         // Note: this is modifying the cryptogram via the mutable slice ciphertext
-        self.decrypt_in_place_detached(key, GenericArray::from_slice(footer), ciphertext)?;
+        let status =
+            self.decrypt_in_place_detached(key, GenericArray::from_slice(footer), ciphertext)?;
         cryptogram.truncate(footer_pos);
-        Ok(())
+        Ok(status)
     }
 
     /// Encrypt a fixed-length buffer, producing a fixed-length buffer containing
@@ -156,14 +172,17 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
     /// the plaintext in a fixed-length buffer.
     ///
     /// A non-allocating counterpart to decrypt
+    ///
+    /// Returns:
+    /// - true if decryption succeeded, buffer contains plaintext
+    /// - false if mac check failed, buffer contains failed plaintext.
+    ///   Buffer SHOULD be zeroized to avoid attacks
+    /// - error if anything else is wrong
     fn decrypt_fixed_length<L>(
         &self,
         key: &KexAlgo::Private,
         cryptogram: &GenericArray<u8, L>,
-    ) -> Result<GenericArray<u8, Diff<L, Self::FooterSize>>, Error>
-    // generic_array/typenum can be really annoying...
-    // we have to convince it that not only is L - FooterSize a number,
-    // and an array length, but also that L - (L - FooterSize) is FooterSize
+    ) -> Result<(bool, GenericArray<u8, Diff<L, Self::FooterSize>>), Error>
     where
         L: ArrayLength<u8>
             + Sub<Self::FooterSize>
@@ -172,7 +191,7 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
     {
         let (mut ciphertext, footer) =
             Split::<u8, Diff<L, Self::FooterSize>>::split(cryptogram.clone());
-        self.decrypt_in_place_detached(key, &footer, ciphertext.as_mut_slice())?;
-        Ok(ciphertext)
+        let status = self.decrypt_in_place_detached(key, &footer, ciphertext.as_mut_slice())?;
+        Ok((status, ciphertext))
     }
 }

--- a/crypto/ct-aead/Cargo.toml
+++ b/crypto/ct-aead/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mc-crypto-ct-aead"
+version = "0.5.0"
+authors = ["MobileCoin"]
+edition = "2018"
+
+[dependencies]
+aes-gcm = { version = "0.6", default-features = false }
+block-cipher = "0.7"
+subtle = { version = "2", default-features = false }

--- a/crypto/ct-aead/README.md
+++ b/crypto/ct-aead/README.md
@@ -1,0 +1,10 @@
+ct-aead
+========
+
+This crate contains a trait extending the suite of Aead traits offered by
+https://github.com/RustCrypto/traits
+
+This is needed to offer a decrypt interface with an additional constant-time property:
+Timings, code paths, and data paths are the same whether or not the mac check succeeds.
+
+It also implements this trait on the AesGcm AEAD's from the aes-gcm crate.

--- a/crypto/ct-aead/src/aes_impl.rs
+++ b/crypto/ct-aead/src/aes_impl.rs
@@ -1,0 +1,41 @@
+use crate::CtAeadDecrypt;
+
+use aes_gcm::{AesGcm, Tag, A_MAX, C_MAX};
+use block_cipher::{
+    consts::{U0, U16},
+    generic_array::{ArrayLength, GenericArray},
+    Block, BlockCipher,
+};
+
+impl<Aes, NonceSize> CtAeadDecrypt for AesGcm<Aes, NonceSize>
+where
+    Aes: BlockCipher<BlockSize = U16>,
+    Aes::ParBlocks: ArrayLength<Block<Aes>>,
+    NonceSize: ArrayLength<u8>,
+{
+    type NonceSize = NonceSize;
+    type TagSize = U16;
+    type CiphertextOverhead = U0;
+
+    fn ct_decrypt_in_place_detached(
+        &self,
+        nonce: &GenericArray<u8, NonceSize>,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+        tag: &Tag,
+    ) -> bool {
+        if buffer.len() as u64 > C_MAX || associated_data.len() as u64 > A_MAX {
+            return false;
+        }
+
+        // TODO(tarcieri): interleave encryption with GHASH
+        // See: <https://github.com/RustCrypto/AEADs/issues/74>
+        let mut expected_tag = self.compute_tag(associated_data, buffer);
+        let mut ctr = self.init_ctr(nonce);
+        ctr.apply_keystream(&self.cipher, expected_tag.as_mut_slice());
+        ctr.apply_keystream(&self.cipher, buffer);
+
+        use subtle::ConstantTimeEq;
+        bool::from(expected_tag.ct_eq(&tag))
+    }
+}

--- a/crypto/ct-aead/src/lib.rs
+++ b/crypto/ct-aead/src/lib.rs
@@ -1,0 +1,13 @@
+//! Definition of CtAeadDecrypt trait and an implementation for AesGcm object.
+
+#![no_std]
+
+extern crate alloc;
+
+// Re-export the versions of traits and objects from our dependencies
+pub use aes_gcm;
+
+mod aes_impl;
+
+mod traits;
+pub use traits::CtAeadDecrypt;

--- a/crypto/ct-aead/src/traits.rs
+++ b/crypto/ct-aead/src/traits.rs
@@ -1,0 +1,27 @@
+use block_cipher::generic_array::{ArrayLength, GenericArray};
+
+/// API for Aead in-place decryption which is constant-time with respect to
+/// the mac check failing
+pub trait CtAeadDecrypt {
+    type NonceSize: ArrayLength<u8>;
+    type TagSize: ArrayLength<u8>;
+    type CiphertextOverhead: ArrayLength<u8>;
+
+    /// Decrypt a buffer using given aead nonce, validating associated data
+    /// under the mac (tag).
+    ///
+    /// This API promises to be branchless and constant time, particularly,
+    /// not branching on whether or not the mac check succeeded.
+    ///
+    /// Returns:
+    /// true: The mac check succeeded and the buffer contains the plaintext
+    /// false: The mac check failed, and the buffer contains failed decryption.
+    ///        The caller should zeroize buffer before it is discarded.
+    fn ct_decrypt_in_place_detached(
+        &self,
+        nonce: &GenericArray<u8, Self::NonceSize>,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+        tag: &GenericArray<u8, Self::TagSize>,
+    ) -> bool;
+}


### PR DESCRIPTION
This attempts to make an AeadDecryptCt trait and make the mc-crypto-box crate use it, updating its API appropriately.

It is still WIP, I tried to apply the trait directly on the AesGcm structs and rust wouldn't let me because its members are private unfortunately.

```
   Compiling mc-crypto-ake-enclave v0.5.0 (/tmp/mobilenode/crypto/ake/enclave)
error[E0624]: associated function `compute_tag` is private
  --> crypto/ct-aead/src/aes_impl.rs:33:37
   |
33 |         let mut expected_tag = self.compute_tag(associated_data, buffer);
   |                                     ^^^^^^^^^^^ private associated function

error[E0624]: associated function `init_ctr` is private
  --> crypto/ct-aead/src/aes_impl.rs:34:28
   |
34 |         let mut ctr = self.init_ctr(nonce);
   |                            ^^^^^^^^ private associated function

error[E0616]: field `cipher` of struct `aes_gcm::AesGcm` is private
  --> crypto/ct-aead/src/aes_impl.rs:35:35
   |
35 |         ctr.apply_keystream(&self.cipher, expected_tag.as_mut_slice());
   |                                   ^^^^^^ private field

error[E0616]: field `cipher` of struct `aes_gcm::AesGcm` is private
  --> crypto/ct-aead/src/aes_impl.rs:36:35
   |
36 |         ctr.apply_keystream(&self.cipher, buffer);
   |                                   ^^^^^^ private field

```

Issue in aes-gcm crate:

https://github.com/RustCrypto/AEADs/issues/184