### PR TITLE
limit number of slot state files to prevent directory from growing indefinitely

### DIFF
--- a/consensus/service/src/byzantine_ledger.rs
+++ b/consensus/service/src/byzantine_ledger.rs
@@ -105,7 +105,10 @@ impl ByzantineLedger {
         );
         let wrapped_scp_node: Box<dyn ScpNode<TxHash>> = if let Some(path) = opt_scp_debug_dump_dir
         {
-            Box::new(LoggingScpNode::new(scp_node, path).expect("Failed creating LoggingScpNode"))
+            Box::new(
+                LoggingScpNode::new(scp_node, path, logger.clone())
+                    .expect("Failed creating LoggingScpNode"),
+            )
         } else {
             Box::new(scp_node)
         };


### PR DESCRIPTION
### Motivation

#327 added a feature that logs the slot current slot state for each slot to a file. However, there was no limit on how many of these files could be written. This would eventually result in taking a significant amount of disk space on the nodes for no good reason. There's likely not going to be a need to look at old slot states for debugging purposes.

### In this PR
* Change the code that writes these state files to limit to the last 10 slots.
