### PR TITLE
Dont keep trying to fetch unavailable transactions

### DIFF
--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -93,7 +93,7 @@ pub struct ByzantineLedgerWorker<
     // A map of responder id to a list of tx hashes that it is unable to provide. This allows us to
     // skip attemping to fetch txs that are bound to fail. A BTreeSet is used to speed up lookups
     // as expect to be doing more lookups than inserts.
-    missing_tx_hashes: HashMap<ResponderId, BTreeSet<TxHash>>,
+    unavailable_tx_hashes: HashMap<ResponderId, BTreeSet<TxHash>>,
 }
 
 impl<
@@ -154,7 +154,7 @@ impl<
             network_state,
             ledger_sync_service,
             ledger_sync_state: LedgerSyncState::InSync,
-            missing_tx_hashes: HashMap::default(),
+            unavailable_tx_hashes: HashMap::default(),
         };
 
         loop {
@@ -594,7 +594,7 @@ impl<
 
         // Clear the missing tx hashes map. If we encounter the same tx hash again in a different
         // slot, it is possible we might be able to fetch it.
-        self.missing_tx_hashes.clear();
+        self.unavailable_tx_hashes.clear();
     }
 
     fn fetch_missing_txs(
@@ -610,7 +610,7 @@ impl<
             .collect();
 
         // Don't attempt to issue any RPC calls if we know we're going to fail.
-        if let Some(previously_missed_hashes) = self.missing_tx_hashes.get(from_responder_id) {
+        if let Some(previously_missed_hashes) = self.unavailable_tx_hashes.get(from_responder_id) {
             let previously_encountered_missing_hashes = missing_hashes
                 .iter()
                 .any(|tx_hash| previously_missed_hashes.contains(tx_hash));
@@ -672,7 +672,7 @@ impl<
                     ..
                 }) => {
                     let entry = self
-                        .missing_tx_hashes
+                        .unavailable_tx_hashes
                         .entry(from_responder_id.clone())
                         .or_insert_with(BTreeSet::default);
                     entry.extend(tx_hashes);

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -617,7 +617,10 @@ impl<
             if previously_encountered_missing_hashes {
                 log::debug!(
                     self.logger,
-                    "Not attempting to resolve missing tx hashes {:?}: contains tx hashes known to not be available", missing_hashes);
+                    "Not attempting to resolve missing tx hashes {:?} from {}: contains tx hashes known to not be available",
+                    missing_hashes,
+                    from_responder_id,
+                );
                 return false;
             }
         }

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -12,14 +12,18 @@ use mc_common::{
     logger::{log, Logger},
     NodeID, ResponderId,
 };
-use mc_connection::{BlockchainConnection, ConnectionManager, _retry::delay::Fibonacci};
+use mc_connection::{
+    BlockchainConnection, ConnectionManager,
+    _retry::{delay::Fibonacci, Error as RetryError},
+};
 use mc_consensus_scp::{slot::Phase, Msg, QuorumSet, ScpNode, SlotIndex};
 use mc_ledger_db::Ledger;
 use mc_ledger_sync::{
     LedgerSyncService, NetworkState, ReqwestTransactionsFetcher, SCPNetworkState,
 };
 use mc_peers::{
-    Broadcast, ConsensusConnection, RetryableConsensusConnection, VerifiedConsensusMsg,
+    Broadcast, ConsensusConnection, Error as PeerError, RetryableConsensusConnection,
+    VerifiedConsensusMsg,
 };
 use mc_transaction_core::{tx::TxHash, BlockID};
 use mc_util_metered_channel::Receiver;
@@ -85,6 +89,11 @@ pub struct ByzantineLedgerWorker<
 
     // Ledger sync state.
     ledger_sync_state: LedgerSyncState,
+
+    // A map of responder id to a list of tx hashes that it is unable to provide. This allows us to
+    // skip attemping to fetch txs that are bound to fail. A BTreeSet is used to speed up lookups
+    // as expect to be doing more lookups than inserts.
+    missing_tx_hashes: HashMap<ResponderId, BTreeSet<TxHash>>,
 }
 
 impl<
@@ -145,6 +154,7 @@ impl<
             network_state,
             ledger_sync_service,
             ledger_sync_state: LedgerSyncState::InSync,
+            missing_tx_hashes: HashMap::default(),
         };
 
         loop {
@@ -581,6 +591,10 @@ impl<
             log::info!(self.logger, "sync_service reported we're behind, but we just externalized a slot. resetting to InSync");
             self.ledger_sync_state = LedgerSyncState::InSync;
         }
+
+        // Clear the missing tx hashes map. If we encounter the same tx hash again in a different
+        // slot, it is possible we might be able to fetch it.
+        self.missing_tx_hashes.clear();
     }
 
     fn fetch_missing_txs(
@@ -595,6 +609,20 @@ impl<
             .filter(|tx_hash| !self.tx_manager.contains(tx_hash))
             .collect();
 
+        // Don't attempt to issue any RPC calls if we know we're going to fail.
+        if let Some(previously_missed_hashes) = self.missing_tx_hashes.get(from_responder_id) {
+            let previously_encountered_missing_hashes = missing_hashes
+                .iter()
+                .any(|tx_hash| previously_missed_hashes.contains(tx_hash));
+            if previously_encountered_missing_hashes {
+                log::debug!(
+                    self.logger,
+                    "Not attempting to resolve missing tx hashes {:?}: contains tx hashes known to not be available", missing_hashes);
+                return false;
+            }
+        }
+
+        // Get the connection we'll be working with
         let conn = match self.peer_manager.conn(from_responder_id) {
             Some(conn) => conn,
             None => {
@@ -638,6 +666,17 @@ impl<
                             }
                         },
                     );
+                }
+                Err(RetryError::Operation {
+                    error: PeerError::TxHashesNotInCache(tx_hashes),
+                    ..
+                }) => {
+                    let entry = self
+                        .missing_tx_hashes
+                        .entry(from_responder_id.clone())
+                        .or_insert_with(BTreeSet::default);
+                    entry.extend(tx_hashes);
+                    return false;
                 }
                 Err(err) => {
                     log::error!(

--- a/peers/src/error.rs
+++ b/peers/src/error.rs
@@ -68,6 +68,7 @@ impl Error {
         match self {
             Error::Grpc(_ge) => true,
             Error::Attestation(_ae) => true,
+            Error::Enclave(EnclaveError::Attest(_ae)) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
### Motivation

@mfaulk and me discovered a bug in which a node would repeatedly try to resolve missing tx hashes from a peer, even if the peer does not have them in its cache. Each attempt takes about 15 seconds due to unnecessary retries, and this happens for each SCP message that refers to the missing hashes.
For example, a potential scenario in which hashes would be missing is if a peer restarted mid-slot. The local node would have a bunch of queued up SCP messages from before the peer restarted, and when it gets to processing them it will repeatedly attempt to FetchTxs from this peer, even though it will never succeed. This effectively results in the node falling back for a long duration of time.

### In this PR
* A small change that prevents nodes from retrying to fetch txs that have been reported as unavailable by a given peer.

### Future Work
* In theory, the node could attempt to fetch the txs from a different peer. However, that would be a bigger and more complicated change.
* This still needs to go through some slam testing.

