### PR TITLE
Add a basic constant time FogHint::ct_decrypt function

### DIFF
--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -160,10 +160,7 @@ impl FogHint {
             }
         }
 
-        let default_fog_hint = FogHint::from_slice(
-            &default_plaintext.as_ref()[0..RISTRETTO_PUBLIC_LEN],
-        )
-        .expect("default plaintext should always contain a valid RistrettoPublic at the beginning");
+        let default_fog_hint = FogHint::new(default_pubkey);
 
         match FogHint::from_slice(&plaintext.as_ref()[0..RISTRETTO_PUBLIC_LEN]) {
             Ok(fog_hint) => (fog_hint, success),

--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -15,6 +15,8 @@ use mc_crypto_box::{
 use mc_crypto_keys::{
     CompressedRistrettoPublic, ReprBytes, Ristretto, RistrettoPrivate, RistrettoPublic,
 };
+use mc_crypto_rand::McRng;
+use mc_util_from_random::FromRandom;
 use rand_core::{CryptoRng, RngCore};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -116,6 +118,57 @@ impl FogHint {
             }
         }
         FogHint::from_slice(&plaintext.as_ref()[0..RISTRETTO_PUBLIC_LEN])
+    }
+
+    /// ct_decrypt
+    ///
+    /// Try to decrypt an encrypted payload onto this FogHint object in constant time.
+    /// Fails if decryption fails, or the magic number is wrong.
+    ///
+    /// # Arguments
+    /// * acct_server_private_key
+    /// * 128 byte encrypted payload
+    ///
+    /// # Returns
+    /// * Fog hint on success, cryptobox error otherwise
+    pub fn ct_decrypt(
+        ingest_server_private_key: &RistrettoPrivate,
+        ciphertext: &EncryptedFogHint,
+    ) -> (Self, bool) {
+        let mut default_plaintext = GenericArray::<
+            u8,
+            Diff<EncryptedFogHintSize, <VersionedCryptoBox as CryptoBox<Ristretto>>::FooterSize>,
+        >::default();
+
+        let mut rng = McRng::default();
+        let default_pubkey = RistrettoPublic::from_random(&mut rng);
+
+        default_plaintext.as_mut()[..RISTRETTO_PUBLIC_LEN]
+            .copy_from_slice(&default_pubkey.to_bytes());
+
+        let (plaintext, mut success) = match VersionedCryptoBox::default()
+            .decrypt_fixed_length(ingest_server_private_key, ciphertext.as_ref())
+        {
+            Ok(real_plaintext) => (real_plaintext, true),
+            Err(_) => (default_plaintext, false),
+        };
+
+        // Check magic numbers
+        for byte in &plaintext[RISTRETTO_PUBLIC_LEN..] {
+            if *byte != MAGIC_NUMBER {
+                success = false;
+            }
+        }
+
+        let default_fog_hint = FogHint::from_slice(
+            &default_plaintext.as_ref()[0..RISTRETTO_PUBLIC_LEN],
+        )
+        .expect("default plaintext should always contain a valid RistrettoPublic at the beginning");
+
+        match FogHint::from_slice(&plaintext.as_ref()[0..RISTRETTO_PUBLIC_LEN]) {
+            Ok(fog_hint) => (fog_hint, success),
+            Err(_) => (default_fog_hint, false),
+        }
     }
 }
 

--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -126,11 +126,11 @@ impl FogHint {
     /// Fails if decryption fails, or the magic number is wrong.
     ///
     /// # Arguments
-    /// * acct_server_private_key
+    /// * ingest_server_private_key
     /// * 128 byte encrypted payload
     ///
     /// # Returns
-    /// * Fog hint on success, cryptobox error otherwise
+    /// * (Fog hint, true) on success (Default Fog hint, false) otherwise
     pub fn ct_decrypt(
         ingest_server_private_key: &RistrettoPrivate,
         ciphertext: &EncryptedFogHint,


### PR DESCRIPTION
Soundtrack of this PR: [Walk Like an Egyptian](https://www.youtube.com/watch?v=Cv6tuzHUuuk)

### Motivation

In order to make the ingest loop constant time, we need a constant time decrypt function for the fog hint.  We can't really do this now, due to limitations in the aes-gcm library (https://github.com/RustCrypto/AEADs/issues/184).  I have a PR against aes-gcm that will allow us to do so (https://github.com/RustCrypto/AEADs/pull/188), but there is no guarantee that it will be merged.  We may have to carry a fork of aes-gcm, but that can wait for the future.  This PR will allow us to move forwards, which is good enough for now.

### In this PR
* Adds a FogHint::ct_decrypt function, which returns a (FogHint, bool)

This will help make progress on FOG-96 and FOG-97.

### Future Work
* Use this code in the ingest enclave impl
* Make a constant time aes-gcm decrypt and update this function to use it