### PR TITLE
Mobilecoind offline transactions

### DIFF
--- a/mobilecoind/src/error.rs
+++ b/mobilecoind/src/error.rs
@@ -107,6 +107,9 @@ pub enum Error {
 
     #[fail(display = "Metadata store error: {}", _0)]
     MetadataStore(MetadataStoreError),
+
+    #[fail(display = "No peers configured - running in offline mode")]
+    NoPeersConfigured,
 }
 
 impl From<RetryError<ConnectionError>> for Error {

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -315,8 +315,12 @@ impl<T: UserTxConnection + 'static> TransactionsManager<T> {
     /// Submit a previously built tx proposal to the network.
     pub fn submit_tx_proposal(&self, tx_proposal: &TxProposal) -> Result<u64, Error> {
         // Pick a peer to submit to.
-        let idx = self.submit_node_offset.fetch_add(1, Ordering::SeqCst);
         let responder_ids = self.peer_manager.responder_ids();
+        if responder_ids.is_empty() {
+            return Err(Error::NoPeersConfigured);
+        }
+
+        let idx = self.submit_node_offset.fetch_add(1, Ordering::SeqCst);
         let responder_id = &responder_ids[idx % responder_ids.len()];
 
         // Try and submit.


### PR DESCRIPTION
### Motivation

We'd like to support construction of transactions on an airgapped machine, in case someone wants to take that extra measure of protecting their sensitive keys.

### In this PR
* Changes to allow `mobilecoind` to run in "offline mode". In offline mode, `mobilecoind` does not attempt to sync the ledger or communicate with any peers. When the `--offline` command line argument is passed, `mobilecoind` would allow omitting the `--peer` and `--tx-source-url` arguments.

### How to use this?

If someone wants to construct a transaction on a machine that does not have internet access, they would need to perform the following steps:
1) Copy a recent copy of the ledger database into the airgapped machine. The copied ledger should include TxOuts that are spendable by the user.
2) Run `mobilecoind` on the airgapped machine: `MC_LOG=trace CONSENSUS_ENCLAVE_CSS=$(pwd)/consensus-enclave.css SGX_MODE=SW IAS_MODE=DEV cargo run -p mc-mobilecoind --release -- --offline --listen-uri insecure-mobilecoind://127.0.0.1:4444/ --mobilecoind-db /tmp/wallet-db`. Note that a CSS file is still needed since its impossible to build `mobilecoind` without one, unless you are able to compile the enclave.
3) Connect to this `mobilecoind`, add a monitor with your keys, let it scan the ledger, and construct a transaction using `GenerateTx`.
4) `GenerateTx` will return a `TxProposal`, which you can then protobuf-encode into a blob of bytes.
5) Copy this blob of bytes into a machine that has internet access and `mobilecoind` running.
6) Decode the blob of bytes back into a `TxProposal`and submit it using `SubmitTx`. Even if the `mobilecoind` instance you are submitting to has no monitors defined at all, this would still work.
