### PR TITLE
Remove Ledger from TxManager

### DIFF
--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -61,7 +61,7 @@ impl ByzantineLedger {
         quorum_set: QuorumSet,
         peer_manager: ConnectionManager<PC>,
         ledger: L,
-        tx_manager: TxManager<E, L, UI>,
+        tx_manager: TxManager<E, UI>,
         broadcaster: Arc<Mutex<ThreadedBroadcaster>>,
         msg_signer_key: Arc<Ed25519Pair>,
         tx_source_urls: Vec<String>,
@@ -340,7 +340,6 @@ mod tests {
         let enclave = ConsensusServiceMockEnclave::default();
         let tx_manager = TxManager::new(
             enclave.clone(),
-            ledger.clone(),
             DefaultTxManagerUntrustedInterfaces::new(ledger.clone()),
             logger.clone(),
         );

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -51,7 +51,7 @@ pub struct ByzantineLedgerWorker<
     send_scp_message: F,
     ledger: L,
     peer_manager: ConnectionManager<PC>,
-    tx_manager: TxManager<E, L, UI>,
+    tx_manager: TxManager<E, UI>,
     broadcaster: Arc<Mutex<ThreadedBroadcaster>>,
     logger: Logger,
 
@@ -107,7 +107,7 @@ impl<
         send_scp_message: F,
         ledger: L,
         peer_manager: ConnectionManager<PC>,
-        tx_manager: TxManager<E, L, UI>,
+        tx_manager: TxManager<E, UI>,
         broadcaster: Arc<Mutex<ThreadedBroadcaster>>,
         tx_source_urls: Vec<String>,
         logger: Logger,
@@ -502,9 +502,17 @@ impl<
 
         // Write to ledger.
         {
+            let num_blocks = self
+                .ledger
+                .num_blocks()
+                .expect("Ledger must contain a block.");
+            let parent_block = self
+                .ledger
+                .get_block(num_blocks - 1)
+                .expect("Ledger must contain a block.");
             let (block, block_contents, signature) = self
                 .tx_manager
-                .tx_hashes_to_block(&ext_vals)
+                .tx_hashes_to_block(&ext_vals, &parent_block)
                 .unwrap_or_else(|e| panic!("Failed to build block from {:?}: {:?}", ext_vals, e));
 
             log::info!(

--- a/consensus/service/src/client_api_service.rs
+++ b/consensus/service/src/client_api_service.rs
@@ -7,6 +7,7 @@ use crate::{
     counters,
     grpc_error::ConsensusGrpcError,
     tx_manager::{TxManager, TxManagerError},
+    validators::DefaultTxManagerUntrustedInterfaces,
 };
 use grpcio::{RpcContext, UnarySink};
 use mc_attest_api::attest::Message;
@@ -15,7 +16,7 @@ use mc_consensus_api::{
     consensus_client_grpc::ConsensusClientApi, consensus_common::ProposeTxResponse,
 };
 use mc_consensus_enclave::ConsensusEnclaveProxy;
-use mc_ledger_db::Ledger;
+use mc_ledger_db::{Ledger, LedgerDB};
 use mc_transaction_core::validation::TransactionValidationError;
 use mc_util_grpc::{rpc_logger, send_result};
 use mc_util_metrics::{self, SVC_COUNTERS};
@@ -29,7 +30,7 @@ pub struct ClientApiService<E: ConsensusEnclaveProxy, L: Ledger + Clone> {
     enclave: E,
     scp_client_value_sender: ProposeTxCallback,
     ledger: L,
-    tx_manager: TxManager<E, L>,
+    tx_manager: TxManager<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>,
     is_serving_fn: Arc<(dyn Fn() -> bool + Sync + Send)>,
     logger: Logger,
 }
@@ -39,7 +40,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger + Clone> ClientApiService<E, L> {
         enclave: E,
         scp_client_value_sender: ProposeTxCallback,
         ledger: L,
-        tx_manager: TxManager<E, L>,
+        tx_manager: TxManager<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>,
         is_serving_fn: Arc<(dyn Fn() -> bool + Sync + Send)>,
         logger: Logger,
     ) -> Self {

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -95,7 +95,7 @@ pub struct ConsensusService<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync 
 
     peer_manager: ConnectionManager<PeerConnection<E>>,
     broadcaster: Arc<Mutex<ThreadedBroadcaster>>,
-    tx_manager: TxManager<E, LedgerDB>,
+    tx_manager: TxManager<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>,
     peer_keepalive: Arc<Mutex<PeerKeepalive>>,
 
     admin_rpc_server: Option<AdminServer>,
@@ -153,7 +153,6 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
         // Tx Manager
         let tx_manager = TxManager::new(
             enclave.clone(),
-            ledger_db.clone(),
             DefaultTxManagerUntrustedInterfaces::new(ledger_db.clone()),
             logger.clone(),
         );

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -8,6 +8,7 @@ use crate::{
     counters,
     grpc_error::ConsensusGrpcError,
     tx_manager::{TxManager, TxManagerError},
+    validators::DefaultTxManagerUntrustedInterfaces,
 };
 use grpcio::{RpcContext, UnarySink};
 use mc_attest_api::attest::Message;
@@ -26,7 +27,7 @@ use mc_consensus_api::{
     empty::Empty,
 };
 use mc_consensus_enclave::ConsensusEnclaveProxy;
-use mc_ledger_db::Ledger;
+use mc_ledger_db::{Ledger, LedgerDB};
 use mc_peers::TxProposeAAD;
 use mc_transaction_core::tx::TxHash;
 use mc_util_grpc::{rpc_invalid_arg_error, rpc_logger, send_result};
@@ -57,7 +58,7 @@ pub struct PeerApiService<E: ConsensusEnclaveProxy, L: Ledger> {
     ledger: L,
 
     /// Transactions Manager instance.
-    tx_manager: TxManager<E, L>,
+    tx_manager: TxManager<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>,
 
     /// Callback function for getting the latest SCP statement the local node has issued.
     fetch_latest_msg_fn: FetchLatestMsgFn,
@@ -78,7 +79,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> PeerApiService<E, L> {
         incoming_consensus_msgs_sender: BackgroundWorkQueueSenderFn<IncomingConsensusMsg>,
         scp_client_value_sender: ProposeTxCallback,
         ledger: L,
-        tx_manager: TxManager<E, L>,
+        tx_manager: TxManager<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>,
         fetch_latest_msg_fn: FetchLatestMsgFn,
         known_responder_ids: Vec<ResponderId>,
         logger: Logger,


### PR DESCRIPTION
Soundtrack of this PR: [Tycho](https://www.youtube.com/watch?v=dKh1yvmZpgU)

### Motivation

Components are easier to test if they have fewer sub-components. Previously, TxManager held a Ledger instance, but only used it in one place to query for the previous block.

### In this PR
* Removes the Ledger instance from TxManager
* TxManager::tx_hashes_to_block now takes a `parent_block` instead of querying the ledger for it.

### Future Work
* This is incremental progress towards simplifying and testing TxManager and the things that use TxManager.

