### PR TITLE
Detailed missing tx hashes error

### DIFF
--- a/consensus/api/proto/consensus_peer.proto
+++ b/consensus/api/proto/consensus_peer.proto
@@ -23,7 +23,7 @@ service ConsensusPeerAPI {
 
     /// Fetch transaction contents from a list of Tx Hashes.
     /// The hashes are sent in the AAD data.
-    rpc FetchTxs(FetchTxsRequest) returns (attest.Message);
+    rpc FetchTxs(FetchTxsRequest) returns (FetchTxsResponse);
 }
 
 message ConsensusMsg {
@@ -58,4 +58,18 @@ message FetchTxsRequest {
 
     /// List of tx hashes to fetch.
     repeated bytes tx_hashes = 2;
+}
+
+/// Response from a FetchTxs call.
+message FetchTxsResponse { oneof payload {
+    /// Call succeeded, encrypted Tx data was returned.
+    attest.Message success = 1;
+
+    /// Failed due to tx hashes not in cache.
+    /// (protobuf prohibits using the `repeated` marker inside `oneof`)
+    TxHashesNotInCache tx_hashes_not_in_cache = 2;
+} }
+
+message TxHashesNotInCache {
+    repeated bytes tx_hashes = 1;
 }

--- a/peers/src/error.rs
+++ b/peers/src/error.rs
@@ -8,6 +8,7 @@ use grpcio::Error as GrpcError;
 use mc_connection::AttestationError;
 use mc_consensus_api::ConversionError;
 use mc_consensus_enclave_api::Error as EnclaveError;
+use mc_transaction_core::tx::TxHash;
 use mc_util_serial::{
     decode::Error as RmpDecodeError, encode::Error as RmpEncodeError,
     DecodeError as ProstDecodeError, EncodeError as ProstEncodeError,
@@ -54,6 +55,9 @@ pub enum Error {
     /// Consensus message error.
     #[fail(display = "Conensus message: {}", _0)]
     ConsensusMsg(ConsensusMsgError),
+    /// Tx hashes not in cache.
+    #[fail(display = "Tx hashes not in cache: {:?}", _0)]
+    TxHashesNotInCache(Vec<TxHash>),
     /// Some other error.
     #[fail(display = "Unknown peering issue")]
     Other,


### PR DESCRIPTION
### Motivation

@mfaulk and me discovered a bug in which a node would repeatedly try to resolve missing tx hashes from a peer, even if the peer does not have them in its cache. Each attempt takes about 15 seconds due to unnecessary retries, and this happens for each SCP message that refers to the missing hashes.
A scenario in which hashes would be missing is if a peer restarted mid-slot. The local node would have a bunch of queued up SCP messages from before the peer restarted, and when it gets to processing them it will repeatedly attempt to `FetchTxs` from this peer, even though it will never succeed. This effectively results in the node falling back for a long duration of time.

Ideally, the code that fetches txs should be able to learn which hashes are futile and stop trying them, ignoring the SCP messages that refer to them. Doing so is currently difficult due to `FetchTxs` not returning a structured error response.

### In this PR
* Change the `FetchTxs` GRPC API to support returning structured error data. Specifically, the new error type presented here allows it to report the list of hashes that are no longer available.

### Future Work
* The code in `ByzantineLedger` needs to be adapted to leverage this new error such that it does not attempt to fetch hashes that are not found in the peer's cache more than once.
