### PR TITLE
Move migrations code outside of mc-ledger-db into a dedicated mc-ledger-migration tool.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,6 +2648,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-ledger-migration"
+version = "0.5.0"
+dependencies = [
+ "lmdb-rkv",
+ "mc-common",
+ "mc-ledger-db",
+ "mc-util-serial",
+ "serde",
+ "structopt",
+]
+
+[[package]]
 name = "mc-ledger-sync"
 version = "0.5.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "ledger/db",
     "ledger/distribution",
     "ledger/from-archive",
+    "ledger/migration",
     "ledger/sync",
     "mobilecoind",
     "mobilecoind-json",

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2018"
 [features]
 test_utils = ["rand"]
 
+# The migration_support feature exposes some internals that should only be used by the `mc-ledger-migration` tool.
+migration_support = []
+
 [dependencies]
 mc-account-keys = { path = "../../account-keys" }
 mc-common = { path = "../../common", features = ["log"] }

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -67,7 +67,7 @@ pub struct TxOutStore {
 impl TxOutStore {
     #[cfg(feature = "migration_support")]
     pub fn get_tx_out_index_by_public_key_database(&self) -> Database {
-        self.tx_out_index_by_public_key.clone()
+        self.tx_out_index_by_public_key
     }
 
     /// Opens an existing TxOutStore.

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -25,7 +25,7 @@
 
 use crate::{key_bytes_to_u64, u64_to_key_bytes, Error};
 use lmdb::{Database, DatabaseFlags, Environment, RwTransaction, Transaction, WriteFlags};
-use mc_common::{logger::global_log, Hash, HashMap};
+use mc_common::{Hash, HashMap};
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
     membership_proofs::*,
@@ -35,14 +35,14 @@ use mc_transaction_core::{
 use mc_util_serial::{decode, encode};
 
 // LMDB Database names.
-const COUNTS_DB_NAME: &str = "tx_out_store:counts";
-const TX_OUT_INDEX_BY_HASH_DB_NAME: &str = "tx_out_store:tx_out_index_by_hash";
-const TX_OUT_INDEX_BY_PUBLIC_KEY_DB_NAME: &str = "tx_out_store:tx_out_index_by_public_key";
-const TX_OUT_BY_INDEX_DB_NAME: &str = "tx_out_store:tx_out_by_index";
-const MERKLE_HASH_BY_RANGE_DB_NAME: &str = "tx_out_store:merkle_hash_by_range";
+pub const COUNTS_DB_NAME: &str = "tx_out_store:counts";
+pub const TX_OUT_INDEX_BY_HASH_DB_NAME: &str = "tx_out_store:tx_out_index_by_hash";
+pub const TX_OUT_INDEX_BY_PUBLIC_KEY_DB_NAME: &str = "tx_out_store:tx_out_index_by_public_key";
+pub const TX_OUT_BY_INDEX_DB_NAME: &str = "tx_out_store:tx_out_by_index";
+pub const MERKLE_HASH_BY_RANGE_DB_NAME: &str = "tx_out_store:merkle_hash_by_range";
 
 // Keys used by the `counts` database.
-const NUM_TX_OUTS_KEY: &str = "num_tx_outs";
+pub const NUM_TX_OUTS_KEY: &str = "num_tx_outs";
 
 #[derive(Clone)]
 pub struct TxOutStore {
@@ -65,6 +65,11 @@ pub struct TxOutStore {
 }
 
 impl TxOutStore {
+    #[cfg(feature = "migration_support")]
+    pub fn get_tx_out_index_by_public_key_database(&self) -> Database {
+        self.tx_out_index_by_public_key.clone()
+    }
+
     /// Opens an existing TxOutStore.
     pub fn new(env: &Environment) -> Result<Self, Error> {
         Ok(TxOutStore {
@@ -338,46 +343,6 @@ impl TxOutStore {
             num_tx_outs - 1,
             range_to_hash,
         ))
-    }
-
-    /// A utility function for constructing the tx_out_index_by_public_key store using existing
-    /// data.
-    pub(crate) fn construct_tx_out_index_by_public_key_from_existing_data(
-        env: &Environment,
-    ) -> Result<(), Error> {
-        // When constructing the tx out index by public key database, we first need to create it.
-        env.create_db(
-            Some(TX_OUT_INDEX_BY_PUBLIC_KEY_DB_NAME),
-            DatabaseFlags::empty(),
-        )?;
-
-        // After the database has been created, we can use TxOutStore as normal.
-        let instance = Self::new(env)?;
-
-        let mut db_txn = env.begin_rw_txn()?;
-
-        let num_tx_outs = instance.num_tx_outs(&db_txn)?;
-        let mut percents: u64 = 0;
-        for tx_out_index in 0..num_tx_outs {
-            let tx_out = instance.get_tx_out_by_index(tx_out_index, &db_txn)?;
-            db_txn.put(
-                instance.tx_out_index_by_public_key,
-                &tx_out.public_key,
-                &u64_to_key_bytes(tx_out_index),
-                WriteFlags::NO_OVERWRITE,
-            )?;
-
-            // Throttled logging.
-            let new_percents = tx_out_index * 100 / num_tx_outs;
-            if new_percents != percents {
-                percents = new_percents;
-                global_log::info!(
-                    "Constructing tx_out_index_by_public_key: {}% complete",
-                    percents
-                );
-            }
-        }
-        Ok(db_txn.commit()?)
     }
 }
 

--- a/ledger/migration/Cargo.toml
+++ b/ledger/migration/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "mc-ledger-migration"
+version = "0.5.0"
+authors = ["MobileCoin"]
+edition = "2018"
+
+[[bin]]
+name = "mc-ledger-migration"
+path = "src/main.rs"
+
+[dependencies]
+mc-common = { path = "../../common", features = ["loggers"] }
+mc-ledger-db = { path = "../../ledger/db", features = ["migration_support"] }
+mc-util-serial = { path = "../../util/serial" }
+
+lmdb-rkv = "0.14.0"
+structopt = "0.3"
+
+[build-dependencies]
+# Even though this is unused, it needs to be here otherwise Cargo brings in some weird mixture of packages/features that refuses to compile.
+# Go figure ¯\_(ツ)_/¯
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }

--- a/ledger/migration/src/main.rs
+++ b/ledger/migration/src/main.rs
@@ -1,0 +1,202 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! Ledger migration: Perform updates of LedgerDB to accommodate for backward-incompatible changes.
+
+use lmdb::{DatabaseFlags, Environment, Transaction, WriteFlags};
+use mc_common::logger::{create_app_logger, log, o, Logger};
+use mc_ledger_db::{
+    key_bytes_to_u64, tx_out_store::TX_OUT_INDEX_BY_PUBLIC_KEY_DB_NAME, u64_to_key_bytes, Error,
+    MetadataStore, TxOutStore, TxOutsByBlockValue, BLOCK_NUMBER_BY_TX_OUT_INDEX, COUNTS_DB_NAME,
+    NUM_BLOCKS_KEY, TX_OUTS_BY_BLOCK_DB_NAME,
+};
+use mc_util_serial::decode;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+const MAX_LMDB_FILE_SIZE: usize = 1_099_511_627_776; // 1 TB
+
+/// Command line configuration
+#[derive(Clone, Debug, StructOpt)]
+pub struct Config {
+    /// Ledger DB path.
+    #[structopt(long, parse(from_os_str))]
+    pub ledger_db: PathBuf,
+}
+
+fn main() {
+    let config = Config::from_args();
+
+    mc_common::setup_panic_handler();
+    let _sentry_guard = mc_common::sentry::init();
+    let (logger, _global_logger_guard) = create_app_logger(o!());
+
+    // Open the LMDB database.
+    let env = Environment::new()
+        .set_max_dbs(22)
+        .set_map_size(MAX_LMDB_FILE_SIZE)
+        .open(&config.ledger_db)
+        .expect("Failed opening ledger db");
+
+    // Create metadata store.
+    let metadata_store = MetadataStore::new(&env).expect("Failed creating MetadataStore");
+
+    // Incrementally perform upgrades until we reach the current version.
+    loop {
+        // Check if the database we opened is compatible with the current implementation.
+        let db_txn = env.begin_ro_txn().expect("Failed starting ro transaction");
+        let version = metadata_store
+            .get_version(&db_txn)
+            .expect("Failed getting metadata version");
+        log::info!(logger, "Ledger db is currently at version: {:?}", version);
+        db_txn.commit().expect("Failed committing transaction");
+
+        match version.is_compatible_with_latest() {
+            Ok(_) => {
+                break;
+            }
+            // Version 20200610 introduced the TxOut public key -> index store.
+            Err(Error::VersionIncompatible(20200427, 20200610))
+            | Err(Error::VersionIncompatible(20200427, 20200707)) => {
+                log::info!(logger, "Ledger db migrating from version 20200427 to 20200610, this might take awhile...");
+
+                construct_tx_out_index_by_public_key_from_existing_data(&env, &logger)
+                    .expect("Failed constructing tx out index by public key database");
+
+                let mut db_txn = env.begin_rw_txn().expect("Failed starting rw transaction");
+                metadata_store
+                    .set_version(&mut db_txn, 20200610)
+                    .expect("Failed setting metadata version");
+                log::info!(
+                    logger,
+                    "Ledger db migration complete, now at version: {:?}",
+                    metadata_store.get_version(&db_txn),
+                );
+                db_txn.commit().expect("Failed committing transaction");
+            }
+            // Version 20200707 introduced the TxOut global index -> block index store.
+            Err(Error::VersionIncompatible(20200610, 20200707)) => {
+                log::info!(logger, "Ledger db migrating from version 20200610 to 20200707, this might take awhile...");
+
+                construct_block_number_by_tx_out_index_from_existing_data(&env, &logger)
+                    .expect("Failed constructing block number by tx out index database");
+
+                let mut db_txn = env.begin_rw_txn().expect("Failed starting rw transaction");
+                metadata_store
+                    .set_version_to_latest(&mut db_txn)
+                    .expect("Failed setting metadata version");
+                log::info!(
+                    logger,
+                    "Ledger db migration complete, now at version: {:?}",
+                    metadata_store.get_version(&db_txn),
+                );
+                db_txn.commit().expect("Failed committing transaction");
+            }
+            // Don't know how to migrate.
+            Err(err) => {
+                panic!("Error while migrating: {:?}", err);
+            }
+        };
+    }
+}
+
+/// A utility function for constructing the tx_out_index_by_public_key store using existing
+/// data.
+fn construct_tx_out_index_by_public_key_from_existing_data(
+    env: &Environment,
+    logger: &Logger,
+) -> Result<(), Error> {
+    // When constructing the tx out index by public key database, we first need to create it.
+    env.create_db(
+        Some(TX_OUT_INDEX_BY_PUBLIC_KEY_DB_NAME),
+        DatabaseFlags::empty(),
+    )?;
+
+    // After the database has been created, we can use TxOutStore as normal.
+    let instance = TxOutStore::new(env)?;
+
+    let mut db_txn = env.begin_rw_txn()?;
+
+    let num_tx_outs = instance.num_tx_outs(&db_txn)?;
+    let mut percents: u64 = 0;
+    let tx_out_index_by_public_key = instance.get_tx_out_index_by_public_key_database();
+
+    for tx_out_index in 0..num_tx_outs {
+        let tx_out = instance.get_tx_out_by_index(tx_out_index, &db_txn)?;
+        db_txn.put(
+            tx_out_index_by_public_key,
+            &tx_out.public_key,
+            &u64_to_key_bytes(tx_out_index),
+            WriteFlags::NO_OVERWRITE,
+        )?;
+
+        // Throttled logging.
+        let new_percents = tx_out_index * 100 / num_tx_outs;
+        if new_percents != percents {
+            percents = new_percents;
+            log::info!(
+                logger,
+                "Constructing tx_out_index_by_public_key: {}% complete",
+                percents
+            );
+        }
+    }
+    Ok(db_txn.commit()?)
+}
+
+/// A utility function for constructing the block_number_by_tx_out_index store using existing
+/// data.
+fn construct_block_number_by_tx_out_index_from_existing_data(
+    env: &Environment,
+    logger: &Logger,
+) -> Result<(), Error> {
+    // When constructing the block index by tx out index database, we first need to create it.
+    let block_number_by_tx_out_index_db =
+        env.create_db(Some(BLOCK_NUMBER_BY_TX_OUT_INDEX), DatabaseFlags::empty())?;
+
+    // Open pre-existing databases that has data we need.
+    let tx_outs_by_block_db = env.open_db(Some(TX_OUTS_BY_BLOCK_DB_NAME))?;
+    let counts_db = env.open_db(Some(COUNTS_DB_NAME))?;
+
+    // After the database has been created, populate it with the existing data.
+    let mut db_txn = env.begin_rw_txn()?;
+
+    let num_blocks = key_bytes_to_u64(&db_txn.get(counts_db, &NUM_BLOCKS_KEY)?);
+
+    let mut percents: u64 = 0;
+    for block_num in 0..num_blocks {
+        // Get information about the TxOuts in the block.
+        let bytes = db_txn.get(tx_outs_by_block_db, &u64_to_key_bytes(block_num))?;
+        let tx_outs_by_block: TxOutsByBlockValue = decode(&bytes)?;
+
+        log::trace!(
+            logger,
+            "Assigning tx outs #{} - #{} to block #{}",
+            tx_outs_by_block.first_tx_out_index,
+            tx_outs_by_block.first_tx_out_index + tx_outs_by_block.num_tx_outs,
+            block_num,
+        );
+
+        for i in 0..tx_outs_by_block.num_tx_outs {
+            let tx_out_index = tx_outs_by_block.first_tx_out_index + i;
+
+            db_txn.put(
+                block_number_by_tx_out_index_db,
+                &u64_to_key_bytes(tx_out_index),
+                &u64_to_key_bytes(block_num),
+                WriteFlags::NO_OVERWRITE,
+            )?;
+        }
+
+        // Throttled logging.
+        let new_percents = block_num * 100 / num_blocks;
+        if new_percents != percents {
+            percents = new_percents;
+            log::info!(
+                logger,
+                "Constructing block_number_by_tx_out_index: {}% complete",
+                percents
+            );
+        }
+    }
+    Ok(db_txn.commit()?)
+}


### PR DESCRIPTION
### Motivation

We want to move away from automatic implicit migrations when opening LedgerDBs to an explicit step taken by an operator. This prevents having to deal with race conditions that could occur if two processes attempt to open the database at the exact same time. It also allows to keep all the migration-specific code in a centralized place, and not bloat LedgerDB with it.

### In this PR
* Moving the migration code out from `mc-ledger-db` into a new `mc-ledger-migration` tool.

### Future Work
* Integrate this into our build and k8 flow. I will reach out to @joekottke to plan this.

