### PR TITLE
Big version update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
 [[package]]
 name = "ed25519-dalek"
 version = "1.0.0-pre.4"
-source = "git+https://github.com/eranrund/ed25519-dalek?rev=006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2#006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2"
+source = "git+https://github.com/eranrund/ed25519-dalek?rev=ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb#ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb"
 dependencies = [
  "curve25519-dalek",
  "ed25519",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,8 +2611,8 @@ dependencies = [
 name = "mc-crypto-digestible-derive-test"
 version = "0.6.0"
 dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.3",
+ "digest 0.9.0",
+ "generic-array 0.14.4",
  "mc-crypto-digestible",
  "mc-crypto-digestible-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,8 +599,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 [[package]]
 name = "cpuid-bool"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+source = "git+https://github.com/eranrund/RustCrypto-utils?rev=e00f5f16e395349c2c2395aac9287da0ac843a73#e00f5f16e395349c2c2395aac9287da0ac843a73"
 
 [[package]]
 name = "crc"
@@ -1018,8 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0-pre.4"
-source = "git+https://github.com/eranrund/ed25519-dalek?rev=ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb#ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d2e93f837d749c16d118e7ddf7a4dfd0ac8f452cf51e46e9348824e5ef6851"
 dependencies = [
  "curve25519-dalek",
  "ed25519",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,56 +8,56 @@ checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
 name = "aead"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf01b9b56e767bb57b94ebf91a58b338002963785cdd7013e21c0d4679471e4"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
 name = "aes"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
+checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
 dependencies = [
  "aes-soft",
  "aesni",
- "block-cipher-trait",
+ "block-cipher",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.3.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e6fb62c3640759142eb73015f57eece23832fde0a7ccd8be17d7ccbd01f21c"
+checksum = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
 dependencies = [
  "aead",
  "aes",
+ "block-cipher",
  "ghash",
  "subtle 2.2.3",
- "zeroize 1.1.0",
 ]
 
 [[package]]
 name = "aes-soft"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
+checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "byteorder",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
+checksum = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
 dependencies = [
- "block-cipher-trait",
- "opaque-debug",
+ "block-cipher",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -209,9 +209,9 @@ checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
 name = "bincode"
-version = "1.3.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 dependencies = [
  "byteorder",
  "serde",
@@ -272,14 +272,15 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
+checksum = "84ce5b6108f8e154604bd4eb76a2f726066c3464d5a552a4229262a18c9bb471"
 dependencies = [
  "byte-tools",
- "crypto-mac",
- "digest",
- "opaque-debug",
+ "byteorder",
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -299,19 +300,29 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
-name = "block-cipher-trait"
-version = "0.6.2"
+name = "block-buffer"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "block-padding 0.2.1",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-cipher"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -322,6 +333,12 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bs58"
@@ -350,13 +367,12 @@ checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 [[package]]
 name = "bulletproofs"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6731420b125f0300427b4f7d146a7c161b02801c126bed8b66c8e1340f574"
+source = "git+https://github.com/eranrund/bulletproofs?rev=e8e8ef45ecc6d31f1a9525140edc977351d0f780#e8e8ef45ecc6d31f1a9525140edc977351d0f780"
 dependencies = [
  "byteorder",
  "clear_on_drop",
  "curve25519-dalek",
- "digest",
+ "digest 0.9.0",
  "merlin",
  "rand_core 0.5.1",
  "serde",
@@ -581,6 +597,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
 name = "crc"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,8 +766,18 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
  "subtle 1.0.0",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.2.3",
 ]
 
 [[package]]
@@ -791,12 +823,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
+checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "packed_simd",
  "rand_core 0.5.1",
  "serde",
@@ -895,7 +927,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -978,14 +1019,13 @@ dependencies = [
 [[package]]
 name = "ed25519-dalek"
 version = "1.0.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
+source = "git+https://github.com/eranrund/ed25519-dalek?rev=006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2#006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.9.1",
  "zeroize 1.1.0",
 ]
 
@@ -1270,8 +1310,18 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
  "serde",
  "typenum",
+ "version_check 0.9.1",
 ]
 
 [[package]]
@@ -1296,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0930ed19a7184089ea46d2fedead2f6dc2b674c5db4276b7da336c7cd83252"
+checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
 dependencies = [
  "polyval",
 ]
@@ -1450,12 +1500,12 @@ checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hkdf"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa08a006102488bd9cd5b8013aabe84955cf5ae22e304c2caf655b633aefae3"
+checksum = "fe1149865383e4526a43aee8495f9a325f0b806c63ce6427d06336a590abbbc9"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.9.0",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -1464,8 +1514,18 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
- "crypto-mac",
- "digest",
+ "crypto-mac 0.7.0",
+ "digest 0.8.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1963,7 +2023,7 @@ dependencies = [
  "criterion",
  "curve25519-dalek",
  "datatest",
- "digest",
+ "digest 0.9.0",
  "displaydoc",
  "hkdf",
  "mc-account-keys-test-vectors",
@@ -2050,7 +2110,7 @@ version = "0.6.0"
 dependencies = [
  "aead",
  "aes-gcm",
- "digest",
+ "digest 0.9.0",
  "failure",
  "mc-attest-core",
  "mc-attest-net",
@@ -2064,7 +2124,7 @@ dependencies = [
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
  "serde",
- "sha2",
+ "sha2 0.9.1",
 ]
 
 [[package]]
@@ -2073,7 +2133,7 @@ version = "0.6.0"
 dependencies = [
  "aead",
  "cargo-emit",
- "digest",
+ "digest 0.9.0",
  "futures 0.3.5",
  "grpcio",
  "mc-attest-ake",
@@ -2091,14 +2151,13 @@ name = "mc-attest-core"
 version = "0.6.0"
 dependencies = [
  "binascii",
- "bincode",
  "bitflags",
  "cfg-if",
  "chrono",
- "digest",
+ "digest 0.9.0",
  "displaydoc",
  "failure",
- "generic-array",
+ "generic-array 0.14.4",
  "hex 0.3.2",
  "hex_fmt",
  "mbedtls",
@@ -2116,7 +2175,7 @@ dependencies = [
  "rand_hc 0.2.0",
  "rjson",
  "serde",
- "sha2",
+ "sha2 0.9.1",
  "subtle 2.2.3",
 ]
 
@@ -2148,7 +2207,7 @@ dependencies = [
  "rand 0.7.3",
  "reqwest",
  "serde_json",
- "sha2",
+ "sha2 0.9.1",
 ]
 
 [[package]]
@@ -2181,7 +2240,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "failure",
- "generic-array",
+ "generic-array 0.14.4",
  "hashbrown 0.6.3",
  "hex_fmt",
  "hostname 0.1.5",
@@ -2235,7 +2294,7 @@ dependencies = [
  "retry",
  "secrecy",
  "serde",
- "sha2",
+ "sha2 0.9.1",
  "tempdir",
 ]
 
@@ -2324,7 +2383,7 @@ name = "mc-consensus-enclave-impl"
 version = "0.6.0"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.9.0",
  "mbedtls",
  "mc-account-keys",
  "mc-attest-core",
@@ -2351,7 +2410,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
- "sha2",
+ "sha2 0.9.1",
 ]
 
 [[package]]
@@ -2383,7 +2442,7 @@ dependencies = [
  "mockall",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
- "sha2",
+ "sha2 0.9.1",
 ]
 
 [[package]]
@@ -2469,7 +2528,6 @@ dependencies = [
  "mc-util-metrics",
  "mc-util-serial",
  "mc-util-uri",
- "mockall",
  "prost",
  "protobuf",
  "rand 0.7.3",
@@ -2490,7 +2548,7 @@ version = "0.6.0"
 dependencies = [
  "aead",
  "aes-gcm",
- "digest",
+ "digest 0.9.0",
  "failure",
  "mc-attest-ake",
  "mc-attest-core",
@@ -2506,7 +2564,7 @@ dependencies = [
  "mc-util-serial",
  "rand_core 0.5.1",
  "serde",
- "sha2",
+ "sha2 0.9.1",
 ]
 
 [[package]]
@@ -2516,7 +2574,7 @@ dependencies = [
  "aead",
  "aes-gcm",
  "blake2",
- "digest",
+ "digest 0.9.0",
  "failure",
  "hkdf",
  "mc-crypto-keys",
@@ -2531,7 +2589,7 @@ version = "0.6.0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
- "digest",
+ "digest 0.9.0",
  "ed25519-dalek",
  "mc-crypto-digestible-derive",
  "sha3",
@@ -2542,19 +2600,12 @@ dependencies = [
 name = "mc-crypto-digestible-derive"
 version = "0.6.0"
 dependencies = [
+ "digest 0.9.0",
+ "generic-array 0.14.4",
+ "mc-crypto-digestible",
  "proc-macro2 1.0.12",
  "quote 1.0.4",
  "syn 1.0.18",
-]
-
-[[package]]
-name = "mc-crypto-digestible-derive-test"
-version = "0.6.0"
-dependencies = [
- "digest",
- "generic-array",
- "mc-crypto-digestible",
- "mc-crypto-digestible-derive",
 ]
 
 [[package]]
@@ -2562,7 +2613,7 @@ name = "mc-crypto-hashes"
 version = "0.6.0"
 dependencies = [
  "blake2",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -2572,7 +2623,7 @@ dependencies = [
  "binascii",
  "cfg-if",
  "curve25519-dalek",
- "digest",
+ "digest 0.9.0",
  "ed25519",
  "ed25519-dalek",
  "failure",
@@ -2589,7 +2640,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.9.1",
  "signature",
  "tempdir",
  "x25519-dalek",
@@ -2602,7 +2653,7 @@ version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "failure",
- "generic-array",
+ "generic-array 0.14.4",
  "mc-util-serial",
  "mc-util-test-helper",
  "rand_core 0.5.1",
@@ -2616,9 +2667,9 @@ version = "0.6.0"
 dependencies = [
  "aead",
  "aes-gcm",
- "digest",
+ "digest 0.9.0",
  "failure",
- "generic-array",
+ "generic-array 0.14.4",
  "hkdf",
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -2627,7 +2678,7 @@ dependencies = [
  "rand_hc 0.2.0",
  "secrecy",
  "serde",
- "sha2",
+ "sha2 0.9.1",
  "subtle 2.2.3",
  "zeroize 0.10.1",
 ]
@@ -2889,7 +2940,7 @@ dependencies = [
  "rand_hc 0.2.0",
  "retry",
  "serde",
- "sha2",
+ "sha2 0.9.1",
  "url 2.1.1",
 ]
 
@@ -2913,7 +2964,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_hc 0.2.0",
  "retry",
- "sha2",
+ "sha2 0.9.1",
 ]
 
 [[package]]
@@ -2984,7 +3035,7 @@ name = "mc-sgx-css"
 version = "0.6.0"
 dependencies = [
  "failure",
- "sha2",
+ "sha2 0.9.1",
 ]
 
 [[package]]
@@ -3191,9 +3242,9 @@ dependencies = [
  "bulletproofs",
  "cfg-if",
  "curve25519-dalek",
- "digest",
+ "digest 0.9.0",
  "failure",
- "generic-array",
+ "generic-array 0.14.4",
  "hex_fmt",
  "lazy_static",
  "mc-account-keys",
@@ -3216,7 +3267,7 @@ dependencies = [
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
  "serde",
- "sha2",
+ "sha2 0.9.1",
  "subtle 2.2.3",
  "tempdir",
  "time",
@@ -3470,7 +3521,7 @@ dependencies = [
 name = "mc-util-repr-bytes"
 version = "0.6.0"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "prost",
  "serde",
  "serde_cbor",
@@ -3857,6 +3908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,9 +4091,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec3341498978de3bfd12d1b22f1af1de22818f5473a11e8a6ef997989e3a212"
+checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
 dependencies = [
  "cfg-if",
  "universal-hash",
@@ -4739,7 +4796,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
  "hex 0.4.2",
- "hmac",
+ "hmac 0.7.1",
  "http 0.1.21",
  "hyper 0.12.35",
  "log 0.4.8",
@@ -4748,7 +4805,7 @@ dependencies = [
  "rusoto_credential",
  "rustc_version",
  "serde",
- "sha2",
+ "sha2 0.8.1",
  "time",
  "tokio 0.1.22",
 ]
@@ -4881,15 +4938,14 @@ dependencies = [
 [[package]]
 name = "schnorrkel"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
+source = "git+https://github.com/eranrund/schnorrkel?rev=9fe3a3c840f3eaa348f55428c40f150bf09aa608#9fe3a3c840f3eaa348f55428c40f150bf09aa608"
 dependencies = [
  "arrayref",
  "arrayvec",
  "curve25519-dalek",
  "merlin",
  "rand_core 0.5.1",
- "sha2",
+ "sha2 0.9.1",
  "subtle 2.2.3",
  "zeroize 1.1.0",
 ]
@@ -5090,10 +5146,24 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "libc",
+ "opaque-debug 0.3.0",
  "sha2-asm",
 ]
 
@@ -5108,15 +5178,14 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "block-buffer",
- "byte-tools",
- "digest",
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
  "keccak",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -5137,11 +5206,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.0.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685e1c5b65c6cc6fd0eb9ba63c6cfb8431f7f9c7e078c626f23f50e13fa378d7"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -5972,11 +6041,11 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "universal-hash"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0c900f2f9b4116803415878ff48b63da9edb268668e08cf9292d7503114a01"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle 2.2.3",
 ]
 
@@ -6284,9 +6353,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "0.6.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
+checksum = "00ffb05621d7d051df0f020edf3e5db20797a4e522bf1f9c5dfa20603f1c85f6"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,9 +209,9 @@ checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
 name = "bincode"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
  "byteorder",
  "serde",
@@ -2151,6 +2151,7 @@ name = "mc-attest-core"
 version = "0.6.0"
 dependencies = [
  "binascii",
+ "bincode",
  "bitflags",
  "cfg-if",
  "chrono",
@@ -2528,6 +2529,7 @@ dependencies = [
  "mc-util-metrics",
  "mc-util-serial",
  "mc-util-uri",
+ "mockall",
  "prost",
  "protobuf",
  "rand 0.7.3",
@@ -2600,12 +2602,19 @@ dependencies = [
 name = "mc-crypto-digestible-derive"
 version = "0.6.0"
 dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.4",
- "mc-crypto-digestible",
  "proc-macro2 1.0.12",
  "quote 1.0.4",
  "syn 1.0.18",
+]
+
+[[package]]
+name = "mc-crypto-digestible-derive-test"
+version = "0.6.0"
+dependencies = [
+ "digest 0.8.1",
+ "generic-array 0.12.3",
+ "mc-crypto-digestible",
+ "mc-crypto-digestible-derive",
 ]
 
 [[package]]
@@ -4938,7 +4947,7 @@ dependencies = [
 [[package]]
 name = "schnorrkel"
 version = "0.9.1"
-source = "git+https://github.com/eranrund/schnorrkel?rev=9fe3a3c840f3eaa348f55428c40f150bf09aa608#9fe3a3c840f3eaa348f55428c40f150bf09aa608"
+source = "git+https://github.com/w3f/schnorrkel?rev=cfdbe9ae865a4d3ffa2566d896d4dbedf5107028#cfdbe9ae865a4d3ffa2566d896d4dbedf5107028"
 dependencies = [
  "arrayref",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,3 +128,7 @@ lmdb-rkv = { git = "https://github.com/mozilla/lmdb-rs", rev = "df1c2f5" }
 # * Allow enabling `serde/std` without also requiring `serde_cbor/std` to be enabled.
 #   See: https://github.com/pyfisch/cbor/pull/198
 serde_cbor = { git = "https://github.com/mobilecoinofficial/cbor", rev = "4c886a7c1d523aae1ec4aa7386f402cb2f4341b5" }
+
+# Patched to depend on crates that depend on digest 0.9
+ed25519-dalek = { git = "https://github.com/eranrund/ed25519-dalek", rev = "006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2" }
+bulletproofs = { git = "https://github.com/eranrund/bulletproofs", rev = "e8e8ef45ecc6d31f1a9525140edc977351d0f780" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,5 +130,5 @@ lmdb-rkv = { git = "https://github.com/mozilla/lmdb-rs", rev = "df1c2f5" }
 serde_cbor = { git = "https://github.com/mobilecoinofficial/cbor", rev = "4c886a7c1d523aae1ec4aa7386f402cb2f4341b5" }
 
 # Patched to depend on crates that depend on digest 0.9
-ed25519-dalek = { git = "https://github.com/eranrund/ed25519-dalek", rev = "006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2" }
+ed25519-dalek = { git = "https://github.com/eranrund/ed25519-dalek", rev = "ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb" }
 bulletproofs = { git = "https://github.com/eranrund/bulletproofs", rev = "e8e8ef45ecc6d31f1a9525140edc977351d0f780" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,5 +130,7 @@ lmdb-rkv = { git = "https://github.com/mozilla/lmdb-rs", rev = "df1c2f5" }
 serde_cbor = { git = "https://github.com/mobilecoinofficial/cbor", rev = "4c886a7c1d523aae1ec4aa7386f402cb2f4341b5" }
 
 # Patched to depend on crates that depend on digest 0.9
-ed25519-dalek = { git = "https://github.com/eranrund/ed25519-dalek", rev = "ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb" }
 bulletproofs = { git = "https://github.com/eranrund/bulletproofs", rev = "e8e8ef45ecc6d31f1a9525140edc977351d0f780" }
+
+# Patched to disable the cpuid instruction because that is incompatible with our sgx builds.
+cpuid-bool = { git = "https://github.com/eranrund/RustCrypto-utils", rev = "e00f5f16e395349c2c2395aac9287da0ac843a73" }

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -7,9 +7,9 @@ readme = "README.md"
 
 [dependencies]
 # External dependencies
-digest = { version = "0.8.1", default-features = false }
+digest = { version = "0.9", default-features = false }
 displaydoc = { version = "0.1.7", default-features = false }
-hkdf = { version = "0.8.0", default-features = false }
+hkdf = { version = "0.9.0", default-features = false }
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.5", default-features = false }
 zeroize = { version = "1", default-features = false }
@@ -24,12 +24,12 @@ mc-util-repr-bytes = { path = "../util/repr-bytes", default-features = false, fe
 mc-util-serial = { path = "../util/serial" }
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["simd_backend", "nightly"] }
-blake2 = { version = "0.8.1", default-features = false, features = ["simd"] }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["simd_backend", "nightly"] }
+blake2 = { version = "0.9.0", default-features = false, features = ["simd"] }
 
 [target.'cfg(not(any(target_feature = "avx2", target_feature = "avx")))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["nightly", "u64_backend"] }
-blake2 = { version = "0.8.1", default-features = false }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["nightly", "u64_backend"] }
+blake2 = { version = "0.9.0", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -393,9 +393,9 @@ impl AccountKey {
         let Hs: Scalar = {
             let n = Scalar::from(index);
             let mut digest = Blake2b::new();
-            digest.input(SUBADDRESS_DOMAIN_TAG);
-            digest.input(a.as_bytes());
-            digest.input(n.as_bytes());
+            digest.update(SUBADDRESS_DOMAIN_TAG);
+            digest.update(a.as_bytes());
+            digest.update(n.as_bytes());
             Scalar::from_hash::<Blake2b>(digest)
         };
 
@@ -416,9 +416,9 @@ impl AccountKey {
         let Hs: Scalar = {
             let n = Scalar::from(index);
             let mut digest = Blake2b::new();
-            digest.input(SUBADDRESS_DOMAIN_TAG);
-            digest.input(a.as_bytes());
-            digest.input(n.as_bytes());
+            digest.update(SUBADDRESS_DOMAIN_TAG);
+            digest.update(a.as_bytes());
+            digest.update(n.as_bytes());
             Scalar::from_hash::<Blake2b>(digest)
         };
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -20,10 +20,10 @@ displaydoc = { version = "0.1.7", default-features = false }
 protobuf = "2.12"
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["simd_backend", "nightly"] }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["simd_backend", "nightly"] }
 
 [target.'cfg(not(any(target_feature = "avx2", target_feature = "avx")))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["nightly", "u64_backend"] }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["nightly", "u64_backend"] }
 
 [build-dependencies]
 mc-util-build-grpc = { path = "../util/build/grpc" }

--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -1132,7 +1132,7 @@ mod conversion_tests {
         );
         assert_eq!(
             block_signature.get_signer().get_data(),
-            source_block_signature.signer().to_bytes().as_ref(),
+            source_block_signature.signer().to_bytes().as_slice(),
         );
         assert_eq!(
             block_signature.get_signed_at(),

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -22,8 +22,8 @@ mc-crypto-keys = { path = "../../crypto/keys", default-features = false }
 mc-crypto-noise = { path = "../../crypto/noise", default-features = false }
 mc-util-serial = { path = "../../util/serial", default-features = false }
 
-aead = "0.2"
-digest = { version = "0.8", default-features = false }
+aead = "0.3"
+digest = { version = "0.9", default-features = false }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
 rand_core = "0.5"
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
@@ -32,9 +32,9 @@ serde = { version = "1.0", default-features = false, features = ["alloc"] }
 mc-attest-net = { path = "../net" }
 mc-util-encodings = { path = "../../util/encodings" }
 mc-util-from-random = { path = "../../util/from-random" }
-aes-gcm = "0.3"
+aes-gcm = "0.6"
 rand_hc = "0.2"
-sha2 = "0.8"
+sha2 = "0.9"
 
 [build-dependencies]
 mc-sgx-build = { path = "../../sgx/build" }

--- a/attest/ake/src/event.rs
+++ b/attest/ake/src/event.rs
@@ -6,7 +6,7 @@ use crate::mealy::{Input as MealyInput, Output as MealyOutput};
 use aead::{AeadMut, NewAead};
 use alloc::vec::Vec;
 use core::marker::PhantomData;
-use digest::{BlockInput, FixedOutput, Input, Reset};
+use digest::{BlockInput, FixedOutput, Reset, Update};
 use mc_attest_core::VerificationReport;
 use mc_crypto_keys::Kex;
 use mc_crypto_noise::{HandshakePattern, NoiseCipher, ProtocolName};
@@ -17,7 +17,7 @@ pub struct NodeInitiate<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     /// This is the local node's identity key
     pub(crate) local_identity: KexAlgo::Private,
@@ -33,7 +33,7 @@ impl<KexAlgo, Cipher, DigestType> NodeInitiate<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     /// Create a new input event to initiate a node-to-node channel.
     pub fn new(local_identity: KexAlgo::Private, ias_report: VerificationReport) -> Self {
@@ -51,7 +51,7 @@ impl<KexAlgo, Cipher, DigestType> MealyInput for NodeInitiate<KexAlgo, Cipher, D
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
 }
 
@@ -61,7 +61,7 @@ pub struct ClientInitiate<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     _kex: PhantomData<fn() -> KexAlgo>,
     _cipher: PhantomData<fn() -> Cipher>,
@@ -72,7 +72,7 @@ impl<KexAlgo, Cipher, DigestType> Default for ClientInitiate<KexAlgo, Cipher, Di
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     fn default() -> Self {
         Self {
@@ -87,7 +87,7 @@ impl<KexAlgo, Cipher, DigestType> MealyInput for ClientInitiate<KexAlgo, Cipher,
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
 }
 
@@ -98,7 +98,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     /// The actual AuthRequest data
     pub(crate) data: Vec<u8>,
@@ -113,7 +113,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     fn from(data: Vec<u8>) -> Self {
         Self {
@@ -129,7 +129,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     fn into(self) -> Vec<u8> {
         self.data
@@ -142,7 +142,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     fn as_ref(&self) -> &[u8] {
         self.data.as_ref()
@@ -156,7 +156,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
 }
 
@@ -169,7 +169,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     /// This is the local node's identity key
     pub(crate) local_identity: KexAlgo::Private,
@@ -186,7 +186,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
 }
 
@@ -196,7 +196,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     pub fn new(
         data: AuthRequestOutput<Handshake, KexAlgo, Cipher, DigestType>,

--- a/attest/ake/src/initiator.rs
+++ b/attest/ake/src/initiator.rs
@@ -11,7 +11,7 @@ use crate::{
 use aead::{AeadMut, NewAead};
 use alloc::{string::String, vec::Vec};
 use core::convert::TryFrom;
-use digest::{BlockInput, Digest, FixedOutput, Input, Reset};
+use digest::{BlockInput, Digest, FixedOutput, Reset, Update};
 use mc_attest_core::{Measurement, QuoteSignType, ReportDataMask, VerificationReport};
 use mc_crypto_keys::{Kex, ReprBytes};
 use mc_crypto_noise::{
@@ -40,7 +40,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset,
 {
     match output.status {
         HandshakeStatus::InProgress(state) => Ok((
@@ -68,7 +68,7 @@ impl<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset,
     ProtocolName<HandshakeNX, KexAlgo, Cipher, DigestType>: AsRef<str>,
 {
     type Error = Error;
@@ -118,7 +118,7 @@ impl<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset,
     ProtocolName<HandshakeIX, KexAlgo, Cipher, DigestType>: AsRef<str>,
 {
     type Error = Error;
@@ -168,7 +168,7 @@ impl<KexAlgo, Cipher, DigestType> Transition<Ready<Cipher>, AuthResponse, AuthSu
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset,
 {
     type Error = Error;
 

--- a/attest/ake/src/responder.rs
+++ b/attest/ake/src/responder.rs
@@ -10,7 +10,7 @@ use crate::{
 use aead::{AeadMut, NewAead};
 use alloc::vec::Vec;
 use core::convert::TryFrom;
-use digest::{BlockInput, Digest, FixedOutput, Input, Reset};
+use digest::{BlockInput, Digest, FixedOutput, Reset, Update};
 use mc_attest_core::{QuoteSignType, ReportDataMask, VerificationReport};
 use mc_crypto_keys::{Kex, ReprBytes};
 use mc_crypto_noise::{
@@ -32,7 +32,7 @@ trait ResponderTransitionMixin {
         Handshake: HandshakePattern,
         KexAlgo: Kex,
         Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-        DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset,
+        DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset,
         ProtocolName<Handshake, KexAlgo, Cipher, DigestType>: AsRef<str>;
 
     fn handle_response<KexAlgo, Cipher, DigestType>(
@@ -43,7 +43,7 @@ trait ResponderTransitionMixin {
     where
         KexAlgo: Kex,
         Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-        DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset;
+        DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset;
 }
 
 impl ResponderTransitionMixin for Start {
@@ -56,7 +56,7 @@ impl ResponderTransitionMixin for Start {
         Handshake: HandshakePattern,
         KexAlgo: Kex,
         Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-        DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset,
+        DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset,
         ProtocolName<Handshake, KexAlgo, Cipher, DigestType>: AsRef<str>,
     {
         let handshake_state = HandshakeState::new(
@@ -89,7 +89,7 @@ impl ResponderTransitionMixin for Start {
     where
         KexAlgo: Kex,
         Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-        DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset,
+        DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset,
     {
         // Encrypt the local report for output
         let local_report = serialize(&ias_report).map_err(|_e| Error::ReportSerialization)?;
@@ -125,7 +125,7 @@ impl<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset,
     ProtocolName<HandshakeIX, KexAlgo, Cipher, DigestType>: AsRef<str>,
 {
     type Error = Error;
@@ -177,7 +177,7 @@ impl<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset,
     ProtocolName<HandshakeNX, KexAlgo, Cipher, DigestType>: AsRef<str>,
 {
     type Error = Error;

--- a/attest/ake/src/state.rs
+++ b/attest/ake/src/state.rs
@@ -5,7 +5,7 @@
 use crate::mealy::State;
 use aead::{AeadMut, NewAead};
 use alloc::{string::String, vec::Vec};
-use digest::{BlockInput, FixedOutput, Input, Reset};
+use digest::{BlockInput, FixedOutput, Reset, Update};
 use mc_attest_core::Measurement;
 use mc_crypto_keys::Kex;
 use mc_crypto_noise::{CipherError, CipherState, HandshakeState, NoiseCipher};
@@ -61,7 +61,7 @@ pub struct AuthPending<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     /// The handshake state
     pub(crate) state: HandshakeState<KexAlgo, Cipher, DigestType>,
@@ -82,7 +82,7 @@ impl<KexAlgo, Cipher, DigestType> State for AuthPending<KexAlgo, Cipher, DigestT
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
 }
 
@@ -90,7 +90,7 @@ impl<KexAlgo, Cipher, DigestType> AuthPending<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     pub(crate) fn new(
         state: HandshakeState<KexAlgo, Cipher, DigestType>,

--- a/attest/api/Cargo.toml
+++ b/attest/api/Cargo.toml
@@ -21,8 +21,8 @@ mc-attest-enclave-api = { path = "../enclave-api" }
 mc-crypto-keys = { path = "../../crypto/keys" }
 mc-crypto-noise = { path = "../../crypto/noise" }
 
-aead = "0.2"
-digest = "0.8"
+aead = "0.3"
+digest = "0.9"
 futures = "0.3"
 grpcio = "0.6.0"
 protobuf = "2.12"

--- a/attest/api/src/conversions.rs
+++ b/attest/api/src/conversions.rs
@@ -4,7 +4,7 @@
 
 use crate::attest::{AuthMessage, Message};
 use aead::{AeadMut, NewAead};
-use digest::{BlockInput, FixedOutput, Input, Reset};
+use digest::{BlockInput, FixedOutput, Reset, Update};
 use mc_attest_ake::{AuthRequestOutput, AuthResponse};
 use mc_attest_enclave_api::{
     ClientAuthRequest, ClientAuthResponse, EnclaveMessage, PeerAuthRequest, PeerAuthResponse,
@@ -19,7 +19,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     fn from(src: AuthRequestOutput<Handshake, KexAlgo, Cipher, DigestType>) -> Self {
         let mut retval = Self::default();

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -39,16 +39,16 @@ binascii = "0.1.2"
 bitflags = "1.2"
 cfg-if = "0.1"
 chrono = { version = "0.4.10", default-features = false, features = ["alloc"] }
-digest = { version = "0.8", default-features = false }
+digest = { version = "0.9", default-features = false }
 displaydoc = { version = "0.1.7", default-features = false }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
 hex_fmt = "0.3"
 rand_core = { version = "0.5", default-features = false }
 rjson = "0.3.1"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-sha2 = { version = "0.8", default-features = false }
+sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2.2", default-features = false, features = ["i128"] }
-generic-array = { version = "0.12" }
+generic-array = { version = "0.14" }
 prost = { version = "0.6.1", default-features = false }
 
 [dev-dependencies]

--- a/attest/net/Cargo.toml
+++ b/attest/net/Cargo.toml
@@ -28,7 +28,7 @@ pem = "0.6"
 reqwest = { version = "0.10" , default-features = false, features = ["rustls-tls", "gzip"] }
 percent-encoding = "1.0.1"
 serde_json = "1.0"
-sha2 = "0.8"
+sha2 = "0.9"
 
 [dev-dependencies]
 rand = "0.7"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -50,7 +50,7 @@ binascii = "0.1.2"
 hex_fmt = "0.3"
 rand_core = { version = "0.5", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-sha3 = { version = "0.8", default-features = false }
+sha3 = { version = "0.9", default-features = false }
 siphasher = "0.3"
 
 # log- and loggers-only dependencies

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -39,7 +39,7 @@ loggers = [
 cfg-if = "0.1"
 mc-crypto-digestible = { path = "../crypto/digestible" }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
-generic-array = { version = "0.12", features = ["serde"] }
+generic-array = { version = "0.14", features = ["serde"] }
 hashbrown = { version = "0.6", default-features = false, features = ["serde", "nightly"] }
 mc-crypto-keys = { path = "../crypto/keys", default-features = false }
 mc-crypto-rand = { path = "../crypto/rand" }

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -19,13 +19,13 @@ mc-util-host-cert = { path = "../util/host-cert" }
 mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }
 
-aes-gcm = "0.3"
+aes-gcm = "0.6"
 failure = "0.1.5"
 grpcio = "0.6.0"
 retry = "0.5"
 secrecy = "0.4"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-sha2 = "0.8"
+sha2 = "0.9"
 
 [dev-dependencies]
 rand = "0.7"

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -47,10 +47,10 @@ mc-util-serial = { path = "../../../util/serial" }
 mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", tag = "mc-0.3", default-features = false, features = ["aesni", "rdrand", "force_aesni_support"] }
 
 cfg-if = "0.1"
-digest = { version = "0.8", default-features = false }
+digest = { version = "0.9", default-features = false }
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.5", default-features = false }
-sha2 = { version = "0.8", default-features = false, features = ["asm"] }
+sha2 = { version = "0.9", default-features = false, features = ["asm"] }
 
 [dev-dependencies]
 rand = "0.7"

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -20,5 +20,5 @@ mc-util-serial = { path = "../../../util/serial" }
 mockall = "0.7.2"
 rand_core = "0.5"
 rand_hc = "0.2"
-sha2 = { version = "0.8", default-features = false, features = ["asm"] }
+sha2 = { version = "0.9", default-features = false, features = ["asm"] }
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 [[package]]
 name = "ed25519-dalek"
 version = "1.0.0-pre.4"
-source = "git+https://github.com/eranrund/ed25519-dalek?rev=006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2#006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2"
+source = "git+https://github.com/eranrund/ed25519-dalek?rev=ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb#ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb"
 dependencies = [
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -815,7 +815,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.4 (git+https://github.com/eranrund/ed25519-dalek?rev=006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2)",
+ "ed25519-dalek 1.0.0-pre.4 (git+https://github.com/eranrund/ed25519-dalek?rev=ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb)",
  "mc-crypto-digestible-derive 0.6.0",
  "x25519-dalek 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -846,7 +846,7 @@ dependencies = [
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.4 (git+https://github.com/eranrund/ed25519-dalek?rev=006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2)",
+ "ed25519-dalek 1.0.0-pre.4 (git+https://github.com/eranrund/ed25519-dalek?rev=ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-digestible 0.6.0",
@@ -1721,7 +1721,7 @@ dependencies = [
 "checksum digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 "checksum displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "adc2ab4d5a16117f9029e9a6b5e4e79f4c67f6519bc134210d4d4a04ba31f41b"
 "checksum ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
-"checksum ed25519-dalek 1.0.0-pre.4 (git+https://github.com/eranrund/ed25519-dalek?rev=006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2)" = "<none>"
+"checksum ed25519-dalek 1.0.0-pre.4 (git+https://github.com/eranrund/ed25519-dalek?rev=ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb)" = "<none>"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -287,7 +287,7 @@ dependencies = [
 [[package]]
 name = "cpuid-bool"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/eranrund/RustCrypto-utils?rev=e00f5f16e395349c2c2395aac9287da0ac843a73#e00f5f16e395349c2c2395aac9287da0ac843a73"
 
 [[package]]
 name = "crypto-mac"
@@ -341,8 +341,8 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0-pre.4"
-source = "git+https://github.com/eranrund/ed25519-dalek?rev=ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb#ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -815,7 +815,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.4 (git+https://github.com/eranrund/ed25519-dalek?rev=ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb)",
+ "ed25519-dalek 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-digestible-derive 0.6.0",
  "x25519-dalek 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -846,7 +846,7 @@ dependencies = [
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.4 (git+https://github.com/eranrund/ed25519-dalek?rev=ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb)",
+ "ed25519-dalek 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-digestible 0.6.0",
@@ -1401,7 +1401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-buffer 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "cpuid-bool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cpuid-bool 0.1.2 (git+https://github.com/eranrund/RustCrypto-utils?rev=e00f5f16e395349c2c2395aac9287da0ac843a73)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1715,13 +1715,13 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clear_on_drop 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
 "checksum cmake 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "49f97562167906afc51aa3fd7e6c83c10a5c96d33bd18f98a4c06a1413134caa"
-"checksum cpuid-bool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+"checksum cpuid-bool 0.1.2 (git+https://github.com/eranrund/RustCrypto-utils?rev=e00f5f16e395349c2c2395aac9287da0ac843a73)" = "<none>"
 "checksum crypto-mac 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 "checksum curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
 "checksum digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 "checksum displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "adc2ab4d5a16117f9029e9a6b5e4e79f4c67f6519bc134210d4d4a04ba31f41b"
 "checksum ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
-"checksum ed25519-dalek 1.0.0-pre.4 (git+https://github.com/eranrund/ed25519-dalek?rev=ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb)" = "<none>"
+"checksum ed25519-dalek 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53d2e93f837d749c16d118e7ddf7a4dfd0ac8f452cf51e46e9348824e5ef6851"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -2,50 +2,50 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aead"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aes"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aes-soft 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "aesni 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-soft 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aesni 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ghash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ghash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aes-soft"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -86,7 +86,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -139,56 +139,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "blake2"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-mac 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-padding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "block-cipher-trait"
-version = "0.6.2"
+name = "block-cipher"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "bulletproofs"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/eranrund/bulletproofs?rev=e8e8ef45ecc6d31f1a9525140edc977351d0f780#e8e8ef45ecc6d31f1a9525140edc977351d0f780"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clear_on_drop 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -254,7 +250,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -289,21 +285,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "crypto-mac"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "packed_simd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -313,10 +314,10 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -335,19 +336,19 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "signature 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signature 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ed25519-dalek"
 version = "1.0.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/eranrund/ed25519-dalek?rev=006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2#006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2"
 dependencies = [
- "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -388,17 +389,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -415,16 +412,16 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "polyval 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polyval 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -451,7 +448,7 @@ name = "hermit-abi"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -466,20 +463,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hkdf"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-mac 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -523,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -575,11 +572,11 @@ dependencies = [
 name = "mc-account-keys"
 version = "0.6.0"
 dependencies = [
- "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-digestible 0.6.0",
  "mc-crypto-hashes 0.6.0",
  "mc-crypto-keys 0.6.0",
@@ -596,8 +593,8 @@ dependencies = [
 name = "mc-attest-ake"
 version = "0.6.0"
 dependencies = [
- "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-attest-core 0.6.0",
  "mc-common 0.6.0",
@@ -617,10 +614,10 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
  "mbedtls-sys-auto 2.18.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
@@ -633,7 +630,7 @@ dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rjson 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -668,7 +665,7 @@ dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-digestible 0.6.0",
@@ -677,7 +674,7 @@ dependencies = [
  "mc-util-serial 0.6.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.6.0 (git+https://github.com/mobilecoinofficial/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf)",
 ]
@@ -715,7 +712,7 @@ name = "mc-consensus-enclave-impl"
 version = "0.6.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
  "mc-account-keys 0.6.0",
  "mc-attest-core 0.6.0",
@@ -738,7 +735,7 @@ dependencies = [
  "mc-util-serial 0.6.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -769,16 +766,16 @@ dependencies = [
  "mc-util-build-sgx 0.6.0",
  "mc-util-serial 0.6.0",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-crypto-ake-enclave"
 version = "0.6.0"
 dependencies = [
- "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aes-gcm 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-attest-ake 0.6.0",
  "mc-attest-core 0.6.0",
@@ -794,19 +791,19 @@ dependencies = [
  "mc-util-serial 0.6.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-crypto-box"
 version = "0.6.0"
 dependencies = [
- "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aes-gcm 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-keys 0.6.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -816,11 +813,11 @@ name = "mc-crypto-digestible"
 version = "0.6.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.4 (git+https://github.com/eranrund/ed25519-dalek?rev=006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2)",
  "mc-crypto-digestible-derive 0.6.0",
- "x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x25519-dalek 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -836,8 +833,8 @@ dependencies = [
 name = "mc-crypto-hashes"
 version = "0.6.0"
 dependencies = [
- "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -846,10 +843,10 @@ version = "0.6.0"
 dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.4 (git+https://github.com/eranrund/ed25519-dalek?rev=006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-digestible 0.6.0",
@@ -859,9 +856,9 @@ dependencies = [
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "signature 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signature 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x25519-dalek 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -869,9 +866,9 @@ dependencies = [
 name = "mc-crypto-message-cipher"
 version = "0.6.0"
 dependencies = [
- "aes-gcm 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-util-serial 0.6.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -882,19 +879,19 @@ dependencies = [
 name = "mc-crypto-noise"
 version = "0.6.0"
 dependencies = [
- "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "aes-gcm 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-keys 0.6.0",
  "mc-util-from-random 0.6.0",
  "mc-util-repr-bytes 0.6.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -919,7 +916,7 @@ dependencies = [
  "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.9.1 (git+https://github.com/eranrund/schnorrkel?rev=9fe3a3c840f3eaa348f55428c40f150bf09aa608)",
 ]
 
 [[package]]
@@ -1056,13 +1053,13 @@ version = "0.6.0"
 name = "mc-transaction-core"
 version = "0.6.0"
 dependencies = [
- "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bulletproofs 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bulletproofs 2.0.0 (git+https://github.com/eranrund/bulletproofs?rev=e8e8ef45ecc6d31f1a9525140edc977351d0f780)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-account-keys 0.6.0",
@@ -1079,7 +1076,7 @@ dependencies = [
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1130,7 +1127,7 @@ dependencies = [
 name = "mc-util-repr-bytes"
 version = "0.6.0"
 dependencies = [
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1192,6 +1189,11 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "packed_simd"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,11 +1218,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "polyval"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "universal-hash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "universal-hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1345,14 +1347,14 @@ dependencies = [
 [[package]]
 name = "schnorrkel"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/eranrund/schnorrkel?rev=9fe3a3c840f3eaa348f55428c40f150bf09aa608#9fe3a3c840f3eaa348f55428c40f150bf09aa608"
 dependencies = [
  "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1394,13 +1396,15 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cpuid-bool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2-asm 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1414,14 +1418,13 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1431,10 +1434,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "signature"
-version = "1.0.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1460,11 +1463,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "strsim"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1522,14 +1520,14 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.11.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1560,10 +1558,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "universal-hash"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1585,6 +1583,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "version_check"
 version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1612,7 +1615,7 @@ name = "which"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1644,10 +1647,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "x25519-dalek"
-version = "0.6.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1677,11 +1680,11 @@ dependencies = [
 ]
 
 [metadata]
-"checksum aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4cf01b9b56e767bb57b94ebf91a58b338002963785cdd7013e21c0d4679471e4"
-"checksum aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
-"checksum aes-gcm 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4001f31800fc9b8c774728f82c7348f4f91474afd38c12a0e7dfa8303ae2dbd6"
-"checksum aes-soft 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
-"checksum aesni 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
+"checksum aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+"checksum aes 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
+"checksum aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
+"checksum aes-soft 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
+"checksum aesni 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
 "checksum aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
@@ -1694,11 +1697,11 @@ dependencies = [
 "checksum binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 "checksum bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ebd71393f1ec0509b553aa012b9b58e81dadbdff7130bd3b8cba576e69b32f75"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
-"checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-"checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
-"checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-"checksum bulletproofs 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "69e6731420b125f0300427b4f7d146a7c161b02801c126bed8b66c8e1340f574"
+"checksum blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "84ce5b6108f8e154604bd4eb76a2f726066c3464d5a552a4229262a18c9bb471"
+"checksum block-buffer 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+"checksum block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
+"checksum block-padding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+"checksum bulletproofs 2.0.0 (git+https://github.com/eranrund/bulletproofs?rev=e8e8ef45ecc6d31f1a9525140edc977351d0f780)" = "<none>"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
@@ -1712,35 +1715,35 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clear_on_drop 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
 "checksum cmake 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "49f97562167906afc51aa3fd7e6c83c10a5c96d33bd18f98a4c06a1413134caa"
-"checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-"checksum curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
-"checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+"checksum cpuid-bool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+"checksum crypto-mac 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+"checksum curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+"checksum digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 "checksum displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "adc2ab4d5a16117f9029e9a6b5e4e79f4c67f6519bc134210d4d4a04ba31f41b"
 "checksum ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
-"checksum ed25519-dalek 1.0.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)" = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
+"checksum ed25519-dalek 1.0.0-pre.4 (git+https://github.com/eranrund/ed25519-dalek?rev=006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2)" = "<none>"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
-"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+"checksum generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 "checksum genio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4e26859a808ffa83a83f20c7e3c9366afea91edae637a6ac203051885882dc8"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
-"checksum ghash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0930ed19a7184089ea46d2fedead2f6dc2b674c5db4276b7da336c7cd83252"
+"checksum ghash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum half 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20d6a47d6e4b8559729f58287efa8e6f767e603c068fea7a5e4d9f1cebe2bebb"
 "checksum hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 "checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
 "checksum hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 "checksum hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
-"checksum hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fa08a006102488bd9cd5b8013aabe84955cf5ae22e304c2caf655b633aefae3"
-"checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+"checksum hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe1149865383e4526a43aee8495f9a325f0b806c63ce6427d06336a590abbbc9"
+"checksum hmac 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+"checksum libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
@@ -1752,11 +1755,12 @@ dependencies = [
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+"checksum opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 "checksum packed_simd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a85ea9fc0d4ac0deb6fe7911d38786b32fc11119afd9e9d38b84ff691ce64220"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
-"checksum polyval 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ec3341498978de3bfd12d1b22f1af1de22818f5473a11e8a6ef997989e3a212"
+"checksum polyval 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
 "checksum prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)" = "<none>"
@@ -1773,22 +1777,21 @@ dependencies = [
 "checksum rjson 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5510dbde48c4c37bf69123b1f636b6dd5f8dffe1f4e358af03c46a4947dca219"
 "checksum rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-"checksum schnorrkel 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
+"checksum schnorrkel 0.9.1 (git+https://github.com/eranrund/schnorrkel?rev=9fe3a3c840f3eaa348f55428c40f150bf09aa608)" = "<none>"
 "checksum secrecy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb052cf770a381fa9a6ee63038ff9a0b11d30abb53be970672e950649ff0bfb"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_cbor 0.11.1 (git+https://github.com/mobilecoinofficial/cbor?rev=4c886a7c1d523aae1ec4aa7386f402cb2f4341b5)" = "<none>"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
-"checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
+"checksum sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 "checksum sha2-asm 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "817aaf5c624a7ccba7b46fb2caea2c3192831a5a2e5f66a288de21eac5e6784c"
-"checksum sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
+"checksum sha3 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
-"checksum signature 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "685e1c5b65c6cc6fd0eb9ba63c6cfb8431f7f9c7e078c626f23f50e13fa378d7"
+"checksum signature 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 "checksum siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "83da420ee8d1a89e640d0948c646c1c088758d3a3c538f943bfa97bdac17929d"
 "checksum slog 2.6.0 (git+https://github.com/mobilecoinofficial/slog?rev=cc1562258b81353426d17a55b7447256fa6eabbf)" = "<none>"
 "checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 "checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
@@ -1796,15 +1799,16 @@ dependencies = [
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+"checksum typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum universal-hash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df0c900f2f9b4116803415878ff48b63da9edb268668e08cf9292d7503114a01"
+"checksum universal-hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
@@ -1813,7 +1817,7 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
+"checksum x25519-dalek 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00ffb05621d7d051df0f020edf3e5db20797a4e522bf1f9c5dfa20603f1c85f6"
 "checksum zeroize 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4090487fa66630f7b166fba2bbb525e247a5449f41c468cc1d98f8ae6ac03120"
 "checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 "checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -916,7 +916,7 @@ dependencies = [
  "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.9.1 (git+https://github.com/eranrund/schnorrkel?rev=9fe3a3c840f3eaa348f55428c40f150bf09aa608)",
+ "schnorrkel 0.9.1 (git+https://github.com/w3f/schnorrkel?rev=cfdbe9ae865a4d3ffa2566d896d4dbedf5107028)",
 ]
 
 [[package]]
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "schnorrkel"
 version = "0.9.1"
-source = "git+https://github.com/eranrund/schnorrkel?rev=9fe3a3c840f3eaa348f55428c40f150bf09aa608#9fe3a3c840f3eaa348f55428c40f150bf09aa608"
+source = "git+https://github.com/w3f/schnorrkel?rev=cfdbe9ae865a4d3ffa2566d896d4dbedf5107028#cfdbe9ae865a4d3ffa2566d896d4dbedf5107028"
 dependencies = [
  "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1777,7 +1777,7 @@ dependencies = [
 "checksum rjson 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5510dbde48c4c37bf69123b1f636b6dd5f8dffe1f4e358af03c46a4947dca219"
 "checksum rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-"checksum schnorrkel 0.9.1 (git+https://github.com/eranrund/schnorrkel?rev=9fe3a3c840f3eaa348f55428c40f150bf09aa608)" = "<none>"
+"checksum schnorrkel 0.9.1 (git+https://github.com/w3f/schnorrkel?rev=cfdbe9ae865a4d3ffa2566d896d4dbedf5107028)" = "<none>"
 "checksum secrecy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb052cf770a381fa9a6ee63038ff9a0b11d30abb53be970672e950649ff0bfb"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde_cbor 0.11.1 (git+https://github.com/mobilecoinofficial/cbor?rev=4c886a7c1d523aae1ec4aa7386f402cb2f4341b5)" = "<none>"

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -42,7 +42,7 @@ mc-sgx-types = { path = "../../../sgx/types" }
 mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", tag = "mc-0.3", default-features = false, features = ["aesni","force_aesni_support","rdrand"] }
 
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
-sha2 = { version = "0.8", default-features = false, features = ["asm"] }
+sha2 = { version = "0.9", default-features = false, features = ["asm"] }
 
 [build-dependencies]
 mc-util-build-script = { path = "../../../util/build/script" }

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -76,7 +76,7 @@ slog = { git = "https://github.com/mobilecoinofficial/slog", rev = "cc1562258b81
 serde_cbor = { git = "https://github.com/mobilecoinofficial/cbor", rev = "4c886a7c1d523aae1ec4aa7386f402cb2f4341b5" }
 
 # Patched to depend on crates that depend on digest 0.9
-ed25519-dalek = { git = "https://github.com/eranrund/ed25519-dalek", rev = "006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2" }
+ed25519-dalek = { git = "https://github.com/eranrund/ed25519-dalek", rev = "ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb" }
 bulletproofs = { git = "https://github.com/eranrund/bulletproofs", rev = "e8e8ef45ecc6d31f1a9525140edc977351d0f780" }
 
 [workspace]

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -76,7 +76,9 @@ slog = { git = "https://github.com/mobilecoinofficial/slog", rev = "cc1562258b81
 serde_cbor = { git = "https://github.com/mobilecoinofficial/cbor", rev = "4c886a7c1d523aae1ec4aa7386f402cb2f4341b5" }
 
 # Patched to depend on crates that depend on digest 0.9
-ed25519-dalek = { git = "https://github.com/eranrund/ed25519-dalek", rev = "ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb" }
 bulletproofs = { git = "https://github.com/eranrund/bulletproofs", rev = "e8e8ef45ecc6d31f1a9525140edc977351d0f780" }
+
+# Patched to disable the cpuid instruction because that is incompatible with our sgx builds.
+cpuid-bool = { git = "https://github.com/eranrund/RustCrypto-utils", rev = "e00f5f16e395349c2c2395aac9287da0ac843a73" }
 
 [workspace]

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -75,4 +75,8 @@ slog = { git = "https://github.com/mobilecoinofficial/slog", rev = "cc1562258b81
 #   See: https://github.com/pyfisch/cbor/pull/198
 serde_cbor = { git = "https://github.com/mobilecoinofficial/cbor", rev = "4c886a7c1d523aae1ec4aa7386f402cb2f4341b5" }
 
+# Patched to depend on crates that depend on digest 0.9
+ed25519-dalek = { git = "https://github.com/eranrund/ed25519-dalek", rev = "006d9d387f2c780a8f6f2c934668ddfcb1a6f3e2" }
+bulletproofs = { git = "https://github.com/eranrund/bulletproofs", rev = "e8e8ef45ecc6d31f1a9525140edc977351d0f780" }
+
 [workspace]

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -24,7 +24,7 @@ rand = "0.7"
 rand_hc = "0.2"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = "1.0"
-sha3 = "0.8"
+sha3 = "0.9"
 
 [dev-dependencies]
 mc-common = { path = "../../common", features = ["loggers"] }

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -74,7 +74,7 @@ rand_hc = "0.2.0"
 tempdir = "0.3"
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dev-dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["simd_backend", "nightly"] }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["simd_backend", "nightly"] }
 
 [target.'cfg(not(any(target_feature = "avx2", target_feature = "avx")))'.dev-dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["nightly", "u64_backend"] }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["nightly", "u64_backend"] }

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -17,13 +17,13 @@ mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-serial = { path = "../../../util/serial", default-features = false }
 mc-sgx-compat = { path = "../../../sgx/compat", default-features = false }
 
-aead = "0.2"
-aes-gcm = "0.3"
-digest = { version = "0.8", default-features = false }
+aead = "0.3"
+aes-gcm = "0.6"
+digest = { version = "0.9", default-features = false }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
 rand_core = { version = "0.5", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
-sha2 = { version = "0.8", default-features = false }
+sha2 = { version = "0.9", default-features = false }
 
 [build-dependencies]
 mc-sgx-build = { path = "../../../sgx/build" }

--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -365,7 +365,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         for (nonce, _) in quote_pending.iter() {
             hasher.update(<QuoteNonce as AsRef<[u8]>>::as_ref(nonce));
             hasher.update(quote.as_ref());
-            let output_arr = hasher.result_reset();
+            let output_arr = hasher.finalize_reset();
             let output = output_arr.as_slice();
             debug_assert!(output.len() < qe_report_bytes.len());
             if output == &qe_report_bytes[..output.len()] {

--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -363,8 +363,8 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         // We iterate each nonce in our cache, and save the key of the one
         // we want to work on
         for (nonce, _) in quote_pending.iter() {
-            hasher.input(<QuoteNonce as AsRef<[u8]>>::as_ref(nonce));
-            hasher.input(quote.as_ref());
+            hasher.update(<QuoteNonce as AsRef<[u8]>>::as_ref(nonce));
+            hasher.update(quote.as_ref());
             let output_arr = hasher.result_reset();
             let output = output_arr.as_slice();
             debug_assert!(output.len() < qe_report_bytes.len());

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["MobileCoin"]
 edition = "2018"
 
 [dependencies]
-aead = "0.2"
-aes-gcm = { version = "0.3.0", default-features = false }
-blake2 = { version = "0.8", default-features = false }
-digest = { version = "0.8" }
+aead = "0.3"
+aes-gcm = { version = "0.6.0" }
+blake2 = { version = "0.9", default-features = false }
+digest = { version = "0.9" }
 failure = { version = "0.1.5", default-features = false }
-hkdf = { version = "0.8.0", default-features = false }
+hkdf = { version = "0.9.0", default-features = false }
 mc-crypto-keys = { path = "../keys", default-features = false }
 rand_core = { version = "0.5", default-features = false }
 

--- a/crypto/box/src/hkdf_box.rs
+++ b/crypto/box/src/hkdf_box.rs
@@ -6,14 +6,14 @@ use aead::{
         typenum::{Sum, Unsigned},
         ArrayLength, GenericArray,
     },
-    Aead, Error as AeadError, NewAead,
+    AeadInPlace, Error as AeadError, NewAead,
 };
 use core::{
     convert::TryFrom,
     marker::PhantomData,
     ops::{Add, Sub},
 };
-use digest::{BlockInput, Digest, FixedOutput, Input, Reset};
+use digest::{BlockInput, Digest, FixedOutput, Reset, Update};
 use hkdf::Hkdf;
 use mc_crypto_keys::{Kex, ReprBytes};
 use rand_core::{CryptoRng, RngCore};
@@ -30,8 +30,8 @@ pub struct HkdfBox<KexAlgo, DigestAlgo, AeadAlgo>
 where
     KexAlgo: Kex,
     for<'privkey> <KexAlgo as Kex>::Public: From<&'privkey <KexAlgo as Kex>::EphemeralPrivate>,
-    DigestAlgo: Digest + Input + FixedOutput + Default + Clone + BlockInput + Reset,
-    AeadAlgo: Aead + NewAead,
+    DigestAlgo: Digest + Update + FixedOutput + Default + Clone + BlockInput + Reset,
+    AeadAlgo: AeadInPlace + NewAead,
 {
     _kex: PhantomData<fn() -> KexAlgo>,
     _digest: PhantomData<fn() -> DigestAlgo>,
@@ -42,8 +42,8 @@ impl<KexAlgo, DigestAlgo, AeadAlgo> CryptoBox<KexAlgo> for HkdfBox<KexAlgo, Dige
 where
     KexAlgo: Kex,
     for<'privkey> <KexAlgo as Kex>::Public: From<&'privkey <KexAlgo as Kex>::EphemeralPrivate>,
-    DigestAlgo: Digest + Input + FixedOutput + Default + Clone + BlockInput + Reset,
-    AeadAlgo: Aead + NewAead,
+    DigestAlgo: Digest + Update + FixedOutput + Default + Clone + BlockInput + Reset,
+    AeadAlgo: AeadInPlace + NewAead,
     // Note: I think all of these bounds should go away after RFC 2089 is implemented
     // https://github.com/rust-lang/rfcs/blob/master/text/2089-implied-bounds.md
     <<KexAlgo as Kex>::Public as ReprBytes>::Size:
@@ -83,7 +83,7 @@ where
         let (aes_key, aes_nonce) = Self::kdf_step(&shared_secret);
 
         // AES
-        let aead = AeadAlgo::new(aes_key);
+        let aead = AeadAlgo::new(&aes_key);
         let mac = aead.encrypt_in_place_detached(&aes_nonce, &[], buffer)?;
 
         // Tag is curve_point_bytes || aes_mac_bytes
@@ -111,7 +111,7 @@ where
         let mac_ref = <&GenericArray<u8, AeadAlgo::TagSize>>::from(
             &tag[<KexAlgo::Public as ReprBytes>::Size::USIZE..],
         );
-        let aead = AeadAlgo::new(aes_key);
+        let aead = AeadAlgo::new(&aes_key);
         aead.decrypt_in_place_detached(&aes_nonce, &[], buffer, mac_ref)
             .map_err(|_| Error::MacFailed)?;
 
@@ -123,8 +123,8 @@ impl<KexAlgo, DigestAlgo, AeadAlgo> HkdfBox<KexAlgo, DigestAlgo, AeadAlgo>
 where
     KexAlgo: Kex,
     for<'privkey> <KexAlgo as Kex>::Public: From<&'privkey <KexAlgo as Kex>::EphemeralPrivate>,
-    DigestAlgo: Digest + Input + FixedOutput + Default + Clone + BlockInput + Reset,
-    AeadAlgo: Aead + NewAead,
+    DigestAlgo: Digest + Update + FixedOutput + Default + Clone + BlockInput + Reset,
+    AeadAlgo: AeadInPlace + NewAead,
     AeadAlgo::KeySize: Add<AeadAlgo::NonceSize>,
     Sum<AeadAlgo::KeySize, AeadAlgo::NonceSize>:
         ArrayLength<u8> + Sub<AeadAlgo::KeySize, Output = AeadAlgo::NonceSize>,
@@ -151,8 +151,8 @@ impl<KexAlgo, DigestAlgo, AeadAlgo> Default for HkdfBox<KexAlgo, DigestAlgo, Aea
 where
     KexAlgo: Kex,
     for<'privkey> <KexAlgo as Kex>::Public: From<&'privkey <KexAlgo as Kex>::EphemeralPrivate>,
-    DigestAlgo: Digest + Input + FixedOutput + Default + Clone + BlockInput + Reset,
-    AeadAlgo: Aead + NewAead,
+    DigestAlgo: Digest + Update + FixedOutput + Default + Clone + BlockInput + Reset,
+    AeadAlgo: AeadInPlace + NewAead,
 {
     fn default() -> Self {
         Self {

--- a/crypto/box/src/lib.rs
+++ b/crypto/box/src/lib.rs
@@ -32,7 +32,7 @@ pub use fixed_buffer::FixedBuffer;
 #[cfg(test)]
 mod test {
     use super::*;
-    use aead::generic_array::{arr, arr_impl};
+    use aead::generic_array::arr;
     use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
     use mc_util_from_random::FromRandom;
 

--- a/crypto/box/src/versioned.rs
+++ b/crypto/box/src/versioned.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use aead::{
     generic_array::{
-        arr, arr_impl,
+        arr,
         sequence::Concat,
         typenum::{Unsigned, U50},
         GenericArray,

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -6,23 +6,23 @@ edition = "2018"
 
 [dependencies]
 cfg-if = "0.1"
-digest = { version = "0.8", default-features = false }
+digest = { version = "0.9", default-features = false }
 
 # For derive support
 mc-crypto-digestible-derive = { path = "./derive", optional = true }
 
 # Built-in support for dalek primitives
 ed25519-dalek = { version = "1.0.0-pre.4", default-features = false, optional = true }
-x25519-dalek = { version = "0.6", default-features = false, optional = true }
+x25519-dalek = { version = "1.0.1", default-features = false, optional = true }
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["simd_backend", "nightly"], optional = true }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["simd_backend", "nightly"], optional = true }
 
 [target.'cfg(not(any(target_feature = "avx2", target_feature = "avx")))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["nightly", "u64_backend"], optional = true }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["nightly", "u64_backend"], optional = true }
 
 [dev-dependencies]
-sha3 = "0.8"
+sha3 = "0.9"
 
 [features]
 default=["alloc", "derive"]

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -12,7 +12,7 @@ digest = { version = "0.9", default-features = false }
 mc-crypto-digestible-derive = { path = "./derive", optional = true }
 
 # Built-in support for dalek primitives
-ed25519-dalek = { version = "1.0.0-pre.4", default-features = false, optional = true }
+ed25519-dalek = { version = "1.0.0", default-features = false, optional = true }
 x25519-dalek = { version = "1.0.1", default-features = false, optional = true }
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]

--- a/crypto/digestible/derive/test/Cargo.toml
+++ b/crypto/digestible/derive/test/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 [dependencies]
 mc-crypto-digestible = { path = "../.." }
 mc-crypto-digestible-derive = { path = ".." }
-generic-array = "0.12"
-digest = { version = "0.8", default-features = false }
+generic-array = "0.14"
+digest = { version = "0.9", default-features = false }

--- a/crypto/digestible/derive/test/tests/behavior.rs
+++ b/crypto/digestible/derive/test/tests/behavior.rs
@@ -17,18 +17,18 @@ impl Digest for Tester {
         Default::default()
     }
 
-    fn input<B: AsRef<[u8]>>(&mut self, src: B) {
+    fn update(&mut self, src: impl AsRef<[u8]>) {
         self.args.push(src.as_ref().to_vec())
     }
 
     // Unused stuff
-    fn chain<B: AsRef<[u8]>>(self, _src: B) -> Self {
+    fn chain(self, _src: impl AsRef<[u8]>) -> Self {
         unimplemented!()
     }
-    fn result(self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize(self) -> GenericArray<u8, Self::OutputSize> {
         unimplemented!()
     }
-    fn result_reset(&mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_reset(&mut self) -> GenericArray<u8, Self::OutputSize> {
         unimplemented!()
     }
     fn reset(&mut self) {}

--- a/crypto/digestible/src/lib.rs
+++ b/crypto/digestible/src/lib.rs
@@ -21,7 +21,7 @@ pub trait Digestible {
     ) -> generic_array::GenericArray<u8, <D as Digest>::OutputSize> {
         let mut hasher = D::default();
         self.digest(&mut hasher);
-        hasher.result()
+        hasher.finalize()
     }
 }
 
@@ -43,28 +43,28 @@ pub trait Digestible {
 // impl Digestible for u8 {
 //    #[inline]
 //    fn digest<D: Digest>(&self, hasher: &mut D) {
-//        hasher.input(core::slice::from_ref(self))
+//        hasher.update(core::slice::from_ref(self))
 //    }
 // }
 
 impl Digestible for u16 {
     #[inline]
     fn digest<D: Digest>(&self, hasher: &mut D) {
-        hasher.input(&self.to_le_bytes())
+        hasher.update(&self.to_le_bytes())
     }
 }
 
 impl Digestible for u32 {
     #[inline]
     fn digest<D: Digest>(&self, hasher: &mut D) {
-        hasher.input(&self.to_le_bytes())
+        hasher.update(&self.to_le_bytes())
     }
 }
 
 impl Digestible for u64 {
     #[inline]
     fn digest<D: Digest>(&self, hasher: &mut D) {
-        hasher.input(&self.to_le_bytes())
+        hasher.update(&self.to_le_bytes())
     }
 }
 
@@ -89,7 +89,7 @@ pub trait RawDigestible: AsRef<[u8]> + Sized {}
 impl<T: RawDigestible> Digestible for T {
     #[inline]
     fn digest<D: Digest>(&self, hasher: &mut D) {
-        hasher.input(self)
+        hasher.update(self)
     }
 }
 
@@ -153,7 +153,7 @@ impl Digestible for &[u8] {
     #[inline]
     fn digest<D: Digest>(&self, hasher: &mut D) {
         self.len().digest(hasher);
-        hasher.input(self);
+        hasher.update(self);
     }
 }
 
@@ -163,11 +163,11 @@ impl<T: Digestible> Digestible for Option<T> {
     fn digest<D: Digest>(&self, hasher: &mut D) {
         match self {
             Some(ref val) => {
-                hasher.input(&[1u8]);
+                hasher.update(&[1u8]);
                 val.digest(hasher);
             }
             None => {
-                hasher.input(&[0u8]);
+                hasher.update(&[0u8]);
             }
         }
     }
@@ -245,28 +245,28 @@ cfg_if! {
         impl Digestible for CompressedRistretto {
             #[inline]
             fn digest<D: Digest>(&self, hasher: &mut D) {
-                hasher.input(&self.as_bytes());
+                hasher.update(&self.as_bytes());
             }
         }
 
         impl Digestible for Scalar {
             #[inline]
             fn digest<D: Digest>(&self, hasher: &mut D) {
-                hasher.input(self.as_bytes())
+                hasher.update(self.as_bytes())
             }
         }
 
         impl Digestible for ed25519_dalek::PublicKey {
             #[inline]
             fn digest<D: Digest>(&self, hasher: &mut D) {
-                hasher.input(self)
+                hasher.update(self)
             }
         }
 
         impl Digestible for x25519_dalek::PublicKey {
             #[inline]
             fn digest<D: Digest>(&self, hasher: &mut D) {
-                hasher.input(self.as_bytes())
+                hasher.update(self.as_bytes())
             }
         }
     }

--- a/crypto/digestible/tests/basic.rs
+++ b/crypto/digestible/tests/basic.rs
@@ -7,7 +7,7 @@ struct Foo {}
 
 impl Digestible for Foo {
     fn digest<D: Digest>(&self, hasher: &mut D) {
-        hasher.input(b"Moose");
+        hasher.update(b"Moose");
     }
 }
 

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["MobileCoin"]
 edition = "2018"
 
 [dependencies]
-blake2 = { version = "0.8.1", default-features = false, features = ["simd"] }
-digest = { version = "0.8.1", default-features = false }
+blake2 = { version = "0.9", default-features = false, features = ["simd"] }
+digest = { version = "0.9", default-features = false }

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 binascii = "0.1.2"
 cfg-if = "0.1"
-digest = { version = "0.8", default-features = false }
+digest = { version = "0.9", default-features = false }
 mc-crypto-digestible = { path = "../../crypto/digestible", features = ["dalek", "derive"] }
 ed25519 = { version = "1.0.0-pre.4", default-features = false, features = ["serde"] }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
@@ -17,21 +17,18 @@ mc-util-repr-bytes = { path = "../../util/repr-bytes" }
 mc-util-serial = { path = "../../util/serial", default-features = false }
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.5", default-features = false }
-# Note: Signature must be pinned because signature 1.2 depends on digest = 0.9, but
-# ed25519-dalek gets digest from curve25519-dalek re-export, and curve25519-dalek is on digest 0.8,
-# we cannot move forward with digest 0.9 until curve25519-dalek crate does
-signature = { version = "=1.0", default-features = false, features = ["digest-preview"] }
+signature = { version = "1.2", default-features = false, features = ["digest-preview"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-sha2 = { version = "0.8", default-features = false }
-x25519-dalek = { version = "0.6", default-features = false, features = ["nightly", "u64_backend"] }
+sha2 = { version = "0.9", default-features = false }
+x25519-dalek = { version = "1.0.1", default-features = false, features = ["nightly", "u64_backend"] }
 zeroize = { version = "1", default-features = false }
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["simd_backend", "nightly"] }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["simd_backend", "nightly"] }
 ed25519-dalek = { version = "1.0.0-pre.4", default-features = false, features = ["alloc", "nightly", "serde", "simd_backend"] }
 
 [target.'cfg(not(any(target_feature = "avx2", target_feature = "avx")))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["nightly", "u64_backend"] }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["nightly", "u64_backend"] }
 ed25519-dalek = { version = "1.0.0-pre.4", default-features = false, features = ["alloc", "nightly", "serde", "u64_backend"] }
 
 [dev-dependencies]

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 binascii = "0.1.2"
 cfg-if = "0.1"
 digest = { version = "0.9", default-features = false }
+ed25519 = { version = "1.0.1", default-features = false, features = ["serde"] }
 mc-crypto-digestible = { path = "../../crypto/digestible", features = ["dalek", "derive"] }
-ed25519 = { version = "1.0.0-pre.4", default-features = false, features = ["serde"] }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
 hex_fmt = "0.3"
 mc-util-from-random = { path = "../../util/from-random" }
@@ -25,11 +25,11 @@ zeroize = { version = "1", default-features = false }
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
 curve25519-dalek = { version = "3.0", default-features = false, features = ["simd_backend", "nightly"] }
-ed25519-dalek = { version = "1.0.0-pre.4", default-features = false, features = ["alloc", "nightly", "serde", "simd_backend"] }
+ed25519-dalek = { version = "1.0.0", default-features = false, features = ["alloc", "nightly", "serde", "simd_backend"] }
 
 [target.'cfg(not(any(target_feature = "avx2", target_feature = "avx")))'.dependencies]
 curve25519-dalek = { version = "3.0", default-features = false, features = ["nightly", "u64_backend"] }
-ed25519-dalek = { version = "1.0.0-pre.4", default-features = false, features = ["alloc", "nightly", "serde", "u64_backend"] }
+ed25519-dalek = { version = "1.0.0", default-features = false, features = ["alloc", "nightly", "serde", "u64_backend"] }
 
 [dev-dependencies]
 mc-util-serial = { path = "../../util/serial", features = ["std"] }

--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -383,7 +383,7 @@ impl Ed25519Signature {
 impl Digestible for Ed25519Signature {
     #[inline]
     fn digest<D: Digest>(&self, hasher: &mut D) {
-        hasher.input(&self.to_bytes()[..])
+        hasher.update(&self.to_bytes()[..])
     }
 }
 

--- a/crypto/keys/src/x25519.rs
+++ b/crypto/keys/src/x25519.rs
@@ -52,8 +52,8 @@ impl AsRef<[u8]> for X25519Secret {
 impl Debug for X25519Secret {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         let mut hasher = Sha256::new();
-        hasher.input(self.as_ref());
-        let hash_results = hasher.result();
+        hasher.update(self.as_ref());
+        let hash_results = hasher.finalize();
         let mut hash_strbuf: Vec<u8> = Vec::with_capacity(hash_results.len() * 2);
         let hash_len = {
             let hash_strslice =
@@ -177,8 +177,8 @@ impl AsRef<[u8]> for X25519Public {
     /// let key = [0x55u8; 32];
     /// let pubkey = X25519Public::try_from(&key as &[u8]).expect("Could not create key.");
     /// let mut hasher = Sha256::new();
-    /// hasher.input(pubkey);
-    /// let hash = hasher.result();
+    /// hasher.update(pubkey);
+    /// let hash = hasher.finalize();
     /// let expected : [u8; 32] = [
     ///     132, 18, 109, 13, 216, 80, 25, 155, 226, 144, 33, 170, 219, 174, 230, 140,
     ///     185, 25, 144, 71, 177, 203, 126, 201, 137, 77, 219, 30, 53, 98, 120, 60

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 [dependencies]
 mc-util-serial = { path = "../../util/serial", default-features = false }
 
-aes-gcm = { version = "0.3.0" }
+aes-gcm = { version = "0.6.0" }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
-generic-array = { version = "0.12" }
+generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.5", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 subtle = { version = "2.2", default-features = false, features = ["i128"] }

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -9,16 +9,16 @@ mc-crypto-keys = { path = "../../crypto/keys", default-features = false }
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-repr-bytes = { path = "../../util/repr-bytes" }
 
-aes-gcm = "0.3"
-aead = "0.2"
-digest = { version = "0.8", default-features = false }
+aes-gcm = "0.6"
+aead = "0.3"
+digest = { version = "0.9", default-features = false }
 failure = { version = "0.1", default-features = false, features = ["derive"] }
-generic-array = { version = "0.12", features = ["serde"] }
-hkdf = "0.8.0"
+generic-array = { version = "0.14", default-features = false, features = ["serde"] }
+hkdf = "0.9.0"
 rand_core = "0.5"
 secrecy = "0.4"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-sha2 = { version = "0.8", default-features = false }
+sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2.2", default-features = false, features = ["i128"] }
 zeroize = "0.10"
 

--- a/crypto/noise/src/cipher_state.rs
+++ b/crypto/noise/src/cipher_state.rs
@@ -55,7 +55,7 @@ pub trait NoiseCipher: AeadMut + NewAead + Sized {
             },
         )?);
         let keyslice = key.expose_secret().as_slice();
-        Ok(Self::new(GenericArray::clone_from_slice(
+        Ok(Self::new(&GenericArray::clone_from_slice(
             &keyslice[..Self::KeySize::to_usize()],
         )))
     }
@@ -135,7 +135,7 @@ impl<Cipher: AeadMut + NewAead + Sized + NoiseCipher> CipherState<Cipher> {
                 if key_slice.len() != Cipher::KeySize::to_usize() {
                     return Err(CipherError::KeyLength);
                 }
-                self.cipher = Some(Cipher::new(GenericArray::clone_from_slice(key_slice)));
+                self.cipher = Some(Cipher::new(&GenericArray::clone_from_slice(key_slice)));
             }
             None => {
                 self.cipher = None;

--- a/crypto/noise/src/handshake_state.rs
+++ b/crypto/noise/src/handshake_state.rs
@@ -11,7 +11,7 @@ use crate::{
 use aead::{AeadMut, NewAead};
 use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};
-use digest::{BlockInput, Digest, FixedOutput, Input, Reset};
+use digest::{BlockInput, Digest, FixedOutput, Reset, Update};
 use failure::Fail;
 use generic_array::typenum::Unsigned;
 use mc_crypto_keys::{Kex, KexReusablePrivate, ReprBytes};
@@ -102,7 +102,7 @@ pub struct HandshakeOutput<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset,
 {
     /// The payload is the read plaintext or written ciphertext
     pub payload: Vec<u8>,
@@ -116,7 +116,7 @@ pub enum HandshakeStatus<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset,
 {
     InProgress(HandshakeState<KexAlgo, Cipher, DigestType>),
     Complete(SymmetricOutput<Cipher, KexAlgo::Public>),
@@ -129,7 +129,7 @@ pub struct HandshakeState<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset,
 {
     /// Whether this state machine is an initiator (true) or a responder (false)
     is_initiator: bool,
@@ -161,7 +161,7 @@ impl<KexAlgo, Cipher, DigestType> HandshakeState<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + Digest + FixedOutput + Update + Reset,
 {
     /// Static method, dispatched from new(), used to perform step 4 of
     /// `HandshakeState::Initialize()`.

--- a/crypto/noise/src/protocol_name.rs
+++ b/crypto/noise/src/protocol_name.rs
@@ -6,7 +6,7 @@ use crate::patterns::{HandshakeIX, HandshakeNX, HandshakePattern};
 use aead::AeadMut;
 use aes_gcm::Aes256Gcm;
 use core::marker::PhantomData;
-use digest::{FixedOutput, Input};
+use digest::{FixedOutput, Update};
 use failure::Fail;
 use mc_crypto_keys::{Kex, X25519};
 use serde::{Deserialize, Serialize};
@@ -33,7 +33,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut,
-    DigestType: Default + Input + FixedOutput,
+    DigestType: Default + Update + FixedOutput,
 {
     _pattern: PhantomData<fn() -> Handshake>,
     _kex: PhantomData<fn() -> KexAlgo>,
@@ -47,7 +47,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut,
-    DigestType: Default + Input + FixedOutput,
+    DigestType: Default + Update + FixedOutput,
 {
     fn clone(&self) -> Self {
         Self {
@@ -65,7 +65,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut,
-    DigestType: Default + Input + FixedOutput,
+    DigestType: Default + Update + FixedOutput,
 {
     fn default() -> Self {
         Self {

--- a/crypto/noise/src/symmetric_state.rs
+++ b/crypto/noise/src/symmetric_state.rs
@@ -13,7 +13,7 @@ use crate::{
 use aead::{AeadMut, NewAead};
 use alloc::vec::Vec;
 use core::{convert::TryInto, marker::PhantomData};
-use digest::{BlockInput, FixedOutput, Input, Reset};
+use digest::{BlockInput, FixedOutput, Reset, Update};
 use failure::Fail;
 use generic_array::typenum::Unsigned;
 use hkdf::{Hkdf, InvalidLength};
@@ -48,7 +48,7 @@ pub struct SymmetricState<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     hash: HandshakeHash<DigestType>,
     chaining_key: SecretVec<u8>,
@@ -63,7 +63,7 @@ where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
     ProtocolName<Handshake, KexAlgo, Cipher, DigestType>: AsRef<str>,
 {
     /// The noise protocol `InitializeSymmetric()` operation.
@@ -88,7 +88,7 @@ impl<KexAlgo, Cipher, DigestType> SymmetricState<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     /// Retrieve the expected size (in bytes) of a public key to read.
     ///
@@ -279,7 +279,7 @@ impl<KexAlgo, Cipher, DigestType> TryInto<SymmetricOutput<Cipher, KexAlgo::Publi
 where
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
-    DigestType: BlockInput + Clone + Default + FixedOutput + Input + Reset,
+    DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
     type Error = SymmetricError;
 

--- a/crypto/sig/Cargo.toml
+++ b/crypto/sig/Cargo.toml
@@ -12,8 +12,8 @@ merlin = { version = "2.0", default-features = false }
 rand_core = { version = "0.5", default-features = false }
 rand_hc = "0.2"
 
-# Overridden since we needed to update a bunch of its dependencies
-schnorrkel = { git = "https://github.com/eranrund/schnorrkel", rev= "9fe3a3c840f3eaa348f55428c40f150bf09aa608", default-features = false }
+# Overridden since we need a not-yet-released commit that uprevs a bunch of dependencies.
+schnorrkel = { git = "https://github.com/w3f/schnorrkel", rev = "cfdbe9ae865a4d3ffa2566d896d4dbedf5107028", default-features = false }
 
 [dev-dependencies]
 mc-util-from-random = { path = "../../util/from-random" }

--- a/crypto/sig/Cargo.toml
+++ b/crypto/sig/Cargo.toml
@@ -11,7 +11,9 @@ mc-crypto-keys = { path = "../keys", default-features = false }
 merlin = { version = "2.0", default-features = false }
 rand_core = { version = "0.5", default-features = false }
 rand_hc = "0.2"
-schnorrkel = { version = "0.9", default-features = false }
+
+# Overridden since we needed to update a bunch of its dependencies
+schnorrkel = { git = "https://github.com/eranrund/schnorrkel", rev= "9fe3a3c840f3eaa348f55428c40f150bf09aa608", default-features = false }
 
 [dev-dependencies]
 mc-util-from-random = { path = "../../util/from-random" }

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -29,10 +29,10 @@ rand_core = "0.5"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["simd_backend", "nightly"] }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["simd_backend", "nightly"] }
 
 [target.'cfg(not(any(target_feature = "avx2", target_feature = "avx")))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["nightly", "u64_backend"] }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["nightly", "u64_backend"] }
 
 [dev-dependencies]
 mc-crypto-keys = { path = "../../crypto/keys" }

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -48,7 +48,7 @@ rand = "0.7"
 rand_core = "0.5"
 retry = "0.5.1"
 serde_json = "1.0"
-sha3 = "0.8.0"
+sha3 = "0.9"
 structopt = "0.3"
 tempdir = "0.3"
 

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -29,7 +29,7 @@ failure = "0.1.5"
 grpcio = "0.6.0"
 protobuf = "2.12"
 retry = "0.5"
-sha2 = { version = "0.8", default-features = false }
+sha2 = { version = "0.9", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 url = "2.1"
 

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -24,7 +24,7 @@ mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }
 
 crossbeam-channel = "0.3"
-ed25519 = { version = "1.0.0-pre.1", default-features = false, features = ["serde"] }
+ed25519 = { version = "1.0.1", default-features = false, features = ["serde"] }
 failure = "0.1.5"
 grpcio = "0.6.0"
 protobuf = "2.12"

--- a/peers/src/consensus_msg.rs
+++ b/peers/src/consensus_msg.rs
@@ -130,7 +130,7 @@ impl ConsensusMsg {
         let mut contents_hasher = Sha256::new();
         scp_msg.digest(&mut contents_hasher);
         prev_block.id.digest(&mut contents_hasher);
-        let contents_hash = contents_hasher.result();
+        let contents_hash = contents_hasher.finalize();
 
         let signature = signer_key.try_sign(&contents_hash)?;
 
@@ -155,7 +155,7 @@ impl ConsensusMsg {
         let mut contents_hasher = Sha256::new();
         self.scp_msg.digest(&mut contents_hasher);
         self.prev_block_id.digest(&mut contents_hasher);
-        let contents_hash = contents_hasher.result();
+        let contents_hash = contents_hasher.finalize();
 
         Ok(self
             .scp_msg

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -22,7 +22,7 @@ hex = "0.4"
 rand = "0.7"
 rand_hc = "0.2"
 retry = "0.5"
-sha2 = { version = "0.8", features = ["asm"] }
+sha2 = { version = "0.9", features = ["asm"] }
 
 [dev-dependencies]
 mc-common = { path = "../../common", features = ["loggers"] }

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
-sha2 = { version = "0.8", default-features = false }
+sha2 = { version = "0.9", default-features = false }

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -14,16 +14,16 @@ test-net-fee-keys = []
 [dependencies]
 # External dependencies
 cfg-if = "0.1"
-digest = { version = "0.8.1", default-features = false }
+digest = { version = "0.9", default-features = false }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
-generic-array = { version = "0.12", features = ["serde"] }
+generic-array = { version = "0.14", features = ["serde"] }
 hex_fmt = "0.3"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 merlin = { version = "2.0", default-features = false }
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.5", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-sha2 = { version = "0.8", default-features = false }
+sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2.2", default-features = false, features = ["i128"] }
 zeroize = { version = "1", default-features = false }
 
@@ -46,12 +46,12 @@ bulletproofs = {version = "2.0", default-features = false, features = ["avx2_bac
 bulletproofs = {version = "2.0", default-features = false}
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["simd_backend", "nightly"] }
-blake2 = { version = "0.8.1", default-features = false, features = ["simd"] }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["simd_backend", "nightly"] }
+blake2 = { version = "0.9", default-features = false, features = ["simd"] }
 
 [target.'cfg(not(any(target_feature = "avx2", target_feature = "avx")))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["nightly", "u64_backend"] }
-blake2 = { version = "0.8.1", default-features = false }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["nightly", "u64_backend"] }
+blake2 = { version = "0.9", default-features = false }
 
 [dev-dependencies]
 rand = "0.7"

--- a/transaction/core/src/amount.rs
+++ b/transaction/core/src/amount.rs
@@ -113,8 +113,8 @@ impl Amount {
 /// * `shared_secret` - The shared secret, e.g. `rB`.
 fn get_value_mask(shared_secret: &RistrettoPublic) -> Scalar {
     let mut hasher = Blake2b::new();
-    hasher.input(&AMOUNT_VALUE_DOMAIN_TAG);
-    hasher.input(&shared_secret.to_bytes());
+    hasher.update(&AMOUNT_VALUE_DOMAIN_TAG);
+    hasher.update(&shared_secret.to_bytes());
     Scalar::from_hash(hasher)
 }
 
@@ -124,8 +124,8 @@ fn get_value_mask(shared_secret: &RistrettoPublic) -> Scalar {
 /// * `shared_secret` - The shared secret, e.g. `rB`.
 fn get_blinding(shared_secret: &RistrettoPublic) -> Scalar {
     let mut hasher = Blake2b::new();
-    hasher.input(&AMOUNT_BLINDING_DOMAIN_TAG);
-    hasher.input(&shared_secret.to_bytes());
+    hasher.update(&AMOUNT_BLINDING_DOMAIN_TAG);
+    hasher.update(&shared_secret.to_bytes());
     Scalar::from_hash(hasher)
 }
 

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -186,7 +186,7 @@ pub fn compute_block_id<D: Digest>(
     root_element.digest(&mut hasher);
     contents_hash.digest(&mut hasher);
 
-    BlockID(hasher.result())
+    BlockID(hasher.finalize())
 }
 
 #[cfg(test)]

--- a/transaction/core/src/blockchain/block_contents.rs
+++ b/transaction/core/src/blockchain/block_contents.rs
@@ -46,7 +46,7 @@ pub struct BlockContentsHash<D: Digest = Blake2b256>(pub GenericArray<u8, D::Out
 
 impl<D: Digest> Digestible for BlockContentsHash<D> {
     fn digest<DD: Digest>(&self, hasher: &mut DD) {
-        hasher.input(&self.0)
+        hasher.update(&self.0)
     }
 }
 

--- a/transaction/core/src/blockchain/block_id.rs
+++ b/transaction/core/src/blockchain/block_id.rs
@@ -24,7 +24,7 @@ pub struct BlockID<D: Digest = Blake2b256>(pub GenericArray<u8, D::OutputSize>);
 
 impl<D: Digest> Digestible for BlockID<D> {
     fn digest<DD: Digest>(&self, hasher: &mut DD) {
-        hasher.input(&self.0)
+        hasher.update(&self.0)
     }
 }
 

--- a/transaction/core/src/membership_proofs/mod.rs
+++ b/transaction/core/src/membership_proofs/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     tx::{TxOut, TxOutMembershipHash, TxOutMembershipProof},
 };
 use alloc::vec::Vec;
-use blake2::digest::Input;
+use blake2::digest::Update;
 use core::convert::TryInto;
 pub use errors::Error as MembershipProofError;
 use mc_common::HashMap;
@@ -29,7 +29,7 @@ lazy_static! {
 /// Merkle tree hash function for a leaf node.
 pub fn hash_leaf(tx_out: &TxOut) -> [u8; 32] {
     let mut hasher = Blake2b256::new();
-    hasher.input(&TXOUT_MERKLE_LEAF_DOMAIN_TAG);
+    hasher.update(&TXOUT_MERKLE_LEAF_DOMAIN_TAG);
     tx_out.digest(&mut hasher);
     hasher.result().try_into().unwrap()
 }
@@ -37,16 +37,16 @@ pub fn hash_leaf(tx_out: &TxOut) -> [u8; 32] {
 /// Merkle tree hash function for an internal node.
 pub fn hash_nodes(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
     let mut hasher = Blake2b256::new();
-    hasher.input(&TXOUT_MERKLE_NODE_DOMAIN_TAG);
-    hasher.input(left);
-    hasher.input(right);
+    hasher.update(&TXOUT_MERKLE_NODE_DOMAIN_TAG);
+    hasher.update(left);
+    hasher.update(right);
     hasher.result().try_into().unwrap()
 }
 
 /// Merkle tree Hash function for hashing a "nil" value.
 fn hash_nil() -> [u8; 32] {
     let mut hasher = Blake2b256::new();
-    hasher.input(&TXOUT_MERKLE_NIL_DOMAIN_TAG);
+    hasher.update(&TXOUT_MERKLE_NIL_DOMAIN_TAG);
     hasher.result().try_into().unwrap()
 }
 

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -22,16 +22,16 @@ const G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
 /// Applies a hash function and returns a RistrettoPoint.
 pub fn hash_to_point(ristretto_public: &RistrettoPublic) -> RistrettoPoint {
     let mut hasher = Blake2b::new();
-    hasher.input(&HASH_TO_POINT_DOMAIN_TAG);
-    hasher.input(&ristretto_public.to_bytes());
+    hasher.update(&HASH_TO_POINT_DOMAIN_TAG);
+    hasher.update(&ristretto_public.to_bytes());
     RistrettoPoint::from_hash(hasher)
 }
 
 /// Applies a hash function and returns a Scalar.
 pub fn hash_to_scalar<B: AsRef<[u8]>>(data: B) -> Scalar {
     let mut hasher = Blake2b::new();
-    hasher.input(&HASH_TO_SCALAR_DOMAIN_TAG);
-    hasher.input(data);
+    hasher.update(&HASH_TO_SCALAR_DOMAIN_TAG);
+    hasher.update(data);
     Scalar::from_hash::<Blake2b>(hasher)
 }
 

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -176,12 +176,12 @@ impl RingMLSAG {
 
             c[(i + 1) % ring_size] = {
                 let mut hasher = Blake2b::new();
-                hasher.input(&RING_MLSAG_CHALLENGE_DOMAIN_TAG);
-                hasher.input(message);
-                hasher.input(&key_image);
-                hasher.input(L0.compress().as_bytes());
-                hasher.input(R0.compress().as_bytes());
-                hasher.input(L1.compress().as_bytes());
+                hasher.update(&RING_MLSAG_CHALLENGE_DOMAIN_TAG);
+                hasher.update(message);
+                hasher.update(&key_image);
+                hasher.update(L0.compress().as_bytes());
+                hasher.update(R0.compress().as_bytes());
+                hasher.update(L1.compress().as_bytes());
                 Scalar::from_hash::<Blake2b>(hasher)
             };
         }
@@ -290,12 +290,12 @@ impl RingMLSAG {
 
             recomputed_c[(i + 1) % ring_size] = {
                 let mut hasher = Blake2b::new();
-                hasher.input(&RING_MLSAG_CHALLENGE_DOMAIN_TAG);
-                hasher.input(message);
-                hasher.input(&self.key_image);
-                hasher.input(L0.compress().as_bytes());
-                hasher.input(R0.compress().as_bytes());
-                hasher.input(L1.compress().as_bytes());
+                hasher.update(&RING_MLSAG_CHALLENGE_DOMAIN_TAG);
+                hasher.update(message);
+                hasher.update(&self.key_image);
+                hasher.update(L0.compress().as_bytes());
+                hasher.update(R0.compress().as_bytes());
+                hasher.update(L1.compress().as_bytes());
                 Scalar::from_hash::<Blake2b>(hasher)
             };
         }

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use alloc::vec::Vec;
-use blake2::digest::Input;
+use blake2::digest::Update;
 use core::{
     convert::{TryFrom, TryInto},
     fmt,
@@ -444,8 +444,8 @@ impl core::convert::From<[u8; 32]> for TxOutConfirmationNumber {
 impl core::convert::From<&RistrettoPublic> for TxOutConfirmationNumber {
     fn from(shared_secret: &RistrettoPublic) -> Self {
         let mut hasher = Blake2b256::new();
-        hasher.input(&TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG);
-        hasher.input(shared_secret.to_bytes());
+        hasher.update(&TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG);
+        hasher.update(shared_secret.to_bytes());
 
         let result: [u8; 32] = hasher.result().into();
         Self(result)

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -10,8 +10,7 @@ failure = "0.1.5"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand = { version = "0.7", default-features = false }
 rand_core = { version = "0.5", default-features = false }
-blake2 = { version = "0.8.1", default-features = false, features = ["simd"] }
-hkdf = { version = "0.8.0", default-features = false }
+hkdf = { version = "0.9.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 zeroize = "1"
 
@@ -25,12 +24,12 @@ mc-transaction-core = { path = "../../transaction/core"}
 mc-util-from-random = { path = "../../util/from-random" }
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["simd_backend", "nightly"] }
-blake2 = { version = "0.8.1", default-features = false, features = ["simd"] }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["simd_backend", "nightly"] }
+blake2 = { version = "0.9", default-features = false, features = ["simd"] }
 
 [target.'cfg(not(any(target_feature = "avx2", target_feature = "avx")))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["nightly", "u64_backend"] }
-blake2 = { version = "0.8.1", default-features = false }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["nightly", "u64_backend"] }
+blake2 = { version = "0.9", default-features = false }
 
 [dev-dependencies]
 yaml-rust = "0.4"

--- a/util/generate-sample-ledger/Cargo.toml
+++ b/util/generate-sample-ledger/Cargo.toml
@@ -24,10 +24,10 @@ rayon = "1.1"
 structopt = "0.3"
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["simd_backend", "nightly"] }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["simd_backend", "nightly"] }
 
 [target.'cfg(not(any(target_feature = "avx2", target_feature = "avx")))'.dependencies]
-curve25519-dalek = { version = "2.0", default-features = false, features = ["nightly", "u64_backend"] }
+curve25519-dalek = { version = "3.0", default-features = false, features = ["nightly", "u64_backend"] }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-generic-array = { version = "0.12", default-features = false, features = ["serde"] }
+generic-array = "0.14"
 prost = { version = "0.6.1", optional = true, default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -11,7 +11,7 @@ mc-crypto-keys = { path = "../../crypto/keys" }
 
 base64 = "0.11"
 displaydoc = { version = "0.1.7", default-features = false }
-ed25519 = { version = "1.0.0-pre.1", default-features = false, features = ["serde"] }
+ed25519 = { version = "1.0.1", default-features = false, features = ["serde"] }
 hex = "0.4"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 url = "2.1"


### PR DESCRIPTION
### Motivation

As ToB pointed out, some of our dependencies are not up to date. This is the first take at upreving a bunch of our deps, focusing on RustCrypto-related ones.

### In this PR
* Upreving of a bunch of deps

### Future Work
* Unfortunately, for this to work, I had to fork `schnorrkel` (https://github.com/eranrund/schnorrkel/commit/9fe3a3c840f3eaa348f55428c40f150bf09aa608), `ed25519-dalek` (https://github.com/eranrund/ed25519-dalek/commit/ffb1db5edf1fcb5aaebfb3a54dbba98072dbafbb) and `bulletproofs` (https://github.com/eranrund/bulletproofs/commit/e8e8ef45ecc6d31f1a9525140edc977351d0f780). These uprevs may or may not be tricky to get in:
   - `schnorrkel` depends on `ed25519-dalek`, so until that goes in there's no chance.
   - `ed25519-dalek` is pretty unobtrusive but it does require a new major version due to moving to a newer `curve25519-dalek` which updated its major version (`Update the digest dependency to 0.9. This requires a major version because the digest traits are part of the public API, but there are otherwise no changes to the API.`)
  - `bulletproofs` - This one required a newer rust toolchain, so I am not sure how they're going to feel about that. I need to see why that was needed.


----

I'm putting this draft here to see what people think. I still need to see it successfully deployed, but I'm getting closer to achieving that.


