### PR TITLE
LedgerDB metrics rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,7 +2398,6 @@ dependencies = [
  "mc-util-metrics",
  "mc-util-serial",
  "mc-util-uri",
- "prometheus",
  "prost",
  "protobuf",
  "rand 0.7.3",
@@ -3335,7 +3334,6 @@ dependencies = [
  "lazy_static",
  "mc-common",
  "mc-util-metrics",
- "prometheus",
  "protobuf",
  "reqwest",
  "serde_json",
@@ -3965,16 +3963,16 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5567486d5778e2c6455b1b90ff1c558f29e751fc018130fa182e15828e728af1"
+checksum = "dd0ced56dee39a6e960c15c74dc48849d614586db2eaada6497477af7c7811cd"
 dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
  "protobuf",
- "quick-error",
  "spin",
+ "thiserror",
 ]
 
 [[package]]
@@ -5316,6 +5314,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+dependencies = [
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,6 +2596,7 @@ version = "0.5.0"
 dependencies = [
  "curve25519-dalek",
  "failure",
+ "lazy_static",
  "lmdb-rkv",
  "mc-account-keys",
  "mc-common",
@@ -2604,6 +2605,7 @@ dependencies = [
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
  "mc-util-from-random",
+ "mc-util-metrics",
  "mc-util-serial",
  "prost",
  "rand 0.7.3",

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -46,7 +46,6 @@ futures = "0.3"
 grpcio = "0.6.0"
 hex = "0.4"
 lazy_static = "1.4"
-prometheus = "0.7"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 protobuf = "2.12"
 rand = "0.7"

--- a/consensus/service/src/counters.rs
+++ b/consensus/service/src/counters.rs
@@ -1,11 +1,8 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
-use mc_util_metrics::{Histogram, IntCounter, IntGauge, OpMetrics};
-use prometheus::{
-    core::{Collector, Desc},
-    histogram_opts,
-    proto::MetricFamily,
-    register_histogram, IntCounterVec, Opts,
+use mc_util_metrics::{
+    register, register_histogram, Collector, Desc, Histogram, IntCounter, IntCounterVec, IntGauge,
+    MetricFamily, OpMetrics, Opts,
 };
 
 lazy_static::lazy_static! {
@@ -147,7 +144,7 @@ impl TxValidationErrorMetrics {
 
     pub fn new_and_registered() -> Self {
         let metrics = Self::new();
-        prometheus::register(Box::new(metrics.clone()))
+        register(Box::new(metrics.clone()))
             .expect("TxValidationErrorMetrics registration on Prometheus failed.");
 
         metrics

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -13,9 +13,11 @@ mc-common = { path = "../../common", features = ["log"] }
 mc-crypto-keys = { path = "../../crypto/keys" }
 mc-transaction-core = { path = "../../transaction/core" }
 mc-util-from-random = { path = "../../util/from-random" }
+mc-util-metrics = { path = "../../util/metrics" }
 mc-util-serial = { path = "../../util/serial", features = ["std"] }
 
 failure = "0.1.5"
+lazy_static = "1.4"
 lmdb-rkv = "0.14.0"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand = { version = "0.7", optional = true }

--- a/ledger/db/src/metrics.rs
+++ b/ledger/db/src/metrics.rs
@@ -8,7 +8,7 @@
 
 use mc_util_metrics::{
     register, Collector, Desc, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec,
-    IntGaugeVec, MetricFamily, Opts,
+    IntGauge, IntGaugeVec, MetricFamily, Opts,
 };
 use std::{
     path::PathBuf,
@@ -83,6 +83,15 @@ pub struct LedgerMetrics {
     /// Blocks written through ledger sync since this node started.
     pub blocks_written_count: IntCounter,
 
+    /// Transaction outputs written through ledger sync since this node started.
+    pub txo_written_count: IntCounter,
+
+    /// Number of blocks written to the ledger (by querying ledger).
+    pub num_blocks: IntGauge,
+
+    /// Number of txouts in the ledger (by querying ledger).
+    pub num_txos: IntGauge,
+
     /// Time it takes to perform append_block.
     append_block_time: Histogram,
 }
@@ -97,6 +106,18 @@ impl LedgerMetrics {
             blocks_written_count: COLLECTOR
                 .counters
                 .with_label_values(&["blocks_written_count", db_path_str]),
+
+            txo_written_count: COLLECTOR
+                .counters
+                .with_label_values(&["txo_written_count", db_path_str]),
+
+            num_blocks: COLLECTOR
+                .gauges
+                .with_label_values(&["num_blocks", db_path_str]),
+
+            num_txos: COLLECTOR
+                .gauges
+                .with_label_values(&["num_txos", db_path_str]),
 
             append_block_time: COLLECTOR
                 .duration

--- a/ledger/db/src/metrics.rs
+++ b/ledger/db/src/metrics.rs
@@ -107,7 +107,7 @@ impl LedgerMetrics {
             .to_str()
             .expect("failed converting ledger path to string");
 
-        let metrics = Self {
+        Self {
             blocks_written_count: COLLECTOR
                 .counters
                 .with_label_values(&["blocks_written_count", db_path_str]),
@@ -131,9 +131,7 @@ impl LedgerMetrics {
             append_block_time: COLLECTOR
                 .duration
                 .with_label_values(&["append_block", db_path_str]),
-        };
-
-        metrics
+        }
     }
 
     pub fn observe_append_block_time(&self, start_time: Instant) {

--- a/ledger/db/src/metrics.rs
+++ b/ledger/db/src/metrics.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! LedgerDB metrics.
+//! Usually we would use `uc_util_metrics::OpMetrics` for metric collections. However, since there
+//! could exist multiple LedgerDB instances in a given process, we'd like to group the metric
+//! collection by the database so that they do not get mixed together. The code here is based on
+//! OpMetrics and allows us to do so.
+
+use mc_util_metrics::{
+    register, Collector, Desc, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec,
+    IntGaugeVec, MetricFamily, Opts,
+};
+use std::{
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+
+#[derive(Clone)]
+struct LedgerMetricsCollector {
+    /// Counters collection to be reported to Prometheus.
+    counters: IntCounterVec,
+
+    /// Gauges collection to be reported to Prometheus.
+    gauges: IntGaugeVec,
+
+    /// Duration histograms to be reported to Prometheus.
+    duration: HistogramVec,
+}
+
+impl LedgerMetricsCollector {
+    pub fn new_and_registered() -> Self {
+        let metrics = Self {
+            counters: IntCounterVec::new(
+                Opts::new("ledger_db_counter", "LedgerDB Counters"),
+                &["op", "db_path"],
+            )
+            .unwrap(),
+
+            gauges: IntGaugeVec::new(
+                Opts::new("ledger_db_gauge", "LedgerDB Gauges"),
+                &["op", "db_path"],
+            )
+            .unwrap(),
+
+            duration: HistogramVec::new(
+                HistogramOpts::new("ledger_db_duration", "LedgerDB Duration Histograms"),
+                &["op", "db_path"],
+            )
+            .unwrap(),
+        };
+
+        register(Box::new(metrics.clone()))
+            .expect("LedgerMetrics registration on Prometheus failed.");
+
+        metrics
+    }
+}
+
+lazy_static::lazy_static! {
+    static ref COLLECTOR: LedgerMetricsCollector = LedgerMetricsCollector::new_and_registered();
+}
+
+impl Collector for LedgerMetricsCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        let mut ms = Vec::with_capacity(1);
+        ms.extend(self.counters.desc());
+        ms.extend(self.gauges.desc());
+        ms.extend(self.duration.desc());
+        ms
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        let mut ms = Vec::with_capacity(1);
+        ms.extend(self.counters.collect());
+        ms.extend(self.gauges.collect());
+        ms.extend(self.duration.collect());
+        ms
+    }
+}
+
+#[derive(Clone)]
+pub struct LedgerMetrics {
+    /// Blocks written through ledger sync since this node started.
+    pub blocks_written_count: IntCounter,
+
+    /// Time it takes to perform append_block.
+    append_block_time: Histogram,
+}
+
+impl LedgerMetrics {
+    pub fn new(db_path: &PathBuf) -> Self {
+        let db_path_str = db_path
+            .to_str()
+            .expect("failed converting ledger path to string");
+
+        let metrics = Self {
+            blocks_written_count: COLLECTOR
+                .counters
+                .with_label_values(&["blocks_written_count", db_path_str]),
+
+            append_block_time: COLLECTOR
+                .duration
+                .with_label_values(&["append_block", db_path_str]),
+        };
+
+        metrics
+    }
+
+    pub fn observe_append_block_time(&self, start_time: Instant) {
+        self.append_block_time
+            .observe(duration_to_seconds(start_time.elapsed()));
+    }
+}
+
+/// `duration_to_seconds` converts Duration to seconds.
+// Taken from `prometheus::histogram`.
+#[inline]
+fn duration_to_seconds(d: Duration) -> f64 {
+    let nanos = f64::from(d.subsec_nanos()) / 1e9;
+    d.as_secs() as f64 + nanos
+}

--- a/ledger/db/src/metrics.rs
+++ b/ledger/db/src/metrics.rs
@@ -15,6 +15,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+/// Metrics collector - used internally to report metrics into the Prometheus crate.
 #[derive(Clone)]
 struct LedgerMetricsCollector {
     /// Counters collection to be reported to Prometheus.
@@ -78,6 +79,7 @@ impl Collector for LedgerMetricsCollector {
     }
 }
 
+/// The collection of metrics tracked for each LedgerDB instance.
 #[derive(Clone)]
 pub struct LedgerMetrics {
     /// Blocks written through ledger sync since this node started.

--- a/ledger/db/src/metrics.rs
+++ b/ledger/db/src/metrics.rs
@@ -92,6 +92,9 @@ pub struct LedgerMetrics {
     /// Number of txouts in the ledger (by querying ledger).
     pub num_txos: IntGauge,
 
+    /// The size (in bytes) of the ledger database.
+    pub db_file_size: IntGauge,
+
     /// Time it takes to perform append_block.
     append_block_time: Histogram,
 }
@@ -118,6 +121,10 @@ impl LedgerMetrics {
             num_txos: COLLECTOR
                 .gauges
                 .with_label_values(&["num_txos", db_path_str]),
+
+            db_file_size: COLLECTOR
+                .gauges
+                .with_label_values(&["db_file_size", db_path_str]),
 
             append_block_time: COLLECTOR
                 .duration

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3"
 grpcio = "0.6.0"
 hex_fmt = "0.3"
 lazy_static = "1.4"
-prometheus = "0.7"
+prometheus = "0.9"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 protobuf = "2.12"
 rand = "0.6.5"

--- a/util/metered-channel/Cargo.toml
+++ b/util/metered-channel/Cargo.toml
@@ -12,7 +12,6 @@ chrono = "0.4"
 crossbeam-channel = "0.3"
 grpcio = "0.6.0"
 lazy_static = "1.4"
-prometheus = "0.7"
 protobuf = "2.12"
 reqwest = { version = "0.10", features = ["rustls-tls"], default_features = false }
 serde_json = "1.0"

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -10,7 +10,7 @@ mc-common = { path = "../../common", features = ["log"] }
 crossbeam-channel = "0.3"
 grpcio = "0.6.0"
 lazy_static = "1.4"
-prometheus = "0.7"
+prometheus = "0.9"
 protobuf = "2.12"
 reqwest = { version = "0.10", features = ["rustls-tls"], default_features = false }
 serde_json = "1.0"

--- a/util/metrics/src/lib.rs
+++ b/util/metrics/src/lib.rs
@@ -17,8 +17,8 @@ pub use op_counters::OpMetrics;
 pub use prometheus::{
     core::{Collector, Desc},
     proto::MetricFamily,
-    register, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge,
-    IntGaugeVec, Opts,
+    register, register_histogram, Histogram, HistogramOpts, HistogramVec, IntCounter,
+    IntCounterVec, IntGauge, IntGaugeVec, Opts,
 };
 pub use service_metrics::ServiceMetrics;
 

--- a/util/metrics/src/lib.rs
+++ b/util/metrics/src/lib.rs
@@ -14,7 +14,12 @@ mod service_metrics;
 
 pub use json_encoder::JsonEncoder as MetricsJsonEncoder;
 pub use op_counters::OpMetrics;
-pub use prometheus::{Histogram, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
+pub use prometheus::{
+    core::{Collector, Desc},
+    proto::MetricFamily,
+    register, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    IntGaugeVec, Opts,
+};
 pub use service_metrics::ServiceMetrics;
 
 lazy_static! {


### PR DESCRIPTION
### Motivation

MC-1726 requested a Prometheus gauge for ledger db size. Currently, ledger-related metrics are managed by the users of LedgerDB that write to it (ByzantineLedger, LedgerSyncService) and the metrics are duplicated between the two:
https://github.com/mobilecoinofficial/mobilecoin/blob/c5746954ed453483069bbf63f80019da0145dec1/consensus/service/src/byzantine_ledger.rs#L761-L764
https://github.com/mobilecoinofficial/mobilecoin/blob/c5746954ed453483069bbf63f80019da0145dec1/ledger/sync/src/ledger_sync_service.rs#L316-L321
There is even a TODO item that refers to an old, non-existent ticket to unify them.

I took the opportunity of adding a new metric to address this duplication.

### In this PR
* New metrics built-in into LedgerDB. This is how they show up in Prometheus:
```
# HELP ledger_db_counter LedgerDB Counters
# TYPE ledger_db_counter counter
ledger_db_counter{db_path="/tmp/mc-local-network/node-ledger-0",op="blocks_written_count"} 3
ledger_db_counter{db_path="/tmp/mc-local-network/node-ledger-0",op="txo_written_count"} 223
# HELP ledger_db_duration LedgerDB Duration Histograms
# TYPE ledger_db_duration histogram
ledger_db_duration_bucket{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block",le="0.005"} 1
ledger_db_duration_bucket{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block",le="0.01"} 2
ledger_db_duration_bucket{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block",le="0.025"} 3
ledger_db_duration_bucket{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block",le="0.05"} 3
ledger_db_duration_bucket{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block",le="0.1"} 3
ledger_db_duration_bucket{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block",le="0.25"} 3
ledger_db_duration_bucket{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block",le="0.5"} 3
ledger_db_duration_bucket{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block",le="1"} 3
ledger_db_duration_bucket{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block",le="2.5"} 3
ledger_db_duration_bucket{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block",le="5"} 3
ledger_db_duration_bucket{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block",le="10"} 3
ledger_db_duration_bucket{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block",le="+Inf"} 3
ledger_db_duration_sum{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block"} 0.017721522
ledger_db_duration_count{db_path="/tmp/mc-local-network/node-ledger-0",op="append_block"} 3
# HELP ledger_db_gauge LedgerDB Gauges
# TYPE ledger_db_gauge gauge
ledger_db_gauge{db_path="/tmp/mc-local-network/node-ledger-0",op="db_file_size"} 64016384
ledger_db_gauge{db_path="/tmp/mc-local-network/node-ledger-0",op="num_blocks"} 4
ledger_db_gauge{db_path="/tmp/mc-local-network/node-ledger-0",op="num_txos"} 100223
```

The way the metrics are implemented is slightly more verbose than in previous places due to the need to support the `db_path` grouping, in case a process opens multiple databases. Notice the new `db_file_size` metric.

### Future Work
* I'd like to remove the old ledger-related metrics and replace them with these ones. However, I wanted to keep this PR to a minimum, and also give @joekottke and @rickying time to adapt their tools in case they need to accommodate for the new sources.

