### PR TITLE
downgrade generic-array to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cf01b9b56e767bb57b94ebf91a58b338002963785cdd7013e21c0d4679471e4"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array",
 ]
 
 [[package]]
@@ -302,7 +302,7 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array 0.12.3",
+ "generic-array",
 ]
 
 [[package]]
@@ -311,7 +311,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array",
  "subtle 1.0.0",
 ]
 
@@ -895,7 +895,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array",
 ]
 
 [[package]]
@@ -1271,15 +1271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 dependencies = [
  "serde",
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
-dependencies = [
  "typenum",
 ]
 
@@ -2106,7 +2097,7 @@ dependencies = [
  "digest",
  "displaydoc",
  "failure",
- "generic-array 0.12.3",
+ "generic-array",
  "hex 0.3.2",
  "hex_fmt",
  "mbedtls",
@@ -2189,7 +2180,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "failure",
- "generic-array 0.12.3",
+ "generic-array",
  "hashbrown 0.6.3",
  "hex_fmt",
  "hostname 0.1.5",
@@ -2549,7 +2540,7 @@ name = "mc-crypto-digestible-derive"
 version = "0.6.0"
 dependencies = [
  "digest",
- "generic-array 0.12.3",
+ "generic-array",
  "mc-crypto-digestible",
  "proc-macro2 1.0.12",
  "quote 1.0.4",
@@ -2601,7 +2592,7 @@ version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "failure",
- "generic-array 0.12.3",
+ "generic-array",
  "mc-util-serial",
  "mc-util-test-helper",
  "rand_core 0.5.1",
@@ -2617,7 +2608,7 @@ dependencies = [
  "aes-gcm",
  "digest",
  "failure",
- "generic-array 0.12.3",
+ "generic-array",
  "hkdf",
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -3191,7 +3182,7 @@ dependencies = [
  "curve25519-dalek",
  "digest",
  "failure",
- "generic-array 0.12.3",
+ "generic-array",
  "hex_fmt",
  "lazy_static",
  "mc-account-keys",
@@ -3468,7 +3459,7 @@ dependencies = [
 name = "mc-util-repr-bytes"
 version = "0.6.0"
 dependencies = [
- "generic-array 0.13.2",
+ "generic-array",
  "prost",
  "serde",
  "serde_cbor",
@@ -5973,7 +5964,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df0c900f2f9b4116803415878ff48b63da9edb268668e08cf9292d7503114a01"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array",
  "subtle 2.2.3",
 ]
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -402,14 +402,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "genio"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,7 +1130,7 @@ dependencies = [
 name = "mc-util-repr-bytes"
 version = "0.6.0"
 dependencies = [
- "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1732,7 +1724,6 @@ dependencies = [
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-"checksum generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
 "checksum genio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4e26859a808ffa83a83f20c7e3c9366afea91edae637a6ac203051885882dc8"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum ghash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0930ed19a7184089ea46d2fedead2f6dc2b674c5db4276b7da336c7cd83252"

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -9,7 +9,7 @@ mc-util-serial = { path = "../../util/serial", default-features = false }
 
 aes-gcm = { version = "0.3.0" }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
-generic-array = { version = "0.12", default-features = false }
+generic-array = { version = "0.12" }
 rand_core = { version = "0.5", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 subtle = { version = "2.2", default-features = false, features = ["i128"] }

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -13,7 +13,7 @@ aes-gcm = "0.3"
 aead = "0.2"
 digest = { version = "0.8", default-features = false }
 failure = { version = "0.1", default-features = false, features = ["derive"] }
-generic-array = { version = "0.12", default-features = false, features = ["serde"] }
+generic-array = { version = "0.12", features = ["serde"] }
 hkdf = "0.8.0"
 rand_core = "0.5"
 secrecy = "0.4"

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-generic-array = "0.13"
+generic-array = "0.12"
 prost = { version = "0.6.1", optional = true, default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 


### PR DESCRIPTION
### Motivation

The build is breaking on CI sporadically and it might have something to do with repr-bytes depending on a different version of generic-array then the rest of the project.

### In this PR
* Change generic-array deps to all be 0.12
* Remove unnecessary default-features = fasle

### Future Work
* Upgrade all of the things so we could use generic-array 0.14.

