### PR TITLE
Trait and Mock for Slot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,6 +2360,7 @@ dependencies = [
  "mc-util-metrics",
  "mc-util-serial",
  "mc-util-test-helper",
+ "mockall",
  "pretty_assertions",
  "rand 0.7.3",
  "rand_hc 0.2.0",

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -32,6 +32,7 @@ mc-util-logger-macros = { path = "../../util/logger-macros" }
 mc-util-test-helper = { path = "../../util/test-helper" }
 
 crossbeam-channel = "0.3"
+mockall = "0.7.2"
 pretty_assertions = "0.6.1"
 serial_test = "0.1"
 serial_test_derive = "0.1"

--- a/consensus/scp/src/core_types.rs
+++ b/consensus/scp/src/core_types.rs
@@ -54,12 +54,22 @@ pub type SlotIndex = u64;
 
 /// The value on which to consense.
 pub trait Value:
-    Hash + Eq + PartialEq + Debug + Clone + PartialOrd + Ord + Send + Serialize + Digestible
+    Hash + Eq + PartialEq + Debug + Clone + PartialOrd + Ord + Send + Serialize + Digestible + 'static
 {
 }
 
 impl<T> Value for T where
-    T: Hash + Eq + PartialEq + Debug + Clone + PartialOrd + Ord + Send + Serialize + Digestible
+    T: Hash
+        + Eq
+        + PartialEq
+        + Debug
+        + Clone
+        + PartialOrd
+        + Ord
+        + Send
+        + Serialize
+        + Digestible
+        + 'static
 {
 }
 

--- a/consensus/scp/src/node.rs
+++ b/consensus/scp/src/node.rs
@@ -147,8 +147,8 @@ pub trait ScpNode<V: Value>: Send {
     /// Get metrics for a specific slot.
     fn get_slot_metrics(&mut self, slot_index: SlotIndex) -> Option<SlotMetrics>;
 
-    /// Get the slot internal state (for debug purposes).
-    fn get_slot_state(&mut self, slot_index: SlotIndex) -> Option<String>;
+    /// Additional debug info, e.g. a JSON representation of the Slot's state.
+    fn get_slot_debug_snapshot(&mut self, slot_index: SlotIndex) -> Option<String>;
 
     /// Clear the list of pending slots. This is useful if the user of this object realizes they
     /// have fallen behind their peers, and as such they want to abort processing of current slots.
@@ -265,7 +265,7 @@ impl<V: Value, ValidationError: Display + 'static> ScpNode<V> for Node<V, Valida
     }
 
     /// Get the slot internal state (for debug purposes).
-    fn get_slot_state(&mut self, slot_index: SlotIndex) -> Option<String> {
+    fn get_slot_debug_snapshot(&mut self, slot_index: SlotIndex) -> Option<String> {
         self.pending
             .get(&slot_index)
             .map(|slot| slot.get_debug_snapshot())

--- a/consensus/scp/src/node.rs
+++ b/consensus/scp/src/node.rs
@@ -279,11 +279,49 @@ impl<V: Value, ValidationError: Display + 'static> ScpNode<V> for Node<V, Valida
 }
 
 #[cfg(test)]
-mod tests {
+mod node_tests {
     use super::*;
     use crate::{core_types::Ballot, msg::*, test_utils::*};
     use mc_common::logger::test_with_logger;
     use std::{iter::FromIterator, sync::Arc};
+
+    // use crate::slot::MockScpSlot;
+
+    #[test_with_logger]
+    fn test_initialization(logger: Logger) {
+        let node = Node::<u32, TransactionValidationError>::new(
+            test_node_id(1),
+            QuorumSet::new_with_node_ids(1, vec![test_node_id(2)]),
+            Arc::new(trivial_validity_fn),
+            Arc::new(trivial_combine_fn),
+            logger.clone(),
+        );
+
+        assert!(node.pending.is_empty());
+        assert!(node.externalized.is_empty());
+    }
+
+    #[test_with_logger]
+    #[ignore]
+    fn test_propose_values_create_new_slot(logger: Logger) {
+        type V = &'static str;
+
+        let mut _node = Node::<V, TransactionValidationError>::new(
+            test_node_id(1),
+            QuorumSet::new_with_node_ids(1, vec![test_node_id(2)]),
+            Arc::new(trivial_validity_fn),
+            Arc::new(trivial_combine_fn),
+            logger.clone(),
+        );
+
+        // // mock the current slot
+        // let slot = MockScpSlot::<V>::new();
+        // node.pending.put(1, Box::new(slot));
+        // node.propose_values()
+
+        // TODO:
+        unimplemented!()
+    }
 
     #[test_with_logger]
     /// Steps through a sequence of messages that allow a two-node network to reach consensus.

--- a/consensus/scp/src/node.rs
+++ b/consensus/scp/src/node.rs
@@ -5,7 +5,7 @@ use crate::{
     core_types::{CombineFn, SlotIndex, ValidityFn, Value},
     msg::{ExternalizePayload, Msg, Topic},
     quorum_set::QuorumSet,
-    slot::{Slot, SlotMetrics},
+    slot::{ScpSlot, Slot, SlotMetrics},
     slot_state::SlotState,
 };
 use mc_common::{

--- a/consensus/scp/src/node.rs
+++ b/consensus/scp/src/node.rs
@@ -6,7 +6,6 @@ use crate::{
     msg::{ExternalizePayload, Msg, Topic},
     quorum_set::QuorumSet,
     slot::{ScpSlot, Slot, SlotMetrics},
-    slot_state::SlotState,
 };
 use mc_common::{
     logger::{log, Logger},
@@ -152,7 +151,7 @@ pub trait ScpNode<V: Value>: Send {
     fn get_slot_metrics(&mut self, slot_index: SlotIndex) -> Option<SlotMetrics>;
 
     /// Get the slot internal state (for debug purposes).
-    fn get_slot_state(&mut self, slot_index: SlotIndex) -> Option<SlotState<V>>;
+    fn get_slot_state(&mut self, slot_index: SlotIndex) -> Option<String>;
 
     /// Clear the list of pending slots. This is useful if the user of this object realizes they
     /// have fallen behind their peers, and as such they want to abort processing of current slots.
@@ -269,8 +268,10 @@ impl<V: Value, ValidationError: Display> ScpNode<V> for Node<V, ValidationError>
     }
 
     /// Get the slot internal state (for debug purposes).
-    fn get_slot_state(&mut self, slot_index: SlotIndex) -> Option<SlotState<V>> {
-        self.pending.get(&slot_index).map(SlotState::from)
+    fn get_slot_state(&mut self, slot_index: SlotIndex) -> Option<String> {
+        self.pending
+            .get(&slot_index)
+            .map(|slot| slot.get_debug_snapshot())
     }
 
     /// Clear the list of pending slots. This is useful if the user of this object realizes they

--- a/consensus/scp/src/scp_log.rs
+++ b/consensus/scp/src/scp_log.rs
@@ -164,7 +164,7 @@ impl<V: Value, N: ScpNode<V>> LoggingScpNode<V, N> {
             .map_err(|e| format!("failed writing {:?}: {:?}", file_path, e))?;
 
         // Write slot state into a file.
-        if let Some(slot_state) = self.get_slot_state(msg_slot_index) {
+        if let Some(slot_state) = self.get_slot_debug_snapshot(msg_slot_index) {
             let slot_as_json = serde_json::to_vec(&slot_state)
                 .map_err(|e| format!("failed serializing slot state: {:?}", e))?;
 
@@ -257,8 +257,8 @@ impl<V: Value, N: ScpNode<V>> ScpNode<V> for LoggingScpNode<V, N> {
         self.node.get_slot_metrics(slot_index)
     }
 
-    fn get_slot_state(&mut self, slot_index: SlotIndex) -> Option<String> {
-        self.node.get_slot_state(slot_index)
+    fn get_slot_debug_snapshot(&mut self, slot_index: SlotIndex) -> Option<String> {
+        self.node.get_slot_debug_snapshot(slot_index)
     }
 
     fn clear_pending_slots(&mut self) {

--- a/consensus/scp/src/scp_log.rs
+++ b/consensus/scp/src/scp_log.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 //! This crate provides a logging framework for recording and replaying SCP messages.
-use crate::{slot::SlotMetrics, slot_state::SlotState, Msg, QuorumSet, ScpNode, SlotIndex, Value};
+use crate::{slot::SlotMetrics, Msg, QuorumSet, ScpNode, SlotIndex, Value};
 use mc_common::{
     logger::{log, Logger},
     NodeID,
@@ -257,7 +257,7 @@ impl<V: Value, N: ScpNode<V>> ScpNode<V> for LoggingScpNode<V, N> {
         self.node.get_slot_metrics(slot_index)
     }
 
-    fn get_slot_state(&mut self, slot_index: SlotIndex) -> Option<SlotState<V>> {
+    fn get_slot_state(&mut self, slot_index: SlotIndex) -> Option<String> {
         self.node.get_slot_state(slot_index)
     }
 

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -27,6 +27,9 @@ use core::cmp;
 use maplit::{btreeset, hashset};
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+use mockall::*;
+
 /// The various phases of the SCP protocol.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Phase {
@@ -44,6 +47,7 @@ pub enum Phase {
 }
 
 /// A Single slot of the SCP protocol.
+#[cfg_attr(test, automock)]
 pub trait ScpSlot<V: Value> {
     /// Get metrics about the slot.
     fn get_metrics(&self) -> SlotMetrics;

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -43,6 +43,21 @@ pub enum Phase {
     Externalize,
 }
 
+/// A Single slot of the SCP protocol.
+pub trait ScpSlot<V: Value> {
+    /// Get metrics about the slot.
+    fn get_metrics(&self) -> SlotMetrics;
+
+    /// Processes any timeouts that may have occurred.
+    fn process_timeouts(&mut self) -> Vec<Msg<V>>;
+
+    /// Propose values for this node to nominate.
+    fn propose_values(&mut self, values: &BTreeSet<V>) -> Result<Option<Msg<V>>, String>;
+
+    /// Handles an incoming message from a peer.
+    fn handle(&mut self, msg: &Msg<V>) -> Result<Option<Msg<V>>, String>;
+}
+
 /// The SCP slot.
 // Note: The fields representing the state of the slot are marked with pub(crate) so that they
 // could be accessed by `SlotState`.
@@ -152,56 +167,9 @@ pub struct SlotMetrics {
     pub bN: u32,
 }
 
-impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
-    ///////////////////////////////////////////////////////////////////////////
-    // Public methods (how the Slot interfaces with the Node)
-    ///////////////////////////////////////////////////////////////////////////
-
-    /// Create a new slot.
-    pub fn new(
-        node_id: NodeID,
-        quorum_set: QuorumSet,
-        slot_index: SlotIndex,
-        validity_fn: ValidityFn<V, ValidationError>,
-        combine_fn: CombineFn<V>,
-        logger: Logger,
-    ) -> Self {
-        let mut slot = Slot {
-            slot_index,
-            node_id,
-            quorum_set,
-            M: HashMap::default(),
-            W: HashSet::default(),
-            X: HashSet::default(),
-            Y: HashSet::default(),
-            Z: HashSet::default(),
-            B: Ballot::new(0, &Vec::new()),
-            P: None,
-            PP: None,
-            C: None,
-            H: None,
-            phase: Phase::NominatePrepare,
-            last_sent_msg: None,
-            max_priority_peers: HashSet::default(),
-            nominate_round: 1,
-            next_nominate_round_at: None,
-            next_ballot_at: None,
-            validity_fn,
-            combine_fn,
-            valid_values: BTreeSet::default(),
-            logger: logger.new(o!("mc.scp.slot" => slot_index)),
-            base_round_interval: Duration::from_millis(1000),
-            base_ballot_interval: Duration::from_millis(1000),
-        };
-
-        let max_priority_peer = slot.find_max_priority_peer(slot.nominate_round);
-        slot.max_priority_peers.insert(max_priority_peer);
-
-        slot
-    }
-
+impl<V: Value, ValidationError: Display> ScpSlot<V> for Slot<V, ValidationError> {
     /// Get some metrics/information about the slot for debugging purposes.
-    pub fn get_metrics(&self) -> SlotMetrics {
+    fn get_metrics(&self) -> SlotMetrics {
         SlotMetrics {
             phase: self.phase,
             num_voted_nominated: self.X.len(),
@@ -214,7 +182,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
 
     /// Processes any timeouts that may have occurred.
     /// Returns list of messages to broadcast to network.
-    pub fn process_timeouts(&mut self) -> Vec<Msg<V>> {
+    fn process_timeouts(&mut self) -> Vec<Msg<V>> {
         let mut msgs = Vec::<Msg<V>>::new();
 
         let mut timeout_occurred = false;
@@ -299,7 +267,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
     }
 
     /// Propose values for this node to nominate.
-    pub fn propose_values(&mut self, values: &BTreeSet<V>) -> Result<Option<Msg<V>>, String> {
+    fn propose_values(&mut self, values: &BTreeSet<V>) -> Result<Option<Msg<V>>, String> {
         // Only accept values during the Nominate phase and if no other values have been confirmed nominated.
         if !(self.phase == Phase::NominatePrepare && self.Z.is_empty()) {
             return Ok(self.out_msg());
@@ -323,7 +291,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
     /// Returns:
     /// * Ok(out_msg) - `out_msg` is an outgoing message from this node, if any.
     /// * Err(e) - Something went wrong while processing `msg`.
-    pub fn handle(&mut self, msg: &Msg<V>) -> Result<Option<Msg<V>>, String> {
+    fn handle(&mut self, msg: &Msg<V>) -> Result<Option<Msg<V>>, String> {
         // Reject messages for other slots.
         if self.slot_index != msg.slot_index {
             return Err("Message is not for the current slot.".to_string());
@@ -354,6 +322,55 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
         self.do_ballot_protocol();
 
         Ok(self.out_msg())
+    }
+}
+
+impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
+    ///////////////////////////////////////////////////////////////////////////
+    // Public methods (how the Slot interfaces with the Node)
+    ///////////////////////////////////////////////////////////////////////////
+
+    /// Create a new slot.
+    pub fn new(
+        node_id: NodeID,
+        quorum_set: QuorumSet,
+        slot_index: SlotIndex,
+        validity_fn: ValidityFn<V, ValidationError>,
+        combine_fn: CombineFn<V>,
+        logger: Logger,
+    ) -> Self {
+        let mut slot = Slot {
+            slot_index,
+            node_id,
+            quorum_set,
+            M: HashMap::default(),
+            W: HashSet::default(),
+            X: HashSet::default(),
+            Y: HashSet::default(),
+            Z: HashSet::default(),
+            B: Ballot::new(0, &Vec::new()),
+            P: None,
+            PP: None,
+            C: None,
+            H: None,
+            phase: Phase::NominatePrepare,
+            last_sent_msg: None,
+            max_priority_peers: HashSet::default(),
+            nominate_round: 1,
+            next_nominate_round_at: None,
+            next_ballot_at: None,
+            validity_fn,
+            combine_fn,
+            valid_values: BTreeSet::default(),
+            logger: logger.new(o!("mc.scp.slot" => slot_index)),
+            base_round_interval: Duration::from_millis(1000),
+            base_ballot_interval: Duration::from_millis(1000),
+        };
+
+        let max_priority_peer = slot.find_max_priority_peer(slot.nominate_round);
+        slot.max_priority_peers.insert(max_priority_peer);
+
+        slot
     }
 
     fn is_valid(&mut self, value: &V) -> Result<(), String> {


### PR DESCRIPTION
### Motivation

Currently, it has been difficult to test Node because some of its behavior requires carefully-constructed SCP messages which it passes to Slot. It would be easier to test if Slot could be mocked.

### In this PR
* Creates a Slot trait, and uses automock to generate mocks for testing.
* Adds some simple unit tests to Node that show mocking in action.

### Future Work
This PR leaves several parts of Node untested because those parts are likely to change soon.
