### PR TITLE
Increases the S3 block sync size to increase performance

### DIFF
--- a/ledger/sync/src/ledger_sync_service_thread.rs
+++ b/ledger/sync/src/ledger_sync_service_thread.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 /// Maximal number of blocks to attempt to sync at each loop iteration.
-const MAX_BLOCKS_PER_SYNC_ITERATION: u32 = 10;
+const MAX_BLOCKS_PER_SYNC_ITERATION: u32 = 100;
 
 pub struct LedgerSyncServiceThread {
     join_handle: Option<thread::JoinHandle<()>>,


### PR DESCRIPTION
### Motivation

As we've grown the testnet initial download times have increased to about 30 mins. This reduces them to close to 10 mins. I attempted larger sizes but found the testnet client would take longer to start up and was subjectively a worse experience. 

### In this PR
* Increase MAX_BLOCKS_PER_SYNC_ITERATION to 100

### Future Work
* Possibly make this a parameter or do more performance tuning
