### PR TITLE
MC-1814 Enclave target features inheritance. #in-review

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -8,7 +8,7 @@ rustflags = ["-D", "warnings"]
 # ...so instead we list all target triples (Tier 1 64-bit platforms)
 
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake", "-C", "target-feature=+sha"]
+rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]
 
 [target.x86_64-pc-windows-gnu]
 rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]

--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -71,11 +71,6 @@ fn main() {
 
     builder
         .target_dir(env.target_dir().join(CONSENSUS_ENCLAVE_NAME).as_path())
-        .add_rust_flags(&["-D", "warnings"])
-        .add_rust_flags(&["-C", "target-cpu=skylake"])
-        .add_rust_flags(&["-C", "target-feature=+sha"]);
-
-    builder
         .config_builder
         .debug(
             sgx.sgx_mode() == SgxMode::Simulation


### PR DESCRIPTION
### Motivation

SHA2 instructions are not available on the platforms we currently have Kubernetes running, and there's no way to remove that other than by hard-code changes. This removes most of the hard-coding (it does keep LVI mitigations), and simply copies target features enabled for the untrusted build into the enclave build.

### In this PR
* Remove SHA target feature where it exists (not supported on our platform yet)
* Copy target features from untrusted into enclave build's RUSTFLAGS.
* Remove explicit skylake from individual enclave build.

