### PR TITLE
Redo change to make Amount proto object have a fixed size

### DIFF
--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -173,7 +173,7 @@ message Amount {
     CompressedRistretto commitment = 1;
 
     // `masked_value = value XOR_8 Blake2B("value_mask" || shared_secret)`
-    uint64 masked_value = 2;
+    fixed64 masked_value = 2;
 }
 
 message EncryptedFogHint {

--- a/transaction/core/src/amount.rs
+++ b/transaction/core/src/amount.rs
@@ -39,7 +39,7 @@ pub struct Amount {
     pub commitment: CompressedCommitment,
 
     /// `masked_value = value XOR_8 Blake2B(value_mask | shared_secret)`
-    #[prost(uint64, required, tag = "2")]
+    #[prost(fixed64, required, tag = "2")]
     pub masked_value: u64,
 }
 


### PR DESCRIPTION
This is needed in some backend services, because serialized TxOut
objects will then have a fixed size, and so we won't leak anything
about them through the size of the buffer representing them.

This is a replay of mobilecoin #333, which was reverted in #336
due to concerns that it would break testnet compatibility unless
we made a way to migrate the ledger. The idea we had was that
we would do it right before launch once we were no longer making
testnet releases.