### PR TITLE
Add ledger-migration to entrypoint and Dockerfile

### DIFF
--- a/ops/Dockerfile-consensus
+++ b/ops/Dockerfile-consensus
@@ -71,6 +71,7 @@ COPY bin/libconsensus-enclave.signed.so /usr/bin/
 COPY bin/consensus-service /usr/bin/
 COPY bin/ledger-distribution /usr/bin/
 COPY bin/mc-admin-http-gateway /usr/bin/
+COPY bin/mc-ledger-migration /usr/bin/
 
 # Q: Why not use NODE_LEDGER_DIR here?
 # A: The ENV dictates where the app actually looks, and the ARG sets

--- a/ops/entrypoints/consensus_validator.sh
+++ b/ops/entrypoints/consensus_validator.sh
@@ -32,6 +32,9 @@ if [ ! -r "${NODE_LEDGER_DIR}/data.mdb" ]; then
     rsync -a --delete /var/lib/mobilecoin/origin_data/* ${NODE_LEDGER_DIR}/
 fi
 
+# Update the ledger to the current version if necessary
+/usr/bin/mc-ledger-migration --ledger-db ${NODE_LEDGER_DIR}
+
 if [[ -z "${AWS_PATH}" ]] || [[ -z "${AWS_SECRET_ACCESS_KEY}" ]] || [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
   echo "Warning: Must provide AWS_PATH, AWS_SECRET_ACCESS_KEY, and AWS_ACCESS_KEY_ID to start ledger distribution";
 else


### PR DESCRIPTION
Soundtrack of this PR: [Revelate](https://www.youtube.com/watch?v=jCyFMnhP_94)

### Motivation

The current Dockerfile and entrypoint for the consensus validator does not include the `mc-ledger-migration` tool to handle automatic ledger upgrades on startup.  This fixes that.

### In this PR
* Add `mc-ledger-migration` to the Dockerfile and in the `consensus_validator.sh` entrypoint script.