### PR TITLE
Interpret public addresses as request codes

### DIFF
--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -377,7 +377,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         } else {
             Err(RpcStatus::new(
                 RpcStatusCode::INVALID_ARGUMENT,
-                Some("has_payment_request".to_string()),
+                Some("Neither payment request nor public address".to_string()),
             ))
         }
     }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -366,14 +366,14 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             response.set_receiver(payment_request.get_public_address().clone());
             response.set_value(payment_request.get_value());
             response.set_memo(payment_request.get_memo().to_string());
-            Ok(response)    
+            Ok(response)
         } else if request_wrapper.has_public_address() {
             let public_address = request_wrapper.get_public_address();
             let mut response = mc_mobilecoind_api::ReadRequestCodeResponse::new();
             response.set_receiver(public_address.clone());
             response.set_value(0);
             response.set_memo(String::new());
-            Ok(response)    
+            Ok(response)
         } else {
             Err(RpcStatus::new(
                 RpcStatusCode::INVALID_ARGUMENT,


### PR DESCRIPTION
### Motivation

We'd like clients to be able to enter either a payment request code or a public address. This PR interprets either case and determines the best thing to do.

### In this PR
* Allows `read_request_code` to take a plain public address, which is interpreted as a payment request with no amount and no memo