### PR TITLE
Make slog actually work inside of sgx enclave/impl crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,7 +2213,6 @@ dependencies = [
  "mc-sgx-debug-edl",
  "mc-sgx-panic-edl",
  "mc-sgx-report-cache-api",
- "mc-sgx-slog",
  "mc-sgx-slog-edl",
  "mc-sgx-types",
  "mc-sgx-urts",
@@ -2387,7 +2386,6 @@ dependencies = [
  "mc-peers-test-utils",
  "mc-sgx-build",
  "mc-sgx-report-cache-untrusted",
- "mc-sgx-slog",
  "mc-sgx-urts",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
@@ -3041,9 +3039,9 @@ name = "mc-sgx-slog"
 version = "0.5.0"
 dependencies = [
  "cfg-if",
+ "mc-common",
+ "mc-sgx-build",
  "prost",
- "slog",
- "slog-scope",
 ]
 
 [[package]]
@@ -3062,9 +3060,12 @@ name = "mc-sgx-urts"
 version = "0.5.0"
 dependencies = [
  "lazy_static",
+ "mc-common",
  "mc-sgx-build",
  "mc-sgx-libc-types",
+ "mc-sgx-slog",
  "mc-sgx-types",
+ "prost",
  "rustc-demangle",
 ]
 
@@ -5017,9 +5018,8 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "slog"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
+version = "2.6.0"
+source = "git+https://github.com/garbageslam/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf#cc1562258b81353426d17a55b7447256fa6eabbf"
 
 [[package]]
 name = "slog-async"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5019,7 +5019,7 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 [[package]]
 name = "slog"
 version = "2.6.0"
-source = "git+https://github.com/garbageslam/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf#cc1562258b81353426d17a55b7447256fa6eabbf"
+source = "git+https://github.com/mobilecoinofficial/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf#cc1562258b81353426d17a55b7447256fa6eabbf"
 
 [[package]]
 name = "slog-async"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ rpath = true
 [patch.crates-io]
 prost = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
 prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
+slog = { git = "https://github.com/garbageslam/slog", rev = "cc1562258b81353426d17a55b7447256fa6eabbf" }
 dialoguer = { git = "https://github.com/mitsuhiko/dialoguer", rev = "a0c6c1e" }
 console = { git = "https://github.com/mitsuhiko/console", rev = "1307823" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,8 +109,13 @@ overflow-checks = false
 rpath = true
 
 [patch.crates-io]
+# prost is patched with no_std support (https://github.com/danburkert/prost/pull/319)
+# current revision is from jun 13 2020, waiting for a new prost release
+# https://github.com/danburkert/prost/issues/329
 prost = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
 prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
+# slog is patched in order to build in no_std config with dynamic_keys feature on
+# https://github.com/slog-rs/slog/pull/268
 slog = { git = "https://github.com/garbageslam/slog", rev = "cc1562258b81353426d17a55b7447256fa6eabbf" }
 dialoguer = { git = "https://github.com/mitsuhiko/dialoguer", rev = "a0c6c1e" }
 console = { git = "https://github.com/mitsuhiko/console", rev = "1307823" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ prost = { git = "https://github.com/danburkert/prost", rev = "6113789f70b6970982
 prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
 # slog is patched in order to build in no_std config with dynamic_keys feature on
 # https://github.com/slog-rs/slog/pull/268
-slog = { git = "https://github.com/garbageslam/slog", rev = "cc1562258b81353426d17a55b7447256fa6eabbf" }
+slog = { git = "https://github.com/mobilecoinofficial/slog", rev = "cc1562258b81353426d17a55b7447256fa6eabbf" }
 dialoguer = { git = "https://github.com/mitsuhiko/dialoguer", rev = "a0c6c1e" }
 console = { git = "https://github.com/mitsuhiko/console", rev = "1307823" }
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,7 +14,6 @@ log = [
     "backtrace",
     "chrono",
     "mc-util-logger-macros",
-    "slog",
     "slog-scope",
 ]
 loggers = [
@@ -58,7 +57,7 @@ siphasher = "0.3"
 backtrace = { version = "0.3", optional = true }
 chrono = { version = "0.4", optional = true }
 mc-util-logger-macros = { path = "../util/logger-macros", optional = true }
-slog = { version = "2.5", features = ["dynamic-keys", "max_level_trace", "release_max_level_trace"], optional = true }
+slog = { version = "2.6", default-features = false, features = ["dynamic-keys", "max_level_trace", "release_max_level_trace"] }
 slog-scope = { version = "4.1.2", optional = true }
 
 # loggers-only dependencies

--- a/common/README.md
+++ b/common/README.md
@@ -6,5 +6,14 @@ This crate contains several things right now:
   Putting the structs in `common` instead of in a larger crate allows to break
   dependencies, and minimize the amount of code that compiles as `std` and `no_std`.
 - Common error types, used at API boundaries. The rationale is similar.
-- A shared hashmap object based on hashbrown that works in and out of the enclave.
-- Logging functionality
+- A hashmap object based on hashbrown that works in and out of the enclave.
+- A simple LRU cache implementation
+- Logging functionality. Some of this is enclave compatible, some isn't,
+  this is controlled by `log` and `loggers` features.
+
+Note (enclave logging)
+----------------------
+
+The `mc-sgx-slog` crate provides an `slog::Logger` appropriate for the enclave.
+It is recommended to refer to `mc_common::logger::Logger` in the portable `enclave-impl` crates,
+and put the calls to `mc-sgx-slog` in the `enclave-trusted` crates.

--- a/common/README.md
+++ b/common/README.md
@@ -6,9 +6,5 @@ This crate contains several things right now:
   Putting the structs in `common` instead of in a larger crate allows to break
   dependencies, and minimize the amount of code that compiles as `std` and `no_std`.
 - Common error types, used at API boundaries. The rationale is similar.
-- Forward declarations of functionality that is "common" to both inside and outside
-  the enclave. For instance, `mchash` and `mc-util-serial` types are forwarded from the
-  `common` crate. This avoids needing to list these dependencies explicitly in
-  all of the high level targets that use them.
-- Constants associated to attestation. These appear in `ias_settings` module.
-- Utility functions such as `for_each_set_bit`, which appears in `bits` module.
+- A shared hashmap object based on hashbrown that works in and out of the enclave.
+- Logging functionality

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -36,11 +36,12 @@ pub fn fast_hash(data: &[u8]) -> Hash {
     output
 }
 
+pub mod logger;
+
 // Logging related functionality
 cfg_if::cfg_if! {
     if #[cfg(feature = "log")] {
         mod panic_handler;
-        pub mod logger;
 
         pub use panic_handler::setup_panic_handler;
     }

--- a/common/src/logger/mod.rs
+++ b/common/src/logger/mod.rs
@@ -13,175 +13,183 @@
 //! Suitable for use with [filebeat](https://www.elastic.co/products/beats/filebeat).
 //! - MC_LOG_EXTRA_CONTEXT - Adds an extra logging context (key=val, separated by comma).
 
-/// Wrap calls to assert! macros to record an error message before panic
-#[macro_export]
-macro_rules! log_assert {
-    ($logger:expr, $cond:expr) => ({
-        if !$cond {
-            let cond_str = stringify!($cond);
-            log::crit!($logger, "assert!({}) failed", cond_str);
-            std::thread::sleep(Duration::from_millis(500));
-            panic!("assert!({}) failed", cond_str);
-        }
-    });
-    ($logger:expr, $cond:expr,) => ({
-        if !$cond {
-            let cond_str = stringify!($cond);
-            log::crit!($logger, "assert!({}) failed", cond_str);
-            std::thread::sleep(Duration::from_millis(500));
-            panic!("assert!({}) failed", cond_str);
-        }
-    });
-    ($logger:expr, $cond:expr, $($arg:tt)+) => ({
-        if !$cond {
-            let m = format!($($arg)+);
-            let cond_str = stringify!($cond);
-            log::crit!($logger, "assert!({}) failed, {}", cond_str, m);
-            std::thread::sleep(Duration::from_millis(500));
-            panic!("assert!({}) failed, {}", cond_str, m);
-        }
-    })
-}
-
-/// Wrap calls to assert_eq! macros to record an error message before panic
-#[macro_export]
-macro_rules! log_assert_eq {
-    ($logger:expr, $left:expr, $right:expr) => ({
-        log_assert!($logger, ($left) == ($right));
-    });
-    ($logger:expr, $left:expr, $right:expr,) => ({
-        log_assert!($logger, ($left) == ($right));
-    });
-    ($logger:expr, $left:expr, $right:expr, $($arg:tt)+) => ({
-        let m = format!($($arg)+);
-        log_assert!($logger, ($left) == ($right), "{}", m);
-    })
-}
-
-/// Wrap calls to assert_ne! macros to record an error message before panic
-#[macro_export]
-macro_rules! log_assert_ne {
-    ($logger:expr, $left:expr, $right:expr) => ({
-        log_assert!($logger, ($left) != ($right));
-    });
-    ($logger:expr, $left:expr, $right:expr,) => ({
-        log_assert!($logger, ($left) != ($right));
-    });
-    ($logger:expr, $left:expr, $right:expr, $($arg:tt)+) => ({
-        let m = format!($($arg)+);
-        log_assert!($logger, ($left) != ($right), "{}", m);
-    })
-}
-
 /// Expose the standard crit! debug! error! etc macros from slog
 /// (those are the ones that accept a Logger instance)
 pub mod log {
     pub use slog::{crit, debug, error, info, trace, warn};
 }
 
-/// A global logger, for when passing a Logger instance is impractical.
-pub mod global_log {
-    pub use slog_scope::{crit, debug, error, info, trace, warn};
-}
-
-/// Expose slog, slog_scope, and select useful primitives.
+/// Expose slog and select useful primitives.
 pub use slog;
 pub use slog::{o, FnValue, Logger, PushFnValue};
-pub use slog_scope;
-
-use std::time::Instant;
-
-// Loggers
-cfg_if::cfg_if! {
-    if #[cfg(feature = "loggers")] {
-        mod loggers;
-        pub use loggers::*;
-    }
-}
 
 /// Create a logger that discards everything.
 pub fn create_null_logger() -> Logger {
     Logger::root(slog::Discard, o!())
 }
 
-/// Get the global Logger instance, managed by `slog_scope`.
-pub fn global_logger() -> Logger {
-    slog_scope::logger()
-}
+cfg_if::cfg_if! {
+    if #[cfg(feature = "log")] {
+        /// Wrap calls to assert! macros to record an error message before panic
+        #[macro_export]
+        macro_rules! log_assert {
+            ($logger:expr, $cond:expr) => ({
+                if !$cond {
+                    let cond_str = stringify!($cond);
+                    log::crit!($logger, "assert!({}) failed", cond_str);
+                    std::thread::sleep(Duration::from_millis(500));
+                    panic!("assert!({}) failed", cond_str);
+                }
+            });
+            ($logger:expr, $cond:expr,) => ({
+                if !$cond {
+                    let cond_str = stringify!($cond);
+                    log::crit!($logger, "assert!({}) failed", cond_str);
+                    std::thread::sleep(Duration::from_millis(500));
+                    panic!("assert!({}) failed", cond_str);
+                }
+            });
+            ($logger:expr, $cond:expr, $($arg:tt)+) => ({
+                if !$cond {
+                    let m = format!($($arg)+);
+                    let cond_str = stringify!($cond);
+                    log::crit!($logger, "assert!({}) failed, {}", cond_str, m);
+                    std::thread::sleep(Duration::from_millis(500));
+                    panic!("assert!({}) failed, {}", cond_str, m);
+                }
+            })
+        }
 
-/// Convenience wrapper around `slog_scope::scope`.
-pub fn scoped_global_logger<F, R>(logger: &Logger, f: F) -> R
-where
-    F: FnOnce(&Logger) -> R,
-{
-    slog_scope::scope(&logger, || f(&logger))
-}
+        /// Wrap calls to assert_eq! macros to record an error message before panic
+        #[macro_export]
+        macro_rules! log_assert_eq {
+            ($logger:expr, $left:expr, $right:expr) => ({
+                log_assert!($logger, ($left) == ($right));
+            });
+            ($logger:expr, $left:expr, $right:expr,) => ({
+                log_assert!($logger, ($left) == ($right));
+            });
+            ($logger:expr, $left:expr, $right:expr, $($arg:tt)+) => ({
+                let m = format!($($arg)+);
+                log_assert!($logger, ($left) == ($right), "{}", m);
+            })
+        }
 
-/// Simple time measurement utility, based on the [measure_time](https://docs.rs/measure_time/) crate.
-/// Note that even though the macro lives inside the `logger` module, it needs to be imported by
-/// `use mc_common::trace_time`, since Rust exports all macros at the crate level :/
-#[macro_export]
-macro_rules! trace_time {
-    ($logger:expr, $($arg:tt)+) => (
-        let _trace_time = $crate::logger::TraceTime::new($logger.clone(), $crate::logger::slog::record_static!($crate::logger::slog::Level::Trace, ""), format!($($arg)+));
-    )
-}
+        /// Wrap calls to assert_ne! macros to record an error message before panic
+        #[macro_export]
+        macro_rules! log_assert_ne {
+            ($logger:expr, $left:expr, $right:expr) => ({
+                log_assert!($logger, ($left) != ($right));
+            });
+            ($logger:expr, $left:expr, $right:expr,) => ({
+                log_assert!($logger, ($left) != ($right));
+            });
+            ($logger:expr, $left:expr, $right:expr, $($arg:tt)+) => ({
+                let m = format!($($arg)+);
+                log_assert!($logger, ($left) != ($right), "{}", m);
+            })
+        }
 
-pub struct TraceTime<'a> {
-    logger: Logger,
-    rstatic: slog::RecordStatic<'a>,
-    msg: String,
-    start: Instant,
-}
+        /// A global logger, for when passing a Logger instance is impractical.
+        pub mod global_log {
+            pub use slog_scope::{crit, debug, error, info, trace, warn};
+        }
 
-impl<'a> TraceTime<'a> {
-    pub fn new(logger: Logger, rstatic: slog::RecordStatic<'a>, msg: String) -> Self {
-        let start = Instant::now();
-        Self {
-            logger,
-            rstatic,
-            msg,
-            start,
+        /// Expose slog_scope
+        pub use slog_scope;
+
+        use std::time::Instant;
+
+        /// Get the global Logger instance, managed by `slog_scope`.
+        #[cfg(feature = "log")]
+        pub fn global_logger() -> Logger {
+            slog_scope::logger()
+        }
+
+        /// Convenience wrapper around `slog_scope::scope`.
+        #[cfg(feature = "log")]
+        pub fn scoped_global_logger<F, R>(logger: &Logger, f: F) -> R
+        where
+            F: FnOnce(&Logger) -> R,
+        {
+            slog_scope::scope(&logger, || f(&logger))
+        }
+
+        /// Simple time measurement utility, based on the [measure_time](https://docs.rs/measure_time/) crate.
+        /// Note that even though the macro lives inside the `logger` module, it needs to be imported by
+        /// `use mc_common::trace_time`, since Rust exports all macros at the crate level :/
+        #[macro_export]
+        macro_rules! trace_time {
+            ($logger:expr, $($arg:tt)+) => (
+                let _trace_time = $crate::logger::TraceTime::new($logger.clone(), $crate::logger::slog::record_static!($crate::logger::slog::Level::Trace, ""), format!($($arg)+));
+            )
+        }
+
+        pub struct TraceTime<'a> {
+            logger: Logger,
+            rstatic: slog::RecordStatic<'a>,
+            msg: String,
+            start: Instant,
+        }
+
+        impl<'a> TraceTime<'a> {
+            pub fn new(logger: Logger, rstatic: slog::RecordStatic<'a>, msg: String) -> Self {
+                let start = Instant::now();
+                Self {
+                    logger,
+                    rstatic,
+                    msg,
+                    start,
+                }
+            }
+        }
+
+        impl<'a> Drop for TraceTime<'a> {
+            fn drop(&mut self) {
+                let time_in_ms = (self.start.elapsed().as_secs() as f64 * 1_000.0)
+                    + (self.start.elapsed().subsec_nanos() as f64 / 1_000_000.0);
+
+                let time = match time_in_ms as u64 {
+                    0..=3000 => format!("{}ms", time_in_ms),
+                    3001..=60000 => format!("{:.2}s", time_in_ms / 1000.0),
+                    _ => format!("{:.2}m", time_in_ms / 1000.0 / 60.0),
+                };
+
+                self.logger.log(&slog::Record::new(
+                    &self.rstatic,
+                    &format_args!("{}: took {}", self.msg, time),
+                    slog::b!("duration_ms" => time_in_ms),
+                ));
+            }
+        }
+
+        #[cfg(test)]
+        mod trace_time_tests {
+            use super::*;
+
+            #[test]
+            fn basic_trace_time() {
+                let logger = create_test_logger("basic_trace_time".to_string());
+
+                slog_scope::scope(&logger.clone(), || {
+                    trace_time!(global_logger(), "test global");
+
+                    {
+                        trace_time!(logger, "test inner");
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                    }
+
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                });
+            }
         }
     }
 }
 
-impl<'a> Drop for TraceTime<'a> {
-    fn drop(&mut self) {
-        let time_in_ms = (self.start.elapsed().as_secs() as f64 * 1_000.0)
-            + (self.start.elapsed().subsec_nanos() as f64 / 1_000_000.0);
-
-        let time = match time_in_ms as u64 {
-            0..=3000 => format!("{}ms", time_in_ms),
-            3001..=60000 => format!("{:.2}s", time_in_ms / 1000.0),
-            _ => format!("{:.2}m", time_in_ms / 1000.0 / 60.0),
-        };
-
-        self.logger.log(&slog::Record::new(
-            &self.rstatic,
-            &format_args!("{}: took {}", self.msg, time),
-            slog::b!("duration_ms" => time_in_ms),
-        ));
-    }
-}
-
-#[cfg(test)]
-mod trace_time_tests {
-    use super::*;
-
-    #[test]
-    fn basic_trace_time() {
-        let logger = create_test_logger("basic_trace_time".to_string());
-
-        slog_scope::scope(&logger.clone(), || {
-            trace_time!(global_logger(), "test global");
-
-            {
-                trace_time!(logger, "test inner");
-                std::thread::sleep(std::time::Duration::from_millis(10));
-            }
-
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        });
+cfg_if::cfg_if! {
+    // Loggers
+    if #[cfg(all(feature = "log", feature = "loggers"))] {
+        mod loggers;
+        pub use loggers::*;
     }
 }

--- a/consensus/enclave/Cargo.toml
+++ b/consensus/enclave/Cargo.toml
@@ -19,7 +19,6 @@ mc-sgx-backtrace-edl = { path = "../../sgx/backtrace-edl" }
 mc-sgx-debug-edl = { path = "../../sgx/debug-edl" }
 mc-sgx-panic-edl = { path = "../../sgx/panic-edl" }
 mc-sgx-report-cache-api = { path = "../../sgx/report-cache/api" }
-mc-sgx-slog = { path = "../../sgx/slog" }
 mc-sgx-slog-edl = { path = "../../sgx/slog-edl" }
 mc-sgx-types = { path = "../../sgx/types" }
 mc-sgx-urts = { path = "../../sgx/urts" }

--- a/consensus/enclave/src/lib.rs
+++ b/consensus/enclave/src/lib.rs
@@ -23,10 +23,6 @@ use mc_sgx_urts::SgxEnclave;
 use mc_transaction_core::{tx::TxOutMembershipProof, Block, BlockContents, BlockSignature};
 use std::{path, result::Result as StdResult, sync::Arc};
 
-// This is here to force linkage
-#[allow(unused_imports)]
-use mc_sgx_slog::enclave_log;
-
 /// The default filename of the consensus service's SGX enclave binary.
 pub const ENCLAVE_FILE: &str = "libconsensus-enclave.signed.so";
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.6.0 (git+https://github.com/garbageslam/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf)",
+ "slog 2.6.0 (git+https://github.com/mobilecoinofficial/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf)",
 ]
 
 [[package]]
@@ -1453,7 +1453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "slog"
 version = "2.6.0"
-source = "git+https://github.com/garbageslam/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf#cc1562258b81353426d17a55b7447256fa6eabbf"
+source = "git+https://github.com/mobilecoinofficial/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf#cc1562258b81353426d17a55b7447256fa6eabbf"
 
 [[package]]
 name = "smallvec"
@@ -1793,7 +1793,7 @@ dependencies = [
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum signature 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "685e1c5b65c6cc6fd0eb9ba63c6cfb8431f7f9c7e078c626f23f50e13fa378d7"
 "checksum siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "83da420ee8d1a89e640d0948c646c1c088758d3a3c538f943bfa97bdac17929d"
-"checksum slog 2.6.0 (git+https://github.com/garbageslam/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf)" = "<none>"
+"checksum slog 2.6.0 (git+https://github.com/mobilecoinofficial/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf)" = "<none>"
 "checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -687,6 +687,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.6.0 (git+https://github.com/garbageslam/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf)",
 ]
 
 [[package]]
@@ -1034,8 +1035,9 @@ name = "mc-sgx-slog"
 version = "0.5.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mc-common 0.5.0",
+ "mc-sgx-build 0.5.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
- "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1450,8 +1452,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "slog"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.6.0"
+source = "git+https://github.com/garbageslam/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf#cc1562258b81353426d17a55b7447256fa6eabbf"
 
 [[package]]
 name = "smallvec"
@@ -1791,7 +1793,7 @@ dependencies = [
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum signature 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "685e1c5b65c6cc6fd0eb9ba63c6cfb8431f7f9c7e078c626f23f50e13fa378d7"
 "checksum siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "83da420ee8d1a89e640d0948c646c1c088758d3a3c538f943bfa97bdac17929d"
-"checksum slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
+"checksum slog 2.6.0 (git+https://github.com/garbageslam/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf)" = "<none>"
 "checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -68,6 +68,6 @@ prost = { git = "https://github.com/danburkert/prost", rev = "6113789f70b6970982
 prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
 # slog is patched in order to build in no_std config with dynamic_keys feature on
 # https://github.com/slog-rs/slog/pull/268
-slog = { git = "https://github.com/garbageslam/slog", rev = "cc1562258b81353426d17a55b7447256fa6eabbf" }
+slog = { git = "https://github.com/mobilecoinofficial/slog", rev = "cc1562258b81353426d17a55b7447256fa6eabbf" }
 
 [workspace]

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -35,7 +35,7 @@ mc-sgx-debug-edl = { path = "../../../sgx/debug-edl" }
 mc-sgx-enclave-id = { path = "../../../sgx/enclave-id" }
 mc-sgx-panic-edl = { path = "../../../sgx/panic-edl" }
 mc-sgx-report-cache-api = { path = "../../../sgx/report-cache/api" }
-mc-sgx-slog = { path = "../../../sgx/slog" }
+mc-sgx-slog = { path = "../../../sgx/slog", features = ["sgx"] }
 mc-sgx-slog-edl = { path = "../../../sgx/slog-edl" }
 mc-sgx-types = { path = "../../../sgx/types" }
 
@@ -63,5 +63,6 @@ overflow-checks = false
 [patch.crates-io]
 prost = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
 prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
+slog = { git = "https://github.com/garbageslam/slog", rev = "cc1562258b81353426d17a55b7447256fa6eabbf" }
 
 [workspace]

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -61,8 +61,13 @@ debug-assertions = false
 overflow-checks = false
 
 [patch.crates-io]
+# prost is patched with no_std support (https://github.com/danburkert/prost/pull/319)
+# current revision is from jun 13 2020, waiting for a new prost release
+# https://github.com/danburkert/prost/issues/329
 prost = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
 prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
+# slog is patched in order to build in no_std config with dynamic_keys feature on
+# https://github.com/slog-rs/slog/pull/268
 slog = { git = "https://github.com/garbageslam/slog", rev = "cc1562258b81353426d17a55b7447256fa6eabbf" }
 
 [workspace]

--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -22,7 +22,7 @@ lazy_static! {
     static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(&ecall_dispatcher);
 
     /// Storage for the business logic / implementation state
-    static ref ENCLAVE: SgxConsensusEnclave = Default::default();
+    static ref ENCLAVE: SgxConsensusEnclave = SgxConsensusEnclave::new(mc_sgx_slog::default_logger());
 }
 
 /// Dispatch ecalls with the unified signature

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -26,7 +26,6 @@ mc-ledger-db = { path = "../../ledger/db" }
 mc-ledger-sync = { path = "../../ledger/sync" }
 mc-peers = { path = "../../peers" }
 mc-sgx-report-cache-untrusted = { path = "../../sgx/report-cache/untrusted" }
-mc-sgx-slog = { path = "../../sgx/slog", features = ["std"] }
 mc-sgx-urts = { path = "../../sgx/urts" }
 mc-transaction-core = { path = "../../transaction/core"}
 mc-transaction-std = { path = "../../transaction/std"}

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -6,12 +6,13 @@ edition = "2018"
 
 [features]
 default = []
-std = [
-    "slog-scope",
-]
+sgx = []
 
 [dependencies]
 cfg-if = "0.1"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
-slog = { version = "2.5", features = ["max_level_trace", "release_max_level_trace"], default-features = false }
-slog-scope = { version = "4.1.2", optional = true }
+
+mc-common = { path = "../../common", default-features = false }
+
+[build-dependencies]
+mc-sgx-build = { path = "../build" }

--- a/sgx/slog/build.rs
+++ b/sgx/slog/build.rs
@@ -1,0 +1,6 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+fn main() {
+    // This is needed because we disable logging in prod
+    mc_sgx_build::handle_ias_dev_feature();
+}

--- a/sgx/slog/src/common.rs
+++ b/sgx/slog/src/common.rs
@@ -2,6 +2,7 @@
 
 //! Code that is common to both enclave and untrusted.
 
+use mc_common::logger::slog;
 use slog::KV;
 
 use alloc::string::{String, ToString};

--- a/sgx/slog/src/lib.rs
+++ b/sgx/slog/src/lib.rs
@@ -1,18 +1,14 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 extern crate alloc;
 
 mod common;
+pub use common::EnclaveLogMessage;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature="std")] {
-        // Untrusted code
-        mod untrusted;
-        pub use untrusted::*;
-    } else {
-        // Enclave
+    if #[cfg(feature="sgx")] {
         mod trusted;
         pub use trusted::*;
     }

--- a/sgx/slog/src/trusted.rs
+++ b/sgx/slog/src/trusted.rs
@@ -8,14 +8,8 @@ extern "C" {
     fn enclave_log(msg: *const u8, msg_len: usize);
 }
 
-/// Expose slog
-pub use slog::*;
-
-/// Expose the standard crit! debug! error! etc macros from slog
-/// (those are the ones that accept a Logger instance), under the `log` namespace.
-pub mod log {
-    pub use slog::{crit, debug, error, info, trace, warn};
-}
+use mc_common::logger::slog;
+use slog::{o, Logger};
 
 /// slog Drain for use inside enclaves, that uses an OCALL to output log messages.
 pub struct EnclaveOCallDrain;
@@ -41,13 +35,13 @@ impl slog::Drain for EnclaveOCallDrain {
 }
 
 /// Utility method to create a Logger suitable for in-enclave logging.
-#[cfg(debug_assertions)]
+#[cfg(feature = "ias-dev")]
 pub fn default_logger() -> Logger {
     Logger::root(slog::Fuse(EnclaveOCallDrain {}), o!())
 }
 
-// No logs from enclave when not compiled in debug mode.
-#[cfg(not(debug_assertions))]
+// No logs from enclave when not compiled in development mode.
+#[cfg(not(feature = "ias-dev"))]
 pub fn default_logger() -> Logger {
     Logger::root(slog::Fuse(slog::Discard), o!())
 }

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -8,11 +8,15 @@ default = [ "backtrace" ]
 backtrace = [ "rustc-demangle", "lazy_static" ]
 
 [dependencies]
+mc-common = { path = "../../common", features = ["log"] }
+mc-sgx-slog = { path = "../slog" }
 mc-sgx-libc-types = { path = "../libc-types" }
 mc-sgx-types = { path = "../types" }
+
 lazy_static = { version = "1.4", optional = true }
 rustc-demangle = { version = "0.1.10", optional = true }
 #backtrace-sys = { version = "0.1.24", optional = true }
+prost = { version = "0.6.1", default-features = false }
 
 [build-dependencies]
 mc-sgx-build = { path = "../build" }

--- a/sgx/urts/src/eprintln.rs
+++ b/sgx/urts/src/eprintln.rs
@@ -3,7 +3,14 @@
 // Mobilenode-side support for sgx_debug crate impl
 //
 // Allows dev-build debugging messages similar to eprintln!
+// from within the enclave.
+//
+// We print them to slog because that is our logging infrastructure
+//
+// Note: This is deprecated and the eprintln should go away, the logger
+// API is what you should use.
 
+use mc_common::logger::global_log;
 use std::str;
 
 #[no_mangle]
@@ -11,10 +18,11 @@ pub extern "C" fn eprintln_message(msg: *const u8, msg_len: usize) {
     let msg_bytes = unsafe { std::slice::from_raw_parts(msg, msg_len) };
 
     match str::from_utf8(msg_bytes) {
-        Ok(v) => eprintln!("Enclave log: {}", v),
-        Err(e) => eprintln!(
-            "Enclave log message contained invalid utf8:\n{}\n{:?}",
-            e, msg_bytes
+        Ok(v) => global_log::info!("Enclave eprintln: {}", v),
+        Err(e) => global_log::info!(
+            "Enclave eprintln message contained invalid utf8:\n{}\n{:?}",
+            e,
+            msg_bytes
         ),
     }
 }

--- a/sgx/urts/src/lib.rs
+++ b/sgx/urts/src/lib.rs
@@ -1,7 +1,11 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
+extern crate mc_common;
 extern crate mc_sgx_libc_types;
+extern crate mc_sgx_slog;
 extern crate mc_sgx_types;
+
+extern crate prost;
 
 #[cfg(feature = "backtrace")]
 extern crate rustc_demangle;
@@ -12,6 +16,7 @@ extern crate lazy_static;
 mod enclave;
 mod eprintln;
 mod panic;
+mod slog;
 
 #[cfg(feature = "backtrace")]
 mod backtrace;

--- a/sgx/urts/src/panic.rs
+++ b/sgx/urts/src/panic.rs
@@ -2,9 +2,10 @@
 
 // Mobilenode-side support for sgx_panic crate impl
 //
-// If the enclave panics, it will pass us a message, which we write to stderr
+// If the enclave panics, it will pass us a message, which we log as critical.
 // The enclave is expected to call rsgx_abort itself after this
 
+use mc_common::logger::global_log;
 use std::str;
 
 #[no_mangle]
@@ -12,10 +13,11 @@ pub extern "C" fn report_panic_message(msg: *const u8, msg_len: usize) {
     let panic_msg_bytes = unsafe { std::slice::from_raw_parts(msg, msg_len) };
 
     match str::from_utf8(panic_msg_bytes) {
-        Ok(v) => eprintln!("Enclave panic:\n{}\n", v),
-        Err(e) => eprintln!(
+        Ok(v) => global_log::crit!("Enclave panic:\n{}\n", v),
+        Err(e) => global_log::crit!(
             "Enclave panic message contained invalid utf8:\n{}\n{:?}",
-            e, panic_msg_bytes
+            e,
+            panic_msg_bytes
         ),
     }
 }

--- a/sgx/urts/src/slog.rs
+++ b/sgx/urts/src/slog.rs
@@ -1,8 +1,15 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
-use crate::common::EnclaveLogMessage;
+//! Backend which forwards EnclaveLogMessages to slog with appropriate source
+//! information
+
+use mc_common::logger::{
+    global_log, slog,
+    slog::{Level, Record, RecordLocation, RecordStatic},
+    slog_scope,
+};
+use mc_sgx_slog::EnclaveLogMessage;
 use prost::Message;
-use slog::{Level, Record, RecordLocation, RecordStatic};
 use std::slice;
 
 static ENCLAVE_SLOG_LOCATION: RecordLocation = RecordLocation {
@@ -13,12 +20,10 @@ static ENCLAVE_SLOG_LOCATION: RecordLocation = RecordLocation {
     module: "<enclave>",
 };
 
-/// # Safety
-///
-/// This function is marked unsafe due to receiving a raw pointer from the caller.
+// This function is unsafe, if the caller misuses the API it can cause undefined behavior
 #[no_mangle]
-pub unsafe extern "C" fn enclave_log(msg: *const u8, msg_len: usize) {
-    let msg_bytes = slice::from_raw_parts(msg, msg_len);
+pub extern "C" fn enclave_log(msg: *const u8, msg_len: usize) {
+    let msg_bytes = unsafe { slice::from_raw_parts(msg, msg_len) };
     let msg = EnclaveLogMessage::decode(msg_bytes);
 
     match msg {
@@ -43,9 +48,10 @@ pub unsafe extern "C" fn enclave_log(msg: *const u8, msg_len: usize) {
                 slog::b!(),
             ));
         }
-        Err(e) => eprintln!(
+        Err(e) => global_log::error!(
             "Enclave log message contained invalid message:\n{}\n{:?}",
-            e, msg_bytes
+            e,
+            msg_bytes
         ),
     }
 }


### PR DESCRIPTION
When we planned out the way that we build enclaves, one of the main
questions was "how do we unit test the mission critical code that
lives in enclaves". We split this logic into `_impl` crates that
can compile as std, without having any sgx-only bits inside them.

Currently, none of these crates support logging, because the
`mc-common::logger` module is std-only. We built an `mc-sgx-slog`
interface which sends slog structures logs over an OCALL to untrusted
to be logged on the global logger. But because this code was
enclave-specific, there was no way to actually use this in the
enclave/impl crates without breaking the tests. And so `mc-sgx-slog`
has been basically unused. None of the `_impl` crates use it, and none
of the tests even use the `[test_with_logger]` functionality, because
they can't actually use the logger in the code under test.

After this revision we make the following changes:

- `mc-common` depends unconditionally on `slog`, and configures it
  in a `no_std` mode.
- `mc-common` unconditionally re-exports `mc-common::logger`, giving
  the `mc-common::logger::log` and `mc-common::logger::slog` parts,
  because these are portable to the enclaves.
- Everything that depends on `slog` now gets it from the `mc-common`
  re-export instead of duplicating the dependency in its cargo toml.
- `slog` is patched to fix minor problems in its no_std build when
  `dynamic_keys` feature is turned on.
- Functionality in `mc-common::logger` that depends on `slog_scope`
  is gated on `log` feature as before, and this requires `std`.
- Functionality in `mc-common::logger` that depends on `loggers`
  feature is still gated on `loggers` as before.
- The `mc-sgx-slog::untrusted` module is moved to the `mc-sgx-urts`
  crate with the other logging related stuff. This also means that
  some times that a server needs to depend `mc-sgx-slog` "only for linkage"
  are removed, because it gets the needed code from `mc-sgx-urts` now.
- `mc-sgx-urts` now sends `eprintln` and `panic` messages to
  `global_log` instead of `eprintln`.
- `consensus-enclave-impl` owns a `Logger` object where it sends log
   messages
- Tests in `consensus-enclave-impl` use `test_with_logger` and build
  the enclave using the test logger, to demonstrate that the functionality
  works.

The biggest drawback in this commit is that it makes the `mc-common::logger`
module messy, but this module was already messy and was re-exporting
a lot of complicated and variously portable stuff from `slog-*` crates. The alternative
here is that everything starts depending on my patched slog, and if they don't all
get the right version then the build breaks. In this commit, we have tried to keep
that module as nice as possible without breaking the API that it defined.

We propose to consider changes to the API of the `mc-common::logger` module
in another commit, because that will be onerous and will require touching
almost the entire project, anything that uses the logger. By scoping this
commit so that we don't change the API of `mc-common` we make it possible
to land it and unblock other work that needs logging in enclaves.

It seems that the logger module needs to be redesigned with the idea that
there are three different components that different consumers need:
- `slog` itself, which is totally portable
- `slog_scope`, which is not portable to enclave, depends on `std` and a
  quite complex `ArcSwap` crate. This is used to manage the lifetime
  of the global logger instance. It also depends on thread local vectors of
  logger pointers, to manage the scope loggers. This stuff is no_std
  compatible only in nightly compiler because it relies on thread_local.
  But we already have several pieces of code that are nightly only.
  IMO We should consider whether
  to patch this crate to make it `no_std` compatible, which would
  simplify stuff somewhat. We would have to get rid of ArcSwap but
  that might be for the best anyways, it's difficult for me to see
  why we need all that, we could require that `set_global_logger`
  is only called once and not allow swapping out global logger on
  the fly. I have never seen a legitimate use-case for that in any project.
  But it's not for sure that we even need
  the `global_log` API in enclaves, we can probably get by without it.
- `sentry` etc., which depends on `std` and an http stack, which we
  cannot compile with `libmobilecoin` or for the phones.