### PR TITLE
fixup `unsafe` status of extern "C" function signatures in sgx-urts

### DIFF
--- a/sgx/urts/src/backtrace/mod.rs
+++ b/sgx/urts/src/backtrace/mod.rs
@@ -43,13 +43,15 @@ lazy_static! {
 }
 
 #[no_mangle]
-pub extern "C" fn report_backtrace(
+pub unsafe extern "C" fn report_backtrace(
     eid: sgx_enclave_id_t,
     frames_ptr: *const Frame,
     num_frames: usize,
 ) {
-    let frames: &[Frame] = unsafe { slice::from_raw_parts(frames_ptr, num_frames) };
+    report_backtrace_impl(eid, slice::from_raw_parts(frames_ptr, num_frames));
+}
 
+fn report_backtrace_impl(eid: sgx_enclave_id_t, frames: &[Frame]) {
     symbolicate_and_print_backtrace(eid, frames);
 }
 

--- a/sgx/urts/src/eprintln.rs
+++ b/sgx/urts/src/eprintln.rs
@@ -14,9 +14,11 @@ use mc_common::logger::global_log;
 use std::str;
 
 #[no_mangle]
-pub extern "C" fn eprintln_message(msg: *const u8, msg_len: usize) {
-    let msg_bytes = unsafe { std::slice::from_raw_parts(msg, msg_len) };
+pub unsafe extern "C" fn eprintln_message(msg: *const u8, msg_len: usize) {
+    eprintln_message_impl(std::slice::from_raw_parts(msg, msg_len))
+}
 
+fn eprintln_message_impl(msg_bytes: &[u8]) {
     match str::from_utf8(msg_bytes) {
         Ok(v) => global_log::info!("Enclave eprintln: {}", v),
         Err(e) => global_log::info!(

--- a/sgx/urts/src/panic.rs
+++ b/sgx/urts/src/panic.rs
@@ -9,9 +9,11 @@ use mc_common::logger::global_log;
 use std::str;
 
 #[no_mangle]
-pub extern "C" fn report_panic_message(msg: *const u8, msg_len: usize) {
-    let panic_msg_bytes = unsafe { std::slice::from_raw_parts(msg, msg_len) };
+pub unsafe extern "C" fn report_panic_message(msg: *const u8, msg_len: usize) {
+    report_panic_message_impl(std::slice::from_raw_parts(msg, msg_len))
+}
 
+fn report_panic_message_impl(panic_msg_bytes: &[u8]) {
     match str::from_utf8(panic_msg_bytes) {
         Ok(v) => global_log::crit!("Enclave panic:\n{}\n", v),
         Err(e) => global_log::crit!(

--- a/sgx/urts/src/slog.rs
+++ b/sgx/urts/src/slog.rs
@@ -22,8 +22,11 @@ static ENCLAVE_SLOG_LOCATION: RecordLocation = RecordLocation {
 
 // This function is unsafe, if the caller misuses the API it can cause undefined behavior
 #[no_mangle]
-pub extern "C" fn enclave_log(msg: *const u8, msg_len: usize) {
-    let msg_bytes = unsafe { slice::from_raw_parts(msg, msg_len) };
+pub unsafe extern "C" fn enclave_log(msg: *const u8, msg_len: usize) {
+    enclave_log_impl(slice::from_raw_parts(msg, msg_len));
+}
+
+fn enclave_log_impl(msg_bytes: &[u8]) {
     let msg = EnclaveLogMessage::decode(msg_bytes);
 
     match msg {


### PR DESCRIPTION
This follows up on review comments from: https://github.com/mobilecoinofficial/mobilecoin/pull/358