### PR TITLE
TxManager traits, mocks, and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,6 +2407,7 @@ dependencies = [
  "mc-peers",
  "mc-peers-test-utils",
  "mc-sgx-build",
+ "mc-sgx-report-cache-api",
  "mc-sgx-report-cache-untrusted",
  "mc-sgx-slog",
  "mc-sgx-urts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
+
+[[package]]
 name = "dtoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,10 +1060,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+
+[[package]]
+name = "fragile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fs_extra"
@@ -2400,6 +2421,7 @@ dependencies = [
  "mc-util-metrics",
  "mc-util-serial",
  "mc-util-uri",
+ "mockall",
  "prost",
  "protobuf",
  "rand 0.7.3",
@@ -3607,6 +3629,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01458f8a19b10cb28195290942e3149161c75acf67ebc8fbf714ab67a2b943bc"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a673cb441f78cd9af4f5919c28576a3cc325fb6b54e42f7047dacce3c718c17b"
+dependencies = [
+ "cfg-if",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.18",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,6 +3681,12 @@ dependencies = [
  "memchr",
  "version_check 0.1.5",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "notify"
@@ -3895,6 +3950,35 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
+name = "predicates"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
+dependencies = [
+ "difference",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -5684,6 +5768,12 @@ name = "traitobject"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+
+[[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "try-lock"

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -19,7 +19,7 @@ use mc_attest_enclave_api::{
 };
 use mc_common::ResponderId;
 use mc_crypto_keys::{CompressedRistrettoPublic, Ed25519Public, X25519Public};
-use mc_sgx_report_cache_api::ReportableEnclave;
+pub use mc_sgx_report_cache_api::ReportableEnclave;
 use mc_transaction_core::{
     ring_signature::KeyImage,
     tx::{Tx, TxHash, TxOutMembershipProof},
@@ -202,7 +202,7 @@ pub trait ConsensusEnclave: ReportableEnclave {
     /// Retrieve the public identity of the enclave.
     fn get_identity(&self) -> Result<X25519Public>;
 
-    /// Retreive the block signing public key from the enclave.
+    /// Retrieve the block signing public key from the enclave.
     fn get_signer(&self) -> Result<Ed25519Public>;
 
     // CLIENT-FACING METHODS

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -10,6 +10,7 @@ mod error;
 mod messages;
 
 pub use crate::{error::Error, messages::EnclaveCall};
+pub use mc_sgx_report_cache_api::ReportableEnclave;
 
 use alloc::{string::String, vec::Vec};
 use core::{cmp::Ordering, hash::Hash, result::Result as StdResult};
@@ -19,7 +20,6 @@ use mc_attest_enclave_api::{
 };
 use mc_common::ResponderId;
 use mc_crypto_keys::{CompressedRistrettoPublic, Ed25519Public, X25519Public};
-pub use mc_sgx_report_cache_api::ReportableEnclave;
 use mc_transaction_core::{
     ring_signature::KeyImage,
     tx::{Tx, TxHash, TxOutMembershipProof},

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -46,7 +46,6 @@ futures = "0.3"
 grpcio = "0.6.0"
 hex = "0.4"
 lazy_static = "1.4"
-mockall = "0.7.2"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 protobuf = "2.12"
 rand = "0.7"
@@ -70,6 +69,7 @@ mc-sgx-report-cache-api = { path = "../../sgx/report-cache/api" }
 mc-transaction-core-test-utils = { path = "../../transaction/core/test-utils" }
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-logger-macros = { path = "../../util/logger-macros" }
+mockall = "0.7.2"
 rand_core = { version = "0.5", default-features = false }
 rand_hc = "0.2.0"
 tempdir = "0.3"

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -46,6 +46,7 @@ futures = "0.3"
 grpcio = "0.6.0"
 hex = "0.4"
 lazy_static = "1.4"
+mockall = "0.7.2"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 protobuf = "2.12"
 rand = "0.7"

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -66,6 +66,7 @@ mc-common = { path = "../../common", features = ["loggers"] }
 mc-consensus-enclave-mock = { path = "../../consensus/enclave/mock" }
 mc-ledger-db = { path = "../../ledger/db", features = ["test_utils"] }
 mc-peers-test-utils = { path = "../../peers/test-utils" }
+mc-sgx-report-cache-api = { path = "../../sgx/report-cache/api" }
 mc-transaction-core-test-utils = { path = "../../transaction/core/test-utils" }
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-logger-macros = { path = "../../util/logger-macros" }

--- a/consensus/service/src/byzantine_ledger.rs
+++ b/consensus/service/src/byzantine_ledger.rs
@@ -852,11 +852,13 @@ impl<
         // an enclave call, since the message is going to be encrypted (MC-74).
         let tx_hashes = scp_msg.values();
 
-        let mut all_missing_hashes = self
-            .tx_manager
-            .lock()
-            .expect("Lock poisoned")
-            .missing_hashes(&tx_hashes);
+        let mut all_missing_hashes: Vec<TxHash> = {
+            let tx_manager = self.tx_manager.lock().expect("Lock poisoned");
+            tx_hashes
+                .into_iter()
+                .filter(|tx_hash| !tx_manager.contains(tx_hash))
+                .collect()
+        };
 
         // Get the connection we'll be working with
         let conn = match self.peer_manager.conn(from_responder_id) {

--- a/consensus/service/src/byzantine_ledger.rs
+++ b/consensus/service/src/byzantine_ledger.rs
@@ -4,10 +4,7 @@
 //!
 //! Orchestrates running single-slot consensus, or performing ledger sync with peers.
 
-use crate::{
-    counters,
-    tx_manager::{TxManager, TxManagerError},
-};
+use crate::{counters, tx_manager::TxManager};
 use mc_common::{
     logger::{log, Logger},
     HashMap, NodeID, ResponderId,
@@ -915,7 +912,7 @@ impl<
                                 .expect("Lock poisoned")
                                 .insert_proposed_tx(tx_context)
                             {
-                                Ok(_) | Err(TxManagerError::AlreadyInCache) => {}
+                                Ok(_) => {}
                                 Err(err) => {
                                     // Not currently logging the malformed transaction to save a
                                     // `.clone()`. We'll see if this ever happens.

--- a/consensus/service/src/byzantine_ledger.rs
+++ b/consensus/service/src/byzantine_ledger.rs
@@ -1102,7 +1102,7 @@ mod tests {
         let tx_manager: Arc<Mutex<Box<dyn TxManager>>> =
             Arc::new(Mutex::new(Box::new(TxManagerImpl::new(
                 enclave.clone(),
-                Box::new(DefaultTxManagerUntrustedInterfaces::new(ledger.clone())),
+                DefaultTxManagerUntrustedInterfaces::new(ledger.clone()),
                 logger.clone(),
             ))));
 

--- a/consensus/service/src/byzantine_ledger.rs
+++ b/consensus/service/src/byzantine_ledger.rs
@@ -519,14 +519,11 @@ impl<
                 self.scp.clear_pending_slots();
 
                 // Clear any pending values that might no longer be valid.
-                let tx_manager = self.tx_manager.clone();
-                self.pending_values.retain(|tx_hash| {
-                    tx_manager
-                        .lock()
-                        .expect("Lock poisoned")
-                        .validate(tx_hash)
-                        .is_ok()
-                });
+                {
+                    let tx_manager = self.tx_manager.lock().expect("Lock poisoned");
+                    self.pending_values
+                        .retain(|tx_hash| tx_manager.validate(tx_hash).is_ok());
+                }
 
                 // Re-construct the BTreeMap with the remaining values, using the old timestamps.
                 let mut new_pending_values_map = BTreeMap::new();

--- a/consensus/service/src/client_api_service.rs
+++ b/consensus/service/src/client_api_service.rs
@@ -88,7 +88,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger + Clone> ClientApiService<E, L> {
             .tx_manager
             .lock()
             .expect("Lock poisoned")
-            .insert_proposed_tx(tx_context)
+            .insert(tx_context)
         {
             Ok(tx_context) => {
                 // Submit for consideration in next SCP slot.

--- a/consensus/service/src/client_api_service.rs
+++ b/consensus/service/src/client_api_service.rs
@@ -29,7 +29,7 @@ pub struct ClientApiService<E: ConsensusEnclaveProxy, L: Ledger + Clone> {
     enclave: E,
     scp_client_value_sender: ProposeTxCallback,
     ledger: L,
-    tx_manager: Arc<Mutex<TxManager<E>>>,
+    tx_manager: Arc<Mutex<Box<dyn TxManager>>>,
     is_serving_fn: Arc<(dyn Fn() -> bool + Sync + Send)>,
     logger: Logger,
 }
@@ -39,7 +39,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger + Clone> ClientApiService<E, L> {
         enclave: E,
         scp_client_value_sender: ProposeTxCallback,
         ledger: L,
-        tx_manager: Arc<Mutex<TxManager<E>>>,
+        tx_manager: Arc<Mutex<Box<dyn TxManager>>>,
         is_serving_fn: Arc<(dyn Fn() -> bool + Sync + Send)>,
         logger: Logger,
     ) -> Self {

--- a/consensus/service/src/client_api_service.rs
+++ b/consensus/service/src/client_api_service.rs
@@ -19,7 +19,7 @@ use mc_ledger_db::Ledger;
 use mc_transaction_core::validation::TransactionValidationError;
 use mc_util_grpc::{rpc_logger, send_result};
 use mc_util_metrics::{self, SVC_COUNTERS};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// Maximum number of pending values for consensus service before rejecting add_transaction requests.
 const PENDING_LIMIT: i64 = 500;
@@ -29,7 +29,7 @@ pub struct ClientApiService<E: ConsensusEnclaveProxy, L: Ledger + Clone> {
     enclave: E,
     scp_client_value_sender: ProposeTxCallback,
     ledger: L,
-    tx_manager: TxManager<E, L>,
+    tx_manager: Arc<Mutex<TxManager<E>>>,
     is_serving_fn: Arc<(dyn Fn() -> bool + Sync + Send)>,
     logger: Logger,
 }
@@ -39,7 +39,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger + Clone> ClientApiService<E, L> {
         enclave: E,
         scp_client_value_sender: ProposeTxCallback,
         ledger: L,
-        tx_manager: TxManager<E, L>,
+        tx_manager: Arc<Mutex<TxManager<E>>>,
         is_serving_fn: Arc<(dyn Fn() -> bool + Sync + Send)>,
         logger: Logger,
     ) -> Self {
@@ -84,7 +84,12 @@ impl<E: ConsensusEnclaveProxy, L: Ledger + Clone> ClientApiService<E, L> {
         let tx_context = self.enclave.client_tx_propose(request.into())?;
         let tx_hash = tx_context.tx_hash;
 
-        match self.tx_manager.insert_proposed_tx(tx_context) {
+        match self
+            .tx_manager
+            .lock()
+            .expect("Lock poisoned")
+            .insert_proposed_tx(tx_context)
+        {
             Ok(tx_context) => {
                 // Submit for consideration in next SCP slot.
                 (*self.scp_client_value_sender)(*tx_context.tx_hash(), None, None);

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -159,7 +159,7 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
         // Tx Manager
         let tx_manager = Box::new(TxManagerImpl::new(
             enclave.clone(),
-            Box::new(DefaultTxManagerUntrustedInterfaces::new(ledger_db.clone())),
+            DefaultTxManagerUntrustedInterfaces::new(ledger_db.clone()),
             logger.clone(),
         ));
 

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -95,7 +95,7 @@ pub struct ConsensusService<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync 
 
     peer_manager: ConnectionManager<PeerConnection<E>>,
     broadcaster: Arc<Mutex<ThreadedBroadcaster>>,
-    tx_manager: TxManager<E, LedgerDB>,
+    tx_manager: Arc<Mutex<TxManager<E>>>,
     peer_keepalive: Arc<Mutex<PeerKeepalive>>,
 
     admin_rpc_server: Option<AdminServer>,
@@ -153,8 +153,7 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
         // Tx Manager
         let tx_manager = TxManager::new(
             enclave.clone(),
-            ledger_db.clone(),
-            DefaultTxManagerUntrustedInterfaces::new(ledger_db.clone()),
+            Box::new(DefaultTxManagerUntrustedInterfaces::new(ledger_db.clone())),
             logger.clone(),
         );
 
@@ -181,7 +180,7 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
 
             peer_manager,
             broadcaster,
-            tx_manager,
+            tx_manager: Arc::new(Mutex::new(tx_manager)),
             peer_keepalive,
 
             admin_rpc_server: None,
@@ -543,7 +542,11 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
             // consensus time.
             if origin_node == &local_node_id || relay_from_nodes.contains(&origin_node.responder_id)
             {
-                if let Some(encrypted_tx) = tx_manager.get_encrypted_tx_by_hash(&tx_hash) {
+                if let Some(encrypted_tx) = tx_manager
+                    .lock()
+                    .expect("Lock poisoned")
+                    .get_encrypted_tx_by_hash(&tx_hash)
+                {
                     broadcaster
                         .lock()
                         .expect("lock poisoned")

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -551,7 +551,7 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
                 if let Some(encrypted_tx) = tx_manager
                     .lock()
                     .expect("Lock poisoned")
-                    .get_encrypted_tx_by_hash(&tx_hash)
+                    .get_encrypted_tx(&tx_hash)
                 {
                     broadcaster
                         .lock()

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -119,7 +119,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> PeerApiService<E, L> {
                 .tx_manager
                 .lock()
                 .expect("Lock poisoned")
-                .insert_proposed_tx(tx_context)
+                .insert(tx_context)
             {
                 Ok(tx_context) => {
                     // Submit for consideration in next SCP slot.
@@ -169,11 +169,15 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> PeerApiService<E, L> {
             })
             .collect::<Result<Vec<TxHash>, ConsensusGrpcError>>()?;
 
-        match self.tx_manager.lock().expect("Lock poisoned").txs_for_peer(
-            &tx_hashes,
-            &[],
-            &PeerSession::from(request.get_channel_id()),
-        ) {
+        match self
+            .tx_manager
+            .lock()
+            .expect("Lock poisoned")
+            .encrypt_for_peer(
+                &tx_hashes,
+                &[],
+                &PeerSession::from(request.get_channel_id()),
+            ) {
             Ok(enclave_message) => Ok(enclave_message.into()),
             Err(err) => {
                 log::warn!(

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -57,7 +57,7 @@ pub struct PeerApiService<E: ConsensusEnclaveProxy, L: Ledger> {
     ledger: L,
 
     /// Transactions Manager instance.
-    tx_manager: Arc<Mutex<TxManager<E>>>,
+    tx_manager: Arc<Mutex<Box<dyn TxManager>>>,
 
     /// Callback function for getting the latest SCP statement the local node has issued.
     fetch_latest_msg_fn: FetchLatestMsgFn,
@@ -78,7 +78,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> PeerApiService<E, L> {
         incoming_consensus_msgs_sender: BackgroundWorkQueueSenderFn<IncomingConsensusMsg>,
         scp_client_value_sender: ProposeTxCallback,
         ledger: L,
-        tx_manager: Arc<Mutex<TxManager<E>>>,
+        tx_manager: Arc<Mutex<Box<dyn TxManager>>>,
         fetch_latest_msg_fn: FetchLatestMsgFn,
         known_responder_ids: Vec<ResponderId>,
         logger: Logger,

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -35,7 +35,7 @@ use mc_util_serial::deserialize;
 use std::{
     convert::{TryFrom, TryInto},
     str::FromStr,
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 // Callback method for returning the latest SCP message issued by the local node, used to
@@ -57,7 +57,7 @@ pub struct PeerApiService<E: ConsensusEnclaveProxy, L: Ledger> {
     ledger: L,
 
     /// Transactions Manager instance.
-    tx_manager: TxManager<E, L>,
+    tx_manager: Arc<Mutex<TxManager<E>>>,
 
     /// Callback function for getting the latest SCP statement the local node has issued.
     fetch_latest_msg_fn: FetchLatestMsgFn,
@@ -78,7 +78,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> PeerApiService<E, L> {
         incoming_consensus_msgs_sender: BackgroundWorkQueueSenderFn<IncomingConsensusMsg>,
         scp_client_value_sender: ProposeTxCallback,
         ledger: L,
-        tx_manager: TxManager<E, L>,
+        tx_manager: Arc<Mutex<TxManager<E>>>,
         fetch_latest_msg_fn: FetchLatestMsgFn,
         known_responder_ids: Vec<ResponderId>,
         logger: Logger,
@@ -115,7 +115,12 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> PeerApiService<E, L> {
         for tx_context in tx_contexts {
             let tx_hash = tx_context.tx_hash;
 
-            match self.tx_manager.insert_proposed_tx(tx_context) {
+            match self
+                .tx_manager
+                .lock()
+                .expect("Lock poisoned")
+                .insert_proposed_tx(tx_context)
+            {
                 Ok(tx_context) => {
                     // Submit for consideration in next SCP slot.
                     (*self.scp_client_value_sender)(
@@ -166,7 +171,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> PeerApiService<E, L> {
             })
             .collect::<Result<Vec<TxHash>, ConsensusGrpcError>>()?;
 
-        match self.tx_manager.txs_for_peer(
+        match self.tx_manager.lock().expect("Lock poisoned").txs_for_peer(
             &tx_hashes,
             &[],
             &PeerSession::from(request.get_channel_id()),

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -130,8 +130,6 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> PeerApiService<E, L> {
                     );
                 }
 
-                Err(TxManagerError::AlreadyInCache) => {}
-
                 Err(TxManagerError::TransactionValidation(err)) => {
                     log::debug!(
                         logger,

--- a/consensus/service/src/tx_manager.rs
+++ b/consensus/service/src/tx_manager.rs
@@ -125,8 +125,7 @@ pub struct TxManager<
     /// Ledger.
     ledger: L,
 
-    /// Application-specific custom interfaces for the untrusted part of validation/combining of
-    /// values.
+    /// Application-specific interfaces for the untrusted part of validation/combining of values.
     untrusted: UI,
 
     /// Logger.
@@ -153,8 +152,6 @@ impl<E: ConsensusEnclaveProxy, L: Ledger, UI: UntrustedInterfaces> TxManager<E, 
     pub fn insert_proposed_tx(
         &self,
         tx_context: TxContext,
-        // _origin_node: Option<NodeID>
-        // _relayed_to: Option<NodeID>,
     ) -> TxManagerResult<WellFormedTxContext> {
         // If already in cache then we're done.
         {
@@ -376,6 +373,27 @@ mod tests {
         create_ledger, create_transaction, initialize_ledger, AccountKey,
     };
     use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    #[ignore]
+    // Should return Ok when a well-formed Tx is inserted.
+    fn test_insert_proposed_tx_ok() {
+        unimplemented!()
+    }
+
+    #[test]
+    #[ignore]
+    // Should return Ok when a well-formed Tx is re-inserted.
+    fn test_insert_proposed_tx_reinsert_ok() {
+        unimplemented!()
+    }
+
+    #[test]
+    #[ignore]
+    // Should return return an error when a not well-formed Tx is inserted.
+    fn test_insert_proposed_tx_error() {
+        unimplemented!()
+    }
 
     #[test_with_logger]
     fn test_hashes_to_block(logger: Logger) {

--- a/consensus/service/src/tx_manager.rs
+++ b/consensus/service/src/tx_manager.rs
@@ -22,6 +22,7 @@ use mc_transaction_core::{
     validation::{TransactionValidationError, TransactionValidationResult},
     Block, BlockContents, BlockSignature,
 };
+#[cfg(test)]
 use mockall::*;
 
 #[derive(Clone, Debug, Fail)]
@@ -80,7 +81,7 @@ impl CacheEntry {
 }
 
 /// Transaction checks performed outside the enclave.
-#[automock]
+#[cfg_attr(test, automock)]
 pub trait UntrustedInterfaces: Send {
     /// Performs the untrusted part of the well-formed check.
     /// Returns current block index and membership proofs to be used by
@@ -106,7 +107,7 @@ pub trait UntrustedInterfaces: Send {
     fn combine(&self, tx_contexts: &[WellFormedTxContext], max_elements: usize) -> Vec<TxHash>;
 }
 
-#[automock]
+#[cfg_attr(test, automock)]
 pub trait TxManager: Send {
     /// Insert a transaction into the cache. The transaction must be well-formed.
     fn insert(&mut self, tx_context: TxContext) -> TxManagerResult<WellFormedTxContext>;

--- a/consensus/service/src/tx_manager.rs
+++ b/consensus/service/src/tx_manager.rs
@@ -838,7 +838,6 @@ mod tx_manager_tests {
     }
 
     #[test_with_logger]
-    #[ignore]
     // Should call enclave.txs_for_peer
     fn test_encrypt_for_peer_ok(logger: Logger) {
         let mock_untrusted = MockUntrustedInterfaces::new();

--- a/consensus/service/src/tx_manager.rs
+++ b/consensus/service/src/tx_manager.rs
@@ -144,8 +144,10 @@ pub trait TxManager: Send {
         peer: &PeerSession,
     ) -> TxManagerResult<EnclaveMessage<PeerSession>>;
 
+    /// Get the encrypted transaction corresponding to the given hash.
     fn get_encrypted_tx_by_hash(&self, tx_hash: &TxHash) -> Option<WellFormedEncryptedTx>;
 
+    /// The number of cached entries.
     fn num_entries(&self) -> usize;
 }
 
@@ -369,6 +371,7 @@ impl<E: ConsensusEnclaveProxy, UI: UntrustedInterfaces> TxManager for TxManagerI
             .map(|entry| entry.encrypted_tx().clone())
     }
 
+    /// The number of cached entries.
     fn num_entries(&self) -> usize {
         self.cache.len()
     }
@@ -390,6 +393,7 @@ mod tx_manager_tests {
     // Should return Ok when a well-formed Tx is inserted.
     fn test_insert_proposed_tx_ok(logger: Logger) {
         let tx_context = TxContext::default();
+        // let tx_hash = tx_context.tx_hash;
 
         let mut mock_untrusted = MockUntrustedInterfaces::new();
         // Untrusted's well-formed check should be called once each time insert_propose_tx is called.
@@ -402,8 +406,13 @@ mod tx_manager_tests {
         let mock_enclave = ConsensusServiceMockEnclave::default();
 
         let mut tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
+        assert_eq!(tx_manager.cache.len(), 0);
+
         assert!(tx_manager.insert_proposed_tx(tx_context.clone()).is_ok());
         assert_eq!(tx_manager.cache.len(), 1);
+
+        // TODO
+        // assert!(tx_manager.cache.contains_key(&tx_hash));
     }
 
     #[test_with_logger]

--- a/consensus/service/src/tx_manager.rs
+++ b/consensus/service/src/tx_manager.rs
@@ -10,7 +10,7 @@ use mc_common::{
     HashMap, HashSet,
 };
 use mc_consensus_enclave::{
-    ConsensusEnclaveProxy, Error as ConsensusEnclaveError, TxContext, WellFormedEncryptedTx,
+    ConsensusEnclave, Error as ConsensusEnclaveError, TxContext, WellFormedEncryptedTx,
     WellFormedTxContext,
 };
 use mc_crypto_keys::CompressedRistrettoPublic;
@@ -151,7 +151,7 @@ pub trait TxManager: Send {
     fn num_entries(&self) -> usize;
 }
 
-pub struct TxManagerImpl<E: ConsensusEnclaveProxy, UI: UntrustedInterfaces> {
+pub struct TxManagerImpl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces> {
     /// Validate and combine functionality provided by an enclave.
     enclave: E,
 
@@ -165,7 +165,7 @@ pub struct TxManagerImpl<E: ConsensusEnclaveProxy, UI: UntrustedInterfaces> {
     cache: HashMap<TxHash, CacheEntry>,
 }
 
-impl<E: ConsensusEnclaveProxy, UI: UntrustedInterfaces> TxManagerImpl<E, UI> {
+impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces> TxManagerImpl<E, UI> {
     /// Construct a new TxManager instance.
     pub fn new(enclave: E, untrusted: UI, logger: Logger) -> Self {
         Self {
@@ -177,7 +177,7 @@ impl<E: ConsensusEnclaveProxy, UI: UntrustedInterfaces> TxManagerImpl<E, UI> {
     }
 }
 
-impl<E: ConsensusEnclaveProxy, UI: UntrustedInterfaces> TxManager for TxManagerImpl<E, UI> {
+impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces> TxManager for TxManagerImpl<E, UI> {
     /// Insert a new transaction into the cache.
     /// This enforces that the transaction is well-formed.
     fn insert_proposed_tx(

--- a/consensus/service/src/tx_manager.rs
+++ b/consensus/service/src/tx_manager.rs
@@ -944,10 +944,31 @@ mod tx_manager_tests {
     }
 
     #[test_with_logger]
-    #[ignore]
     // Should return cache_entry.encrypted_tx if it is in the cache.
-    fn test_get_encrypted_tx(_logger: Logger) {
-        unimplemented!()
+    fn test_get_encrypted_tx(logger: Logger) {
+        let mock_untrusted = MockUntrustedInterfaces::new();
+        let mock_enclave = MockEnclave::new();
+        let mut tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
+
+        // Add a transaction to the cache.
+        let cache_entry = CacheEntry {
+            encrypted_tx: WellFormedEncryptedTx(vec![1, 2, 3]),
+            context: Default::default(),
+        };
+
+        let tx_hash = TxHash([1u8; 32]);
+        tx_manager
+            .well_formed_cache
+            .insert(tx_hash.clone(), cache_entry);
+
+        // Get something that is in the cache.
+        assert_eq!(
+            tx_manager.get_encrypted_tx(&tx_hash),
+            Some(WellFormedEncryptedTx(vec![1, 2, 3]))
+        );
+
+        // Get something that is not in the cache.
+        assert_eq!(tx_manager.get_encrypted_tx(&TxHash([88u8; 32])), None);
     }
 
     #[test_with_logger]

--- a/consensus/service/src/tx_manager.rs
+++ b/consensus/service/src/tx_manager.rs
@@ -33,9 +33,6 @@ pub enum TxManagerError {
     #[fail(display = "Transaction validation error: {}", _0)]
     TransactionValidation(TransactionValidationError),
 
-    #[fail(display = "Tx already in cache")]
-    AlreadyInCache,
-
     #[fail(display = "Tx not in cache ({})", _0)]
     NotInCache(TxHash),
 
@@ -329,8 +326,6 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces> TxManager for TxManage
             })
             .collect::<Result<Vec<(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)>, TxManagerError>>()?;
 
-        // let num_blocks = self.ledger.num_blocks()?;
-        // let parent_block = self.ledger.get_block(num_blocks - 1)?;
         let (block, block_contents, mut signature) = self
             .enclave
             .form_block(&parent_block, &encrypted_txs_with_proofs)?;

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -130,9 +130,9 @@ impl<L: Ledger> TxManagerUntrustedInterfaces for DefaultTxManagerUntrustedInterf
     /// * `max_elements` - Maximum number of elements to return.
     ///
     /// Returns a bounded, deterministically-ordered list of transactions that are safe to append to the ledger.
-    fn combine(&self, tx_contexts: &[&WellFormedTxContext], max_elements: usize) -> Vec<TxHash> {
+    fn combine(&self, tx_contexts: &[WellFormedTxContext], max_elements: usize) -> Vec<TxHash> {
         // WellFormedTxContext defines the sort order of transactions within a block.
-        let mut candidates: Vec<&WellFormedTxContext> = tx_contexts.to_vec();
+        let mut candidates: Vec<&WellFormedTxContext> = tx_contexts.iter().collect();
         candidates.sort();
 
         // Allow transactions that do not cause duplicate key images or output public keys.
@@ -703,8 +703,7 @@ mod combine_tests {
     fn combine(tx_contexts: Vec<WellFormedTxContext>, max_elements: usize) -> Vec<TxHash> {
         let ledger = get_mock_ledger(10);
         let untrusted = DefaultTxManagerUntrustedInterfaces::new(ledger);
-        let ref_tx_contexts: Vec<&WellFormedTxContext> = tx_contexts.iter().collect();
-        untrusted.combine(&ref_tx_contexts[..], max_elements)
+        untrusted.combine(&tx_contexts, max_elements)
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

Several layers of the consensus service contain complex dependencies that make them difficult to test. It is also difficult to create test inputs that exercise particular code paths, because the inputs must be compatible with those complex dependencies. It would be nice if some of those dependencies could be mocked...

### In this PR
This PR focuses on TxManager and using mocks for testing:
* Creates a TxManager trait and updates things that use TxManager to use Box\<TxManager\>,
* Uses `mockall` to make TxManager easily mockable,
* Mocks the ConsensusEnclave trait,
* Adds unit tests for TxManagerImpl, which involve mocking TxManagerImpl's dependencies

### Future Work
* Use MockTxManager when testing things like ByzantineLedger.
* Use mockall's `auotmock` to create mocks in other places, instead of manually defining mock structs.

