### PR TITLE
Revert 1a2f...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
+
+[[package]]
 name = "dtoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,10 +1086,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+
+[[package]]
+name = "fragile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fs_extra"
@@ -3700,6 +3721,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01458f8a19b10cb28195290942e3149161c75acf67ebc8fbf714ab67a2b943bc"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a673cb441f78cd9af4f5919c28576a3cc325fb6b54e42f7047dacce3c718c17b"
+dependencies = [
+ "cfg-if",
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.18",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3725,6 +3773,12 @@ dependencies = [
  "memchr",
  "version_check 0.1.5",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "notify"
@@ -3988,6 +4042,35 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
+name = "predicates"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
+dependencies = [
+ "difference",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -5787,6 +5870,12 @@ name = "traitobject"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+
+[[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "try-lock"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,12 +954,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
-
-[[package]]
 name = "dtoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,25 +1080,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-
-[[package]]
-name = "fragile"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fs_extra"
@@ -2460,7 +2439,6 @@ dependencies = [
  "mc-peers",
  "mc-peers-test-utils",
  "mc-sgx-build",
- "mc-sgx-report-cache-api",
  "mc-sgx-report-cache-untrusted",
  "mc-sgx-urts",
  "mc-transaction-core",
@@ -2474,7 +2452,6 @@ dependencies = [
  "mc-util-metrics",
  "mc-util-serial",
  "mc-util-uri",
- "mockall",
  "prost",
  "protobuf",
  "rand 0.7.3",
@@ -3723,33 +3700,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01458f8a19b10cb28195290942e3149161c75acf67ebc8fbf714ab67a2b943bc"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a673cb441f78cd9af4f5919c28576a3cc325fb6b54e42f7047dacce3c718c17b"
-dependencies = [
- "cfg-if",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.18",
-]
-
-[[package]]
 name = "more-asserts"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3775,12 +3725,6 @@ dependencies = [
  "memchr",
  "version_check 0.1.5",
 ]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "notify"
@@ -4044,35 +3988,6 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
-
-[[package]]
-name = "predicates"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
-dependencies = [
- "difference",
- "float-cmp",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
-dependencies = [
- "predicates-core",
- "treeline",
-]
 
 [[package]]
 name = "pretty_assertions"
@@ -5872,12 +5787,6 @@ name = "traitobject"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
-name = "treeline"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "try-lock"

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -10,7 +10,6 @@ mod error;
 mod messages;
 
 pub use crate::{error::Error, messages::EnclaveCall};
-pub use mc_sgx_report_cache_api::ReportableEnclave;
 
 use alloc::{string::String, vec::Vec};
 use core::{cmp::Ordering, hash::Hash, result::Result as StdResult};
@@ -20,6 +19,7 @@ use mc_attest_enclave_api::{
 };
 use mc_common::ResponderId;
 use mc_crypto_keys::{CompressedRistrettoPublic, Ed25519Public, X25519Public};
+use mc_sgx_report_cache_api::ReportableEnclave;
 use mc_transaction_core::{
     ring_signature::KeyImage,
     tx::{Tx, TxHash, TxOutMembershipProof},
@@ -202,7 +202,7 @@ pub trait ConsensusEnclave: ReportableEnclave {
     /// Retrieve the public identity of the enclave.
     fn get_identity(&self) -> Result<X25519Public>;
 
-    /// Retrieve the block signing public key from the enclave.
+    /// Retreive the block signing public key from the enclave.
     fn get_signer(&self) -> Result<Ed25519Public>;
 
     // CLIENT-FACING METHODS

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -64,11 +64,9 @@ mc-common = { path = "../../common", features = ["loggers"] }
 mc-consensus-enclave-mock = { path = "../../consensus/enclave/mock" }
 mc-ledger-db = { path = "../../ledger/db", features = ["test_utils"] }
 mc-peers-test-utils = { path = "../../peers/test-utils" }
-mc-sgx-report-cache-api = { path = "../../sgx/report-cache/api" }
 mc-transaction-core-test-utils = { path = "../../transaction/core/test-utils" }
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-logger-macros = { path = "../../util/logger-macros" }
-mockall = "0.7.2"
 rand_core = { version = "0.5", default-features = false }
 rand_hc = "0.2.0"
 tempdir = "0.3"

--- a/consensus/service/src/client_api_service.rs
+++ b/consensus/service/src/client_api_service.rs
@@ -19,7 +19,7 @@ use mc_ledger_db::Ledger;
 use mc_transaction_core::validation::TransactionValidationError;
 use mc_util_grpc::{rpc_logger, send_result};
 use mc_util_metrics::{self, SVC_COUNTERS};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 /// Maximum number of pending values for consensus service before rejecting add_transaction requests.
 const PENDING_LIMIT: i64 = 500;
@@ -29,7 +29,7 @@ pub struct ClientApiService<E: ConsensusEnclaveProxy, L: Ledger + Clone> {
     enclave: E,
     scp_client_value_sender: ProposeTxCallback,
     ledger: L,
-    tx_manager: Arc<Mutex<Box<dyn TxManager>>>,
+    tx_manager: TxManager<E, L>,
     is_serving_fn: Arc<(dyn Fn() -> bool + Sync + Send)>,
     logger: Logger,
 }
@@ -39,7 +39,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger + Clone> ClientApiService<E, L> {
         enclave: E,
         scp_client_value_sender: ProposeTxCallback,
         ledger: L,
-        tx_manager: Arc<Mutex<Box<dyn TxManager>>>,
+        tx_manager: TxManager<E, L>,
         is_serving_fn: Arc<(dyn Fn() -> bool + Sync + Send)>,
         logger: Logger,
     ) -> Self {
@@ -84,12 +84,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger + Clone> ClientApiService<E, L> {
         let tx_context = self.enclave.client_tx_propose(request.into())?;
         let tx_hash = tx_context.tx_hash;
 
-        match self
-            .tx_manager
-            .lock()
-            .expect("Lock poisoned")
-            .insert(tx_context)
-        {
+        match self.tx_manager.insert_proposed_tx(tx_context) {
             Ok(tx_context) => {
                 // Submit for consideration in next SCP slot.
                 (*self.scp_client_value_sender)(*tx_context.tx_hash(), None, None);

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -3,15 +3,9 @@
 //! The MobileCoin consensus service.
 
 use crate::{
-    attested_api_service::AttestedApiService,
-    background_work_queue::BackgroundWorkQueue,
-    blockchain_api_service,
-    byzantine_ledger::ByzantineLedger,
-    client_api_service,
-    config::Config,
-    counters, peer_api_service,
-    peer_keepalive::PeerKeepalive,
-    tx_manager::{TxManager, TxManagerImpl},
+    attested_api_service::AttestedApiService, background_work_queue::BackgroundWorkQueue,
+    blockchain_api_service, byzantine_ledger::ByzantineLedger, client_api_service, config::Config,
+    counters, peer_api_service, peer_keepalive::PeerKeepalive, tx_manager::TxManager,
     validators::DefaultTxManagerUntrustedInterfaces,
 };
 use failure::Fail;
@@ -101,7 +95,7 @@ pub struct ConsensusService<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync 
 
     peer_manager: ConnectionManager<PeerConnection<E>>,
     broadcaster: Arc<Mutex<ThreadedBroadcaster>>,
-    tx_manager: Arc<Mutex<Box<dyn TxManager>>>,
+    tx_manager: TxManager<E, LedgerDB>,
     peer_keepalive: Arc<Mutex<PeerKeepalive>>,
 
     admin_rpc_server: Option<AdminServer>,
@@ -157,11 +151,12 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
         )));
 
         // Tx Manager
-        let tx_manager = Box::new(TxManagerImpl::new(
+        let tx_manager = TxManager::new(
             enclave.clone(),
+            ledger_db.clone(),
             DefaultTxManagerUntrustedInterfaces::new(ledger_db.clone()),
             logger.clone(),
-        ));
+        );
 
         // Peer Keepalive
         let peer_keepalive = Arc::new(Mutex::new(PeerKeepalive::start(
@@ -186,7 +181,7 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
 
             peer_manager,
             broadcaster,
-            tx_manager: Arc::new(Mutex::new(tx_manager)),
+            tx_manager,
             peer_keepalive,
 
             admin_rpc_server: None,
@@ -548,11 +543,7 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
             // consensus time.
             if origin_node == &local_node_id || relay_from_nodes.contains(&origin_node.responder_id)
             {
-                if let Some(encrypted_tx) = tx_manager
-                    .lock()
-                    .expect("Lock poisoned")
-                    .get_encrypted_tx(&tx_hash)
-                {
+                if let Some(encrypted_tx) = tx_manager.get_encrypted_tx_by_hash(&tx_hash) {
                     broadcaster
                         .lock()
                         .expect("lock poisoned")

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -35,7 +35,7 @@ use mc_util_serial::deserialize;
 use std::{
     convert::{TryFrom, TryInto},
     str::FromStr,
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 // Callback method for returning the latest SCP message issued by the local node, used to
@@ -57,7 +57,7 @@ pub struct PeerApiService<E: ConsensusEnclaveProxy, L: Ledger> {
     ledger: L,
 
     /// Transactions Manager instance.
-    tx_manager: Arc<Mutex<Box<dyn TxManager>>>,
+    tx_manager: TxManager<E, L>,
 
     /// Callback function for getting the latest SCP statement the local node has issued.
     fetch_latest_msg_fn: FetchLatestMsgFn,
@@ -78,7 +78,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> PeerApiService<E, L> {
         incoming_consensus_msgs_sender: BackgroundWorkQueueSenderFn<IncomingConsensusMsg>,
         scp_client_value_sender: ProposeTxCallback,
         ledger: L,
-        tx_manager: Arc<Mutex<Box<dyn TxManager>>>,
+        tx_manager: TxManager<E, L>,
         fetch_latest_msg_fn: FetchLatestMsgFn,
         known_responder_ids: Vec<ResponderId>,
         logger: Logger,
@@ -115,12 +115,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> PeerApiService<E, L> {
         for tx_context in tx_contexts {
             let tx_hash = tx_context.tx_hash;
 
-            match self
-                .tx_manager
-                .lock()
-                .expect("Lock poisoned")
-                .insert(tx_context)
-            {
+            match self.tx_manager.insert_proposed_tx(tx_context) {
                 Ok(tx_context) => {
                     // Submit for consideration in next SCP slot.
                     (*self.scp_client_value_sender)(
@@ -129,6 +124,8 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> PeerApiService<E, L> {
                         relayed_by.as_ref(),
                     );
                 }
+
+                Err(TxManagerError::AlreadyInCache) => {}
 
                 Err(TxManagerError::TransactionValidation(err)) => {
                     log::debug!(
@@ -169,15 +166,11 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> PeerApiService<E, L> {
             })
             .collect::<Result<Vec<TxHash>, ConsensusGrpcError>>()?;
 
-        match self
-            .tx_manager
-            .lock()
-            .expect("Lock poisoned")
-            .encrypt_for_peer(
-                &tx_hashes,
-                &[],
-                &PeerSession::from(request.get_channel_id()),
-            ) {
+        match self.tx_manager.txs_for_peer(
+            &tx_hashes,
+            &[],
+            &PeerSession::from(request.get_channel_id()),
+        ) {
             Ok(enclave_message) => Ok(enclave_message.into()),
             Err(err) => {
                 log::warn!(

--- a/consensus/service/src/tx_manager.rs
+++ b/consensus/service/src/tx_manager.rs
@@ -10,11 +10,11 @@ use mc_common::{
     HashMap, HashSet,
 };
 use mc_consensus_enclave::{
-    ConsensusEnclave, Error as ConsensusEnclaveError, TxContext, WellFormedEncryptedTx,
+    ConsensusEnclaveProxy, Error as ConsensusEnclaveError, TxContext, WellFormedEncryptedTx,
     WellFormedTxContext,
 };
 use mc_crypto_keys::CompressedRistrettoPublic;
-use mc_ledger_db::Error as LedgerDbError;
+use mc_ledger_db::{Error as LedgerDbError, Ledger};
 use mc_transaction_core::{
     constants::MAX_TRANSACTIONS_PER_BLOCK,
     ring_signature::KeyImage,
@@ -22,8 +22,11 @@ use mc_transaction_core::{
     validation::{TransactionValidationError, TransactionValidationResult},
     Block, BlockContents, BlockSignature,
 };
-#[cfg(test)]
-use mockall::*;
+use std::{
+    collections::BTreeSet,
+    iter::FromIterator,
+    sync::{Arc, Mutex, MutexGuard},
+};
 
 #[derive(Clone, Debug, Fail)]
 pub enum TxManagerError {
@@ -32,6 +35,9 @@ pub enum TxManagerError {
 
     #[fail(display = "Transaction validation error: {}", _0)]
     TransactionValidation(TransactionValidationError),
+
+    #[fail(display = "Tx already in cache")]
+    AlreadyInCache,
 
     #[fail(display = "Tx not in cache ({})", _0)]
     NotInCache(TxHash),
@@ -80,9 +86,9 @@ impl CacheEntry {
     }
 }
 
-/// Transaction checks performed outside the enclave.
-#[cfg_attr(test, automock)]
-pub trait UntrustedInterfaces: Send {
+/// A trait for representing the untrusted part of validation/combining. This is presented as a
+/// trait to make testing easier.
+pub trait UntrustedInterfaces: Clone {
     /// Performs the untrusted part of the well-formed check.
     /// Returns current block index and membership proofs to be used by
     /// the in-enclave well-formed check on success.
@@ -104,93 +110,73 @@ pub trait UntrustedInterfaces: Send {
     /// * `max_elements` - Maximal number of elements to output.
     ///
     /// Returns a bounded, deterministically-ordered list of transactions that are safe to append to the ledger.
-    fn combine(&self, tx_contexts: &[WellFormedTxContext], max_elements: usize) -> Vec<TxHash>;
+    fn combine(&self, tx_contexts: &[&WellFormedTxContext], max_elements: usize) -> Vec<TxHash>;
 }
 
-#[cfg_attr(test, automock)]
-pub trait TxManager: Send {
-    /// Insert a transaction into the cache. The transaction must be well-formed.
-    fn insert(&mut self, tx_context: TxContext) -> TxManagerResult<WellFormedTxContext>;
-
-    /// Remove expired transactions from the cache and return their hashes.
-    fn remove_expired(&mut self, block_index: u64) -> HashSet<TxHash>;
-
-    // Returns true if the cache contains the transaction.
-    fn contains(&self, tx_hash: &TxHash) -> bool;
-
-    /// The number of cached entries.
-    fn num_entries(&self) -> usize;
-
-    /// Check if a transaction, by itself, is safe to append to the current ledger.
-    fn validate(&self, tx_hash: &TxHash) -> TxManagerResult<()>;
-
-    /// Combines the transactions that correspond to the given hashes.
-    fn combine(&self, tx_hashes: &[TxHash]) -> Vec<TxHash>;
-
-    /// Forms a Block containing the transactions that correspond to the given hashes.
-    fn tx_hashes_to_block(
-        &self,
-        tx_hashes: &[TxHash],
-        parent_block: &Block,
-    ) -> TxManagerResult<(Block, BlockContents, BlockSignature)>;
-
-    /// Creates a message containing a set of transactions that are encrypted for a peer.
-    fn encrypt_for_peer(
-        &self,
-        tx_hashes: &[TxHash],
-        aad: &[u8],
-        peer: &PeerSession,
-    ) -> TxManagerResult<EnclaveMessage<PeerSession>>;
-
-    /// Get the locally encrypted transaction corresponding to the given hash.
-    fn get_encrypted_tx(&self, tx_hash: &TxHash) -> Option<WellFormedEncryptedTx>;
-}
-
-pub struct TxManagerImpl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces> {
-    /// Validate and combine functionality provided by an enclave.
+#[derive(Clone)]
+pub struct TxManager<
+    E: ConsensusEnclaveProxy,
+    L: Ledger,
+    UI: UntrustedInterfaces = crate::validators::DefaultTxManagerUntrustedInterfaces<L>,
+> {
+    /// Enclave.
     enclave: E,
 
-    /// Validate and combine functionality provided by the untrusted system.
+    /// Ledger.
+    ledger: L,
+
+    /// Application-specific custom interfaces for the untrusted part of validation/combining of
+    /// values.
     untrusted: UI,
 
     /// Logger.
     logger: Logger,
 
-    /// Well-formed transactions, keyed by hash.
-    well_formed_cache: HashMap<TxHash, CacheEntry>,
+    /// Map of tx hashes to data we hold for each tx.
+    cache: Arc<Mutex<HashMap<TxHash, CacheEntry>>>,
 }
 
-impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces> TxManagerImpl<E, UI> {
+impl<E: ConsensusEnclaveProxy, L: Ledger, UI: UntrustedInterfaces> TxManager<E, L, UI> {
     /// Construct a new TxManager instance.
-    pub fn new(enclave: E, untrusted: UI, logger: Logger) -> Self {
+    pub fn new(enclave: E, ledger: L, untrusted: UI, logger: Logger) -> Self {
         Self {
             enclave,
+            ledger,
             untrusted,
             logger,
-            well_formed_cache: HashMap::default(),
+            cache: Arc::new(Mutex::new(HashMap::default())),
         }
     }
-}
 
-impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces> TxManager for TxManagerImpl<E, UI> {
-    /// Insert a transaction into the cache. The transaction must be well-formed.
-    fn insert(&mut self, tx_context: TxContext) -> TxManagerResult<WellFormedTxContext> {
-        if let Some(entry) = self.well_formed_cache.get(&tx_context.tx_hash) {
-            // The transaction has already been checked and is in the cache.
-            return Ok(entry.context.clone());
+    /// Insert a new transaction into the cache.
+    /// This enforces that the transaction is well-formed.
+    pub fn insert_proposed_tx(
+        &self,
+        tx_context: TxContext,
+        // _origin_node: Option<NodeID>
+        // _relayed_to: Option<NodeID>,
+    ) -> TxManagerResult<WellFormedTxContext> {
+        // If already in cache then we're done.
+        {
+            let cache = self.lock_cache();
+            if let Some(entry) = cache.get(&tx_context.tx_hash) {
+                self.untrusted.is_valid(entry.context())?;
+                return Err(TxManagerError::AlreadyInCache);
+            }
         }
 
         // Start timer for metrics.
         let timer = counters::WELL_FORMED_CHECK_TIME.start_timer();
 
-        // The untrusted part of the well-formed check.
+        // Perform the untrusted part of the well-formed check.
         let (current_block_index, membership_proofs) = self.untrusted.well_formed_check(
             &tx_context.highest_indices,
             &tx_context.key_images,
             &tx_context.output_public_keys,
         )?;
 
-        // The enclave part of the well-formed check.
+        // Check if tx is well-formed, and if it is get the encrypted copy and context for us
+        // to store.
         let (well_formed_encrypted_tx, well_formed_tx_context) = self.enclave.tx_is_well_formed(
             tx_context.locally_encrypted_tx,
             current_block_index,
@@ -205,57 +191,81 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces> TxManager for TxManage
             hash = well_formed_tx_context.tx_hash().to_string(),
         );
 
-        self.well_formed_cache.insert(
-            *well_formed_tx_context.tx_hash(),
-            CacheEntry {
-                encrypted_tx: well_formed_encrypted_tx,
-                context: well_formed_tx_context.clone(),
-            },
-        );
-        counters::TX_CACHE_NUM_ENTRIES.set(self.well_formed_cache.len() as i64);
+        // Store in our cache.
+        {
+            let mut cache = self.lock_cache();
+            cache.insert(
+                *well_formed_tx_context.tx_hash(),
+                CacheEntry {
+                    encrypted_tx: well_formed_encrypted_tx,
+                    context: well_formed_tx_context.clone(),
+                },
+            );
+            counters::TX_CACHE_NUM_ENTRIES.set(cache.len() as i64);
+        }
+
+        // Success!
         Ok(well_formed_tx_context)
     }
 
-    /// Remove expired transactions.
-    fn remove_expired(&mut self, block_index: u64) -> HashSet<TxHash> {
-        let (expired, retained): (HashMap<_, _>, HashMap<_, _>) = self
-            .well_formed_cache
-            .drain()
-            .partition(|(_, entry)| entry.context().tombstone_block() < block_index);
+    /// Evacuate expired transactions from the cache.
+    /// Returns the hashes that were removed.
+    pub fn evacuate_expired(&self, cur_block: u64) -> HashSet<TxHash> {
+        let mut cache = self.lock_cache();
 
-        self.well_formed_cache = retained;
+        let hashes_before_purge = HashSet::from_iter(cache.keys().cloned());
 
+        cache.retain(|_k, entry| entry.context().tombstone_block() >= cur_block);
+
+        let hashes_after_purge = HashSet::from_iter(cache.keys().cloned());
+        let purged_hashes = hashes_before_purge
+            .difference(&hashes_after_purge)
+            .cloned()
+            .collect::<HashSet<_>>();
         log::debug!(
             self.logger,
-            "Removed {} expired transactions, left with {}",
-            expired.len(),
-            self.well_formed_cache.len(),
+            "cleared {} ({:?}) expired txs, left with {} ({:?})",
+            purged_hashes.len(),
+            purged_hashes,
+            hashes_after_purge.len(),
+            hashes_after_purge,
         );
 
-        counters::TX_CACHE_NUM_ENTRIES.set(self.well_formed_cache.len() as i64);
+        counters::TX_CACHE_NUM_ENTRIES.set(cache.len() as i64);
 
-        expired.into_iter().map(|(tx_hash, _)| tx_hash).collect()
+        purged_hashes
     }
 
-    // Returns true if the cache contains the transaction.
-    fn contains(&self, tx_hash: &TxHash) -> bool {
-        self.well_formed_cache.contains_key(tx_hash)
+    /// Returns the list of hashes inside `tx_hashes` that are not inside the cache.
+    pub fn missing_hashes(&self, tx_hashes: &BTreeSet<TxHash>) -> Vec<TxHash> {
+        let mut missing = Vec::new();
+        let cache = self.lock_cache();
+        for tx_hash in tx_hashes {
+            if !cache.contains_key(tx_hash) {
+                missing.push(*tx_hash);
+            }
+        }
+        missing
     }
 
-    /// The number of cached entries.
-    fn num_entries(&self) -> usize {
-        self.well_formed_cache.len()
-    }
-
-    /// Validate the transaction corresponding to the given hash.
-    fn validate(&self, tx_hash: &TxHash) -> TxManagerResult<()> {
-        match self.well_formed_cache.get(tx_hash) {
+    /// Validate a transaction by it's hash. This checks if by itself this transaction is safe to
+    /// append to the ledger.
+    pub fn validate_tx_by_hash(&self, tx_hash: &TxHash) -> TxManagerResult<()> {
+        let cache = self.lock_cache();
+        match cache.get(tx_hash) {
+            None => {
+                log::error!(
+                    self.logger,
+                    "attempting to validate non-existent tx hash {:?}",
+                    tx_hash
+                );
+                Err(TxManagerError::NotInCache(*tx_hash))
+            }
             Some(entry) => {
                 let _timer = counters::VALIDATE_TX_TIME.start_timer();
                 self.untrusted.is_valid(entry.context())?;
                 Ok(())
             }
-            None => Err(TxManagerError::NotInCache(*tx_hash)),
         }
     }
 
@@ -265,14 +275,15 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces> TxManager for TxManage
     /// This will silently ignore non-existent hashes. Our combine methods are allowed to filter
     /// out transactions, so while non-existent hashes should not be fed into this method, they are
     /// not treated as an error.
-    fn combine(&self, tx_hashes: &[TxHash]) -> Vec<TxHash> {
+    pub fn combine_txs_by_hash(&self, tx_hashes: &[TxHash]) -> Vec<TxHash> {
+        let cache = self.lock_cache();
         let mut tx_contexts = Vec::new();
 
         // Dedup
         let tx_hashes: HashSet<&TxHash> = tx_hashes.iter().clone().collect();
         for tx_hash in tx_hashes {
-            if let Some(entry) = self.well_formed_cache.get(&tx_hash) {
-                tx_contexts.push(entry.context().clone());
+            if let Some(entry) = cache.get(&tx_hash) {
+                tx_contexts.push(entry.context());
             } else {
                 log::error!(self.logger, "Ignoring non-existent TxHash {:?}", tx_hash);
             }
@@ -282,16 +293,17 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces> TxManager for TxManage
             .combine(&tx_contexts, MAX_TRANSACTIONS_PER_BLOCK)
     }
 
-    /// Forms a Block containing the transactions that correspond to the given hashes.
-    fn tx_hashes_to_block(
+    /// A "shim" that converts the output of consensus into something that can be written to the ledger.
+    pub fn tx_hashes_to_block(
         &self,
         tx_hashes: &[TxHash],
-        parent_block: &Block,
     ) -> TxManagerResult<(Block, BlockContents, BlockSignature)> {
+        let cache = self.lock_cache();
+
         let encrypted_txs_with_proofs = tx_hashes
             .iter()
             .map(|tx_hash| {
-                let entry = self.well_formed_cache.get(tx_hash).ok_or_else(|| TxManagerError::NotInCache(*tx_hash))?;
+                let entry = cache.get(tx_hash).ok_or_else(|| TxManagerError::NotInCache(*tx_hash))?;
 
                 let (_current_block_index, membership_proofs) = self.untrusted.well_formed_check(
                     entry.context().highest_indices(),
@@ -303,6 +315,8 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces> TxManager for TxManage
             })
             .collect::<Result<Vec<(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)>, TxManagerError>>()?;
 
+        let num_blocks = self.ledger.num_blocks()?;
+        let parent_block = self.ledger.get_block(num_blocks - 1)?;
         let (block, block_contents, mut signature) = self
             .enclave
             .form_block(&parent_block, &encrypted_txs_with_proofs)?;
@@ -313,18 +327,20 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces> TxManager for TxManage
         Ok((block, block_contents, signature))
     }
 
-    /// Creates a message containing a set of transactions that are encrypted for a peer.
-    fn encrypt_for_peer(
+    /// For a given list of TxHashes and a peer session, return a message to send to that peer
+    /// containing the transaction contents.
+    pub fn txs_for_peer(
         &self,
         tx_hashes: &[TxHash],
         aad: &[u8],
         peer: &PeerSession,
     ) -> TxManagerResult<EnclaveMessage<PeerSession>> {
         let encrypted_txs: Result<Vec<WellFormedEncryptedTx>, TxManagerError> = {
+            let cache = self.lock_cache();
             tx_hashes
                 .iter()
                 .map(|tx_hash| {
-                    self.well_formed_cache
+                    cache
                         .get(tx_hash)
                         .map(|entry| entry.encrypted_tx().clone())
                         .ok_or_else(|| TxManagerError::NotInCache(*tx_hash))
@@ -335,374 +351,31 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces> TxManager for TxManage
         Ok(self.enclave.txs_for_peer(&encrypted_txs?, aad, peer)?)
     }
 
-    /// Get the encrypted transaction corresponding to the given hash.
-    fn get_encrypted_tx(&self, tx_hash: &TxHash) -> Option<WellFormedEncryptedTx> {
-        self.well_formed_cache
+    pub fn get_encrypted_tx_by_hash(&self, tx_hash: &TxHash) -> Option<WellFormedEncryptedTx> {
+        self.lock_cache()
             .get(tx_hash)
             .map(|entry| entry.encrypted_tx().clone())
+    }
+
+    pub fn num_entries(&self) -> usize {
+        self.lock_cache().len()
+    }
+
+    fn lock_cache(&self) -> MutexGuard<HashMap<TxHash, CacheEntry>> {
+        self.cache.lock().expect("lock poisoned")
     }
 }
 
 #[cfg(test)]
-mod tx_manager_tests {
+mod tests {
     use super::*;
     use crate::validators::DefaultTxManagerUntrustedInterfaces;
-    use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, VerificationReport};
-    use mc_attest_enclave_api::{
-        ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage, PeerAuthRequest,
-        PeerAuthResponse, PeerSession,
-    };
-    use mc_common::{logger::test_with_logger, ResponderId};
-    use mc_consensus_enclave::{Error as EnclaveError, LocallyEncryptedTx, SealedBlockSigningKey};
+    use mc_common::logger::test_with_logger;
     use mc_consensus_enclave_mock::ConsensusServiceMockEnclave;
-    use mc_crypto_keys::{Ed25519Public, X25519Public};
-    use mc_ledger_db::Ledger;
-    use mc_sgx_report_cache_api::{Error as SgxReportError, ReportableEnclave};
     use mc_transaction_core_test_utils::{
         create_ledger, create_transaction, initialize_ledger, AccountKey,
     };
     use rand::{rngs::StdRng, SeedableRng};
-
-    // ConsensusEnclave inherits from ReportableEnclave, so the traits have to be re-typed here.
-    // Splitting the traits apart might help because TxManager only uses a few of these functions.
-    mock! {
-        Enclave {}
-        trait ConsensusEnclave {
-            fn enclave_init(
-                &self,
-                self_peer_id: &ResponderId,
-                self_client_id: &ResponderId,
-                sealed_key: &Option<SealedBlockSigningKey>,
-            ) -> Result<(SealedBlockSigningKey, Vec<String>), EnclaveError>;
-
-            fn get_identity(&self) -> Result<X25519Public, EnclaveError>;
-
-            fn get_signer(&self) -> Result<Ed25519Public, EnclaveError>;
-
-            fn client_accept(&self, req: ClientAuthRequest) -> Result<(ClientAuthResponse, ClientSession), EnclaveError>;
-
-            fn client_close(&self, channel_id: ClientSession) -> Result<(), EnclaveError>;
-
-            fn client_discard_message(&self, msg: EnclaveMessage<ClientSession>) -> Result<(), EnclaveError>;
-
-            fn peer_init(&self, peer_id: &ResponderId) -> Result<PeerAuthRequest, EnclaveError>;
-
-            fn peer_accept(&self, req: PeerAuthRequest) -> Result<(PeerAuthResponse, PeerSession), EnclaveError>;
-
-            fn peer_connect(&self, peer_id: &ResponderId, res: PeerAuthResponse) -> Result<PeerSession, EnclaveError>;
-
-            fn peer_close(&self, channel_id: &PeerSession) -> Result<(), EnclaveError>;
-
-            fn client_tx_propose(&self, msg: EnclaveMessage<ClientSession>) -> Result<TxContext, EnclaveError>;
-
-            fn peer_tx_propose(&self, msg: EnclaveMessage<PeerSession>) -> Result<Vec<TxContext>, EnclaveError>;
-
-            fn tx_is_well_formed(
-                &self,
-                locally_encrypted_tx: LocallyEncryptedTx,
-                block_index: u64,
-                proofs: Vec<TxOutMembershipProof>,
-            ) -> Result<(WellFormedEncryptedTx, WellFormedTxContext), EnclaveError>;
-
-            fn txs_for_peer(
-                &self,
-                encrypted_txs: &[WellFormedEncryptedTx],
-                aad: &[u8],
-                peer: &PeerSession,
-            ) -> Result<EnclaveMessage<PeerSession>, EnclaveError>;
-
-            fn form_block(
-                &self,
-                parent_block: &Block,
-                txs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
-            ) -> Result<(Block, BlockContents, BlockSignature), EnclaveError>;
-        }
-
-        trait ReportableEnclave {
-            fn new_ereport(&self, qe_info: TargetInfo) -> Result<(Report, QuoteNonce), SgxReportError>;
-
-            fn verify_quote(&self, quote: Quote, qe_report: Report) -> Result<IasNonce, SgxReportError>;
-
-            fn verify_ias_report(&self, ias_report: VerificationReport) -> Result<(), SgxReportError>;
-
-            fn get_ias_report(&self) -> Result<VerificationReport, SgxReportError>;
-        }
-    }
-
-    #[test_with_logger]
-    // Should return Ok when a well-formed Tx is (re)-inserted.
-    fn test_insert_ok(logger: Logger) {
-        let tx_context = TxContext::default();
-        let tx_hash = tx_context.tx_hash;
-
-        let mut mock_untrusted = MockUntrustedInterfaces::new();
-        // Untrusted's well-formed check should be called once each time insert_propose_tx is called.
-        mock_untrusted
-            .expect_well_formed_check()
-            .times(1)
-            .return_const(Ok((0, vec![])));
-
-        // The enclave's well-formed check also ought to be called, and should return Ok.
-        let mut mock_enclave = MockEnclave::new();
-
-        let well_formed_encrypted_tx = WellFormedEncryptedTx::default();
-        let well_formed_tx_context = WellFormedTxContext::new(
-            0,
-            tx_hash.clone(),
-            Default::default(),
-            Default::default(),
-            Default::default(),
-            Default::default(),
-        );
-
-        mock_enclave
-            .expect_tx_is_well_formed()
-            .times(1)
-            .return_const(Ok((well_formed_encrypted_tx, well_formed_tx_context)));
-
-        let mut tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-        assert_eq!(tx_manager.well_formed_cache.len(), 0);
-
-        assert!(tx_manager.insert(tx_context.clone()).is_ok());
-        assert_eq!(tx_manager.well_formed_cache.len(), 1);
-        assert!(tx_manager.well_formed_cache.contains_key(&tx_hash));
-
-        // Re-inserting should also be Ok.
-        assert!(tx_manager.insert(tx_context.clone()).is_ok());
-        assert_eq!(tx_manager.well_formed_cache.len(), 1);
-        assert!(tx_manager.well_formed_cache.contains_key(&tx_hash));
-    }
-
-    #[test_with_logger]
-    // Should return return an error when a not well-formed Tx is inserted.
-    // Here, the untrusted system says the Tx is not well-formed.
-    fn test_insert_error_untrusted(logger: Logger) {
-        let tx_context = TxContext::default();
-
-        let mut mock_untrusted = MockUntrustedInterfaces::new();
-        // Untrusted's well-formed check should be called once each time insert_propose_tx is called.
-        mock_untrusted
-            .expect_well_formed_check()
-            .times(1)
-            .return_const(Err(TransactionValidationError::ContainsSpentKeyImage));
-
-        // This should not be called.
-        let mock_enclave = MockEnclave::new();
-
-        let mut tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-        assert!(tx_manager.insert(tx_context.clone()).is_err());
-        assert_eq!(tx_manager.well_formed_cache.len(), 0);
-    }
-
-    #[test_with_logger]
-    // Should return return an error when a not well-formed Tx is inserted.
-    // Here, the enclave says the Tx is not well-formed.
-    fn test_insert_error_trusted(logger: Logger) {
-        let tx_context = TxContext::default();
-
-        let mut mock_untrusted = MockUntrustedInterfaces::new();
-        // Untrusted's well-formed check should be called once each time insert_propose_tx is called.
-        mock_untrusted
-            .expect_well_formed_check()
-            .times(1)
-            .return_const(Ok((0, vec![])));
-
-        // This should be called, and return an error.
-        let mut mock_enclave = MockEnclave::new();
-        mock_enclave
-            .expect_tx_is_well_formed()
-            .times(1)
-            .return_const(Err(EnclaveError::Signature));
-
-        let mut tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-        assert!(tx_manager.insert(tx_context.clone()).is_err());
-        assert_eq!(tx_manager.well_formed_cache.len(), 0);
-    }
-
-    #[test_with_logger]
-    // Should remove all transactions that have expired by the given slot.
-    fn test_remove_expired(logger: Logger) {
-        let mock_untrusted = MockUntrustedInterfaces::new();
-        let mock_enclave = MockEnclave::new();
-        let mut tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-
-        // Fill the cache with entries that have different tombstone blocks.
-        for tombstone_block in 10..24 {
-            let context = WellFormedTxContext::new(
-                Default::default(),
-                TxHash([tombstone_block as u8; 32]),
-                tombstone_block,
-                Default::default(),
-                Default::default(),
-                Default::default(),
-            );
-
-            let cache_entry = CacheEntry {
-                encrypted_tx: Default::default(),
-                context: context.clone(),
-            };
-
-            tx_manager
-                .well_formed_cache
-                .insert(context.tx_hash().clone(), cache_entry);
-        }
-
-        assert_eq!(tx_manager.well_formed_cache.len(), 14);
-
-        {
-            // By block index 10, none have expired.
-            let removed = tx_manager.remove_expired(10);
-            assert_eq!(removed.len(), 0);
-            assert_eq!(tx_manager.well_formed_cache.len(), 14);
-        }
-
-        {
-            // By block index 15, some have expired.
-            let removed = tx_manager.remove_expired(15);
-            assert_eq!(removed.len(), 5);
-            assert_eq!(tx_manager.well_formed_cache.len(), 9);
-        }
-
-        {
-            // By block index 24, all have expired.
-            let removed = tx_manager.remove_expired(24);
-            assert_eq!(removed.len(), 9);
-            assert_eq!(tx_manager.well_formed_cache.len(), 0);
-        }
-    }
-
-    #[test_with_logger]
-    // Should return Ok if the transaction is in the cache and is valid.
-    fn test_validate_ok(logger: Logger) {
-        let tx_context = TxContext::default();
-
-        let mut mock_untrusted = MockUntrustedInterfaces::new();
-
-        // Untrusted's validate check should be called and return Ok.
-        mock_untrusted
-            .expect_is_valid()
-            .times(1)
-            .return_const(Ok(()));
-
-        // The enclave is not called because its checks are "well-formed-ness" checks.
-        let mock_enclave = MockEnclave::new();
-
-        let mut tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-
-        // Add this transaction to the cache.
-        let cache_entry = CacheEntry {
-            encrypted_tx: Default::default(),
-            context: Default::default(),
-        };
-        tx_manager
-            .well_formed_cache
-            .insert(tx_context.tx_hash.clone(), cache_entry);
-
-        assert!(tx_manager.validate(&tx_context.tx_hash).is_ok());
-    }
-
-    #[test_with_logger]
-    // Should return Err if the transaction is not in the cache.
-    fn test_validate_err_not_in_cache(logger: Logger) {
-        let tx_context = TxContext::default();
-
-        // The method should return before calling untrusted.
-        let mock_untrusted = MockUntrustedInterfaces::new();
-
-        // The enclave is not called because its checks are "well-formed-ness" checks.
-        let mock_enclave = MockEnclave::new();
-
-        let tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-        match tx_manager.validate(&tx_context.tx_hash) {
-            Err(TxManagerError::NotInCache(_)) => {} // This is expected.
-            _ => panic!(),
-        }
-    }
-
-    #[test_with_logger]
-    // Should return Err if the transaction is in the cache (i.e., well-formed) but not valid.
-    fn test_validate_err_not_valid(logger: Logger) {
-        let tx_context = TxContext::default();
-
-        // The method should return before calling untrusted.
-        let mut mock_untrusted = MockUntrustedInterfaces::new();
-
-        // Untrusted's validate check should be called and return Err.
-        mock_untrusted
-            .expect_is_valid()
-            .times(1)
-            .return_const(Err(TransactionValidationError::ContainsSpentKeyImage));
-
-        // The enclave is not called because its checks are "well-formed-ness" checks.
-        let mock_enclave = MockEnclave::new();
-
-        let mut tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-
-        // Add this transaction to the cache.
-        let cache_entry = CacheEntry {
-            encrypted_tx: Default::default(),
-            context: Default::default(),
-        };
-        tx_manager
-            .well_formed_cache
-            .insert(tx_context.tx_hash.clone(), cache_entry);
-
-        match tx_manager.validate(&tx_context.tx_hash) {
-            Err(TxManagerError::TransactionValidation(
-                TransactionValidationError::ContainsSpentKeyImage,
-            )) => {} // This is expected.
-            _ => panic!(),
-        }
-    }
-
-    #[test_with_logger]
-    // Should return Ok if the transactions are in the cache.
-    fn test_combine_ok(logger: Logger) {
-        let tx_hashes: Vec<_> = (0..10).map(|i| TxHash([i as u8; 32])).collect();
-
-        let mut mock_untrusted = MockUntrustedInterfaces::new();
-        let expected: Vec<_> = tx_hashes.iter().take(5).cloned().collect();
-        mock_untrusted
-            .expect_combine()
-            .times(1)
-            .return_const(expected.clone());
-
-        let mock_enclave = MockEnclave::new();
-        let mut tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-
-        // Add transactions to the cache.
-        for tx_hash in &tx_hashes {
-            let context = WellFormedTxContext::new(
-                Default::default(),
-                tx_hash.clone(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-            );
-
-            let cache_entry = CacheEntry {
-                encrypted_tx: Default::default(),
-                context: context.clone(),
-            };
-
-            tx_manager
-                .well_formed_cache
-                .insert(context.tx_hash().clone(), cache_entry);
-        }
-        assert_eq!(tx_manager.well_formed_cache.len(), tx_hashes.len());
-
-        // TODO: combine should return a Result.
-        assert_eq!(tx_manager.combine(&tx_hashes), expected);
-    }
-
-    #[test_with_logger]
-    #[ignore]
-    // Should return Err if any transaction is not in the cache.
-    fn test_combine_err_not_in_cache(_logger: Logger) {
-        // TODO: combine should return a Result.
-        unimplemented!()
-    }
 
     #[test_with_logger]
     fn test_hashes_to_block(logger: Logger) {
@@ -711,11 +384,10 @@ mod tx_manager_tests {
         let mut ledger = create_ledger();
         let n_blocks = 3;
         initialize_ledger(&mut ledger, n_blocks, &sender, &mut rng);
-        let num_blocks = ledger.num_blocks().unwrap();
-        let parent_block = ledger.get_block(num_blocks - 1).unwrap();
-        let mut tx_manager = TxManagerImpl::new(
+        let tx_manager = TxManager::new(
             ConsensusServiceMockEnclave::default(),
-            DefaultTxManagerUntrustedInterfaces::new(ledger),
+            ledger.clone(),
+            DefaultTxManagerUntrustedInterfaces::new(ledger.clone()),
             logger.clone(),
         );
 
@@ -779,21 +451,21 @@ mod tx_manager_tests {
         let client_tx_three = transactions.pop().unwrap();
 
         let hash_tx_zero = *tx_manager
-            .insert(ConsensusServiceMockEnclave::tx_to_tx_context(
+            .insert_proposed_tx(ConsensusServiceMockEnclave::tx_to_tx_context(
                 &client_tx_zero,
             ))
             .unwrap()
             .tx_hash();
 
         let hash_tx_one = *tx_manager
-            .insert(ConsensusServiceMockEnclave::tx_to_tx_context(
+            .insert_proposed_tx(ConsensusServiceMockEnclave::tx_to_tx_context(
                 &client_tx_one,
             ))
             .unwrap()
             .tx_hash();
 
         let hash_tx_two = *tx_manager
-            .insert(ConsensusServiceMockEnclave::tx_to_tx_context(
+            .insert_proposed_tx(ConsensusServiceMockEnclave::tx_to_tx_context(
                 &client_tx_two,
             ))
             .unwrap()
@@ -803,7 +475,7 @@ mod tx_manager_tests {
 
         // Attempting to assemble a block with a non-existent hash should fail
         assert!(tx_manager
-            .tx_hashes_to_block(&[hash_tx_two, hash_tx_three], &parent_block)
+            .tx_hashes_to_block(&[hash_tx_two, hash_tx_three])
             .is_err());
 
         // Attempting to assemble a block with a duplicate transaction should fail.
@@ -822,8 +494,9 @@ mod tx_manager_tests {
 
         // Attempting to assemble a block without duplicates or missing transactions should
         // succeed.
+        // TODO: Right now this relies on ConsensusServiceMockEnclave::form_block
         let (block, block_contents, _signature) = tx_manager
-            .tx_hashes_to_block(&[hash_tx_zero, hash_tx_one], &parent_block)
+            .tx_hashes_to_block(&[hash_tx_zero, hash_tx_one])
             .expect("failed assembling block");
         assert_eq!(
             client_tx_zero.prefix.outputs[0].public_key,
@@ -836,173 +509,5 @@ mod tx_manager_tests {
 
         // The ledger was previously initialized with 3 blocks.
         assert_eq!(block.index, 3);
-    }
-
-    #[test_with_logger]
-    // Should call enclave.txs_for_peer
-    fn test_encrypt_for_peer_ok(logger: Logger) {
-        let mock_untrusted = MockUntrustedInterfaces::new();
-        let mut mock_enclave = MockEnclave::new();
-
-        // This should be called to perform the encryption.
-        mock_enclave
-            .expect_txs_for_peer()
-            .times(1)
-            .return_const(Ok(EnclaveMessage::default()));
-
-        let mut tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-
-        // Add transactions to the cache.
-        let tx_hashes: Vec<_> = (0..10).map(|i| TxHash([i as u8; 32])).collect();
-        for tx_hash in &tx_hashes {
-            let context = WellFormedTxContext::new(
-                Default::default(),
-                tx_hash.clone(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-            );
-
-            let cache_entry = CacheEntry {
-                encrypted_tx: Default::default(),
-                context: context.clone(),
-            };
-
-            tx_manager
-                .well_formed_cache
-                .insert(context.tx_hash().clone(), cache_entry);
-        }
-        assert_eq!(tx_manager.well_formed_cache.len(), tx_hashes.len());
-
-        let aad = vec![];
-        let peer = PeerSession::default();
-        assert!(tx_manager.encrypt_for_peer(&tx_hashes, &aad, &peer).is_ok());
-    }
-
-    #[test_with_logger]
-    // Should return an error if any transaction is not in the cache.
-    fn test_encrypt_for_peer_err_not_in_cache(logger: Logger) {
-        let mock_untrusted = MockUntrustedInterfaces::new();
-        let mock_enclave = MockEnclave::new();
-
-        let tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-        assert!(tx_manager.well_formed_cache.is_empty());
-
-        let tx_hashes: Vec<_> = (0..10).map(|i| TxHash([i as u8; 32])).collect();
-        let aad = vec![];
-        let peer = PeerSession::default();
-        match tx_manager.encrypt_for_peer(&tx_hashes, &aad, &peer) {
-            Err(TxManagerError::NotInCache(_)) => {} // This is expected.
-            _ => panic!(),
-        }
-    }
-
-    #[test_with_logger]
-    // Should return an error if enclave.txs_for_peer returns an error.
-    fn test_encrypt_for_peer_err_enclave_error(logger: Logger) {
-        let mock_untrusted = MockUntrustedInterfaces::new();
-        let mut mock_enclave = MockEnclave::new();
-
-        // This should be called and should return an error.
-        mock_enclave
-            .expect_txs_for_peer()
-            .times(1)
-            .return_const(Err(EnclaveError::Signature));
-
-        let mut tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-
-        // Add transactions to the cache.
-        let tx_hashes: Vec<_> = (0..10).map(|i| TxHash([i as u8; 32])).collect();
-        for tx_hash in &tx_hashes {
-            let context = WellFormedTxContext::new(
-                Default::default(),
-                tx_hash.clone(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-            );
-
-            let cache_entry = CacheEntry {
-                encrypted_tx: Default::default(),
-                context: context.clone(),
-            };
-
-            tx_manager
-                .well_formed_cache
-                .insert(context.tx_hash().clone(), cache_entry);
-        }
-        assert_eq!(tx_manager.well_formed_cache.len(), tx_hashes.len());
-
-        let aad = vec![];
-        let peer = PeerSession::default();
-
-        match tx_manager.encrypt_for_peer(&tx_hashes, &aad, &peer) {
-            Err(TxManagerError::Enclave(EnclaveError::Signature)) => {} // This is expected.
-            _ => panic!(),
-        }
-    }
-
-    #[test_with_logger]
-    // Should return cache_entry.encrypted_tx if it is in the cache.
-    fn test_get_encrypted_tx(logger: Logger) {
-        let mock_untrusted = MockUntrustedInterfaces::new();
-        let mock_enclave = MockEnclave::new();
-        let mut tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-
-        // Add a transaction to the cache.
-        let cache_entry = CacheEntry {
-            encrypted_tx: WellFormedEncryptedTx(vec![1, 2, 3]),
-            context: Default::default(),
-        };
-
-        let tx_hash = TxHash([1u8; 32]);
-        tx_manager
-            .well_formed_cache
-            .insert(tx_hash.clone(), cache_entry);
-
-        // Get something that is in the cache.
-        assert_eq!(
-            tx_manager.get_encrypted_tx(&tx_hash),
-            Some(WellFormedEncryptedTx(vec![1, 2, 3]))
-        );
-
-        // Get something that is not in the cache.
-        assert_eq!(tx_manager.get_encrypted_tx(&TxHash([88u8; 32])), None);
-    }
-
-    #[test_with_logger]
-    // Should return the number of elements in the cache.
-    fn test_get_num_entries(logger: Logger) {
-        let mock_untrusted = MockUntrustedInterfaces::new();
-        let mock_enclave = MockEnclave::new();
-        let mut tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-
-        // Initially, the cache is empty.
-        assert_eq!(tx_manager.well_formed_cache.len(), 0);
-
-        // Add transactions to the cache.
-        let tx_hashes: Vec<_> = (0..10).map(|i| TxHash([i as u8; 32])).collect();
-        for tx_hash in &tx_hashes {
-            let context = WellFormedTxContext::new(
-                Default::default(),
-                tx_hash.clone(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-                Default::default(),
-            );
-
-            let cache_entry = CacheEntry {
-                encrypted_tx: Default::default(),
-                context: context.clone(),
-            };
-
-            tx_manager
-                .well_formed_cache
-                .insert(context.tx_hash().clone(), cache_entry);
-        }
-        assert_eq!(tx_manager.well_formed_cache.len(), tx_hashes.len());
     }
 }

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -130,9 +130,9 @@ impl<L: Ledger> TxManagerUntrustedInterfaces for DefaultTxManagerUntrustedInterf
     /// * `max_elements` - Maximum number of elements to return.
     ///
     /// Returns a bounded, deterministically-ordered list of transactions that are safe to append to the ledger.
-    fn combine(&self, tx_contexts: &[WellFormedTxContext], max_elements: usize) -> Vec<TxHash> {
+    fn combine(&self, tx_contexts: &[&WellFormedTxContext], max_elements: usize) -> Vec<TxHash> {
         // WellFormedTxContext defines the sort order of transactions within a block.
-        let mut candidates: Vec<&WellFormedTxContext> = tx_contexts.iter().collect();
+        let mut candidates: Vec<&WellFormedTxContext> = tx_contexts.to_vec();
         candidates.sort();
 
         // Allow transactions that do not cause duplicate key images or output public keys.
@@ -703,7 +703,8 @@ mod combine_tests {
     fn combine(tx_contexts: Vec<WellFormedTxContext>, max_elements: usize) -> Vec<TxHash> {
         let ledger = get_mock_ledger(10);
         let untrusted = DefaultTxManagerUntrustedInterfaces::new(ledger);
-        untrusted.combine(&tx_contexts, max_elements)
+        let ref_tx_contexts: Vec<&WellFormedTxContext> = tx_contexts.iter().collect();
+        untrusted.combine(&ref_tx_contexts[..], max_elements)
     }
 
     #[test]


### PR DESCRIPTION
Reverts "TxManager traits, mocks, and tests (#346)", which appears to causing the consensus service to handle incoming transactions more slowly, and causing some tests to time out.