### PR TITLE
[MC-1784] Subtraction underflow in Range::len

### DIFF
--- a/transaction/core/src/membership_proofs/mod.rs
+++ b/transaction/core/src/membership_proofs/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         TXOUT_MERKLE_LEAF_DOMAIN_TAG, TXOUT_MERKLE_NIL_DOMAIN_TAG, TXOUT_MERKLE_NODE_DOMAIN_TAG,
     },
     membership_proofs::errors::Error,
-    range::Range,
+    range::{Range, RangeError},
     tx::{TxOut, TxOutMembershipHash, TxOutMembershipProof},
 };
 use alloc::vec::Vec;
@@ -67,6 +67,11 @@ pub fn is_membership_proof_valid(
 ) -> Result<bool, Error> {
     if proof.index > proof.highest_index {
         return Ok(false);
+    }
+    // All Ranges contained in the proof must be valid. An invalid Range could be created
+    // by deserializing invalid bytes.
+    if proof.elements.iter().any(|e| e.range.from > e.range.to) {
+        return Err(Error::RangeError(RangeError {}));
     }
 
     // * The proof must contain the correct leaf hash for the specified index.

--- a/transaction/core/src/range.rs
+++ b/transaction/core/src/range.rs
@@ -29,17 +29,21 @@ impl Range {
 
     /// The number of indices in this Range.
     pub fn len(&self) -> u64 {
-        self.to - self.from + 1
+        if self.from <= self.to {
+            self.to - self.from + 1
+        } else {
+            self.from - self.to + 1
+        }
     }
 }
 
-/// Ranges are ordered by `len`. If two ranges have equal `len`, they are ordered by `from`.
+/// Ranges are ordered by `len`, then lexicographically by (from,to).
 impl Ord for Range {
     fn cmp(&self, other: &Range) -> Ordering {
         if self.len() != other.len() {
             self.len().cmp(&other.len())
         } else {
-            self.from.cmp(&other.from)
+            (self.from, self.to).cmp(&(other.from, other.to))
         }
     }
 }
@@ -53,7 +57,32 @@ impl PartialOrd for Range {
 #[cfg(test)]
 mod range_tests {
     use super::Range;
-    use alloc::vec::Vec;
+
+    #[test]
+    // `len` should return the number of indices in a range.
+    fn test_len() {
+        assert_eq!(Range::new(0, 0).unwrap().len(), 1);
+        assert_eq!(Range::new(0, 7).unwrap().len(), 8);
+        assert_eq!(Range::new(7, 7).unwrap().len(), 1);
+        assert_eq!(Range::new(7, 8).unwrap().len(), 2);
+        assert_eq!(Range::new(10233, 888374662).unwrap().len(), 888364430);
+    }
+
+    #[test]
+    // `len` should return the number of indices in a "negative" range where from > to.
+    fn test_len_negative_range() {
+        // A "negative" range is possible by bypassing the constructor, e.g. when deserializing.
+        assert_eq!(Range { from: 7, to: 0 }.len(), 8);
+        assert_eq!(Range { from: 44, to: 6 }.len(), 39);
+        assert_eq!(
+            Range {
+                from: 888374662,
+                to: 10233
+            }
+            .len(),
+            888364430
+        );
+    }
 
     #[test]
     // `new` should return an Error if `from > to`.
@@ -63,25 +92,67 @@ mod range_tests {
 
     #[test]
     fn test_ord() {
-        let mut ranges: Vec<Range> = Vec::new();
-        ranges.push(Range::new(2, 2).unwrap());
-        ranges.push(Range::new(1, 1).unwrap());
-        ranges.push(Range::new(8, 9).unwrap());
-        ranges.push(Range::new(0, 1).unwrap());
-        ranges.push(Range::new(0, 0).unwrap());
-        ranges.push(Range::new(0, 2).unwrap());
+        let mut ranges = vec![
+            Range::new(2, 2).unwrap(),
+            Range::new(1, 1).unwrap(),
+            Range::new(8, 9).unwrap(),
+            Range::new(0, 1).unwrap(),
+            Range::new(0, 0).unwrap(),
+            Range::new(0, 2).unwrap(),
+        ];
 
         // [0,0] < [1,1] < [2,2] < [0,1] < ... < [8,9] < [0,2] ...
         ranges.sort();
 
-        // Ranges of `len` 1
-        assert_eq!(Range::new(0, 0).unwrap(), *ranges.get(0).unwrap());
-        assert_eq!(Range::new(1, 1).unwrap(), *ranges.get(1).unwrap());
-        assert_eq!(Range::new(2, 2).unwrap(), *ranges.get(2).unwrap());
-        // Ranges of `len` 2
-        assert_eq!(Range::new(0, 1).unwrap(), *ranges.get(3).unwrap());
-        assert_eq!(Range::new(8, 9).unwrap(), *ranges.get(4).unwrap());
-        // Ranges of `len` 3
-        assert_eq!(Range::new(0, 2).unwrap(), *ranges.get(5).unwrap());
+        let expected_ordering = vec![
+            // Ranges of `len` 1
+            Range::new(0, 0).unwrap(),
+            Range::new(1, 1).unwrap(),
+            Range::new(2, 2).unwrap(),
+            // Ranges of `len` 2
+            Range::new(0, 1).unwrap(),
+            Range::new(8, 9).unwrap(),
+            // Ranges of `len` 3
+            Range::new(0, 2).unwrap(),
+        ];
+
+        assert_eq!(ranges, expected_ordering);
+    }
+
+    #[test]
+    // `ord` should correctly order ranges when from > to.
+    fn test_ord_with_negative_ranges() {
+        let mut ranges = vec![
+            Range { from: 11, to: 13 },
+            Range { from: 7, to: 0 }, // from > to
+            Range { from: 0, to: 0 },
+            Range { from: 11, to: 9 },  // from > to
+            Range { from: 13, to: 11 }, // from > to
+            Range { from: 13, to: 22 },
+            Range { from: 5, to: 5 },
+            Range { from: 9, to: 11 },
+            Range { from: 11, to: 22 },
+        ];
+
+        ranges.sort();
+
+        let expected_ordering = vec![
+            // Ranges of `len` 1
+            Range { from: 0, to: 0 },
+            Range { from: 5, to: 5 },
+            // Ranges of `len` 3
+            Range { from: 9, to: 11 },
+            Range { from: 11, to: 9 },
+            Range { from: 11, to: 13 },
+            Range { from: 13, to: 11 },
+            // Ranges of `len` 8
+            Range { from: 7, to: 0 },
+            // Ranges of `len` 10
+            Range { from: 13, to: 22 },
+            // Ranges of `len` 12
+            Range { from: 11, to: 22 },
+        ];
+
+        assert_eq!(ranges, expected_ordering);
     }
 }

--- a/transaction/core/src/range.rs
+++ b/transaction/core/src/range.rs
@@ -38,6 +38,13 @@ impl Range {
 }
 
 /// Ranges are ordered by `len`, then lexicographically by (from,to).
+///
+/// This is a total ordering of (u64, u64) tuples. Additionally, when a node of a binary tree
+/// (i.e. Merkle tree) is identified with the range of indices below that node, the len of a
+/// range is equal to 2^h, where h is the height of the node in the tree. This means that traversing
+/// a list of ranges sorted in ascending order corresponds to a bottom-up traversal of the tree
+/// (which is handy for computing Merkle hashes). Ordering ranges of equal len lexicographically
+/// makes it a bottom-up and left-to-right traversal of the tree.
 impl Ord for Range {
     fn cmp(&self, other: &Range) -> Ordering {
         if self.len() != other.len() {

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -262,6 +262,7 @@ fn validate_membership_proofs(
     }
 
     // Each root proof must contain valid ranges.
+    // (Ranges in the transaction's membership proofs are checked in `is_membership_proof_valid`).
     for root_proof in root_proofs {
         if root_proof
             .elements

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -261,6 +261,17 @@ fn validate_membership_proofs(
         return Err(TransactionValidationError::InvalidLedgerContext);
     }
 
+    // Each root proof must contain valid ranges.
+    for root_proof in root_proofs {
+        if root_proof
+            .elements
+            .iter()
+            .any(|element| element.range.from > element.range.to)
+        {
+            return Err(TransactionValidationError::MembershipProofValidationError);
+        }
+    }
+
     struct TxOutWithProofs<'a> {
         /// A TxOut used as an input ring element.
         tx_out: &'a TxOut,
@@ -367,7 +378,7 @@ mod tests {
         },
     };
 
-    use crate::validation::validate::validate_ring_elements_are_sorted;
+    use crate::{range::Range, validation::validate::validate_ring_elements_are_sorted};
     use mc_crypto_keys::{CompressedRistrettoPublic, ReprBytes};
     use mc_ledger_db::{Ledger, LedgerDB};
     use mc_transaction_core_test_utils::{
@@ -472,6 +483,56 @@ mod tests {
             );
             assert_eq!(validate_membership_proofs(&tx.prefix, &root_proofs), Ok(()));
         }
+    }
+
+    #[test]
+    // Should return InvalidRangeProof if a membership proof containing an invalid Range.
+    fn test_validate_membership_proofs_invalid_range_in_tx() {
+        let (mut tx, ledger) = create_test_tx();
+
+        let highest_indices = tx.get_membership_proof_highest_indices();
+        let root_proofs: Vec<TxOutMembershipProof> = adapt_hack(
+            &ledger
+                .get_tx_out_proof_of_memberships(&highest_indices)
+                .expect("failed getting proofs"),
+        );
+
+        // Modify tx to include an invalid Range.
+        let mut proof = tx.prefix.inputs[0].proofs[0].clone();
+        let mut first_element = proof.elements[0].clone();
+        first_element.range = Range { from: 7, to: 3 };
+        proof.elements[0] = first_element;
+        tx.prefix.inputs[0].proofs[0] = proof;
+
+        assert_eq!(
+            validate_membership_proofs(&tx.prefix, &root_proofs),
+            Err(TransactionValidationError::MembershipProofValidationError)
+        );
+    }
+
+    #[test]
+    // Should return InvalidRangeProof if a root proof containing an invalid Range.
+    fn test_validate_membership_proofs_invalid_range_in_root_proof() {
+        let (tx, ledger) = create_test_tx();
+
+        let highest_indices = tx.get_membership_proof_highest_indices();
+        let mut root_proofs: Vec<TxOutMembershipProof> = adapt_hack(
+            &ledger
+                .get_tx_out_proof_of_memberships(&highest_indices)
+                .expect("failed getting proofs"),
+        );
+
+        // Modify a root proof to include an invalid Range.
+        let mut proof = root_proofs[0].clone();
+        let mut first_element = proof.elements[0].clone();
+        first_element.range = Range { from: 7, to: 3 };
+        proof.elements[0] = first_element;
+        root_proofs[0] = proof;
+
+        assert_eq!(
+            validate_membership_proofs(&tx.prefix, &root_proofs),
+            Err(TransactionValidationError::MembershipProofValidationError)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Soundtrack of this PR: [Numbers](https://www.youtube.com/watch?v=4YPiCeLwh5o)

### Motivation

Merkle proofs use a Range data structure to define a range [a,b] of indices, where the length or the range is b - a + 1. If a > b, this can cause a subtraction underflow.

### In this PR
* Changes Range's `len` and `ord` to allow ranges [a,b] where a > b.
* Adds checks in validation that reject a Merkle proof if it contains a range [a,b] where a > b.