### PR TITLE
[MCC-1694] ByzantineLedger uses TxManager trait

### DIFF
--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -11,7 +11,7 @@ mod worker;
 use crate::{
     byzantine_ledger::{task_message::TaskMessage, worker::ByzantineLedgerWorker},
     counters,
-    tx_manager::TxManagerTrait,
+    tx_manager::TxManager,
 };
 use mc_common::{logger::Logger, NodeID, ResponderId};
 use mc_connection::{BlockchainConnection, ConnectionManager};
@@ -53,7 +53,7 @@ impl ByzantineLedger {
     pub fn new<
         PC: BlockchainConnection + ConsensusConnection + 'static,
         L: Ledger + Sync + 'static,
-        TXM: TxManagerTrait + Send + Sync + 'static,
+        TXM: TxManager + Send + Sync + 'static,
     >(
         node_id: NodeID,
         quorum_set: QuorumSet,
@@ -233,7 +233,7 @@ impl Drop for ByzantineLedger {
 mod tests {
     use super::*;
     use crate::{
-        tx_manager::{MockTxManagerTrait, TxManager},
+        tx_manager::{MockTxManager, TxManagerImpl},
         validators::DefaultTxManagerUntrustedInterfaces,
     };
     use hex;
@@ -367,7 +367,7 @@ mod tests {
         );
 
         // Mock tx_manager
-        let tx_manager = Arc::new(MockTxManagerTrait::new());
+        let tx_manager = Arc::new(MockTxManager::new());
 
         // Mock broadcaster
         let broadcaster = Arc::new(Mutex::new(MockBroadcast::new()));
@@ -445,7 +445,7 @@ mod tests {
         )));
 
         let enclave = ConsensusServiceMockEnclave::default();
-        let tx_manager = Arc::new(TxManager::new(
+        let tx_manager = Arc::new(TxManagerImpl::new(
             enclave.clone(),
             DefaultTxManagerUntrustedInterfaces::new(ledger.clone()),
             logger.clone(),

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -11,11 +11,10 @@ mod worker;
 use crate::{
     byzantine_ledger::{task_message::TaskMessage, worker::ByzantineLedgerWorker},
     counters,
-    tx_manager::{TxManager, TxManagerTrait, UntrustedInterfaces},
+    tx_manager::TxManagerTrait,
 };
 use mc_common::{logger::Logger, NodeID, ResponderId};
 use mc_connection::{BlockchainConnection, ConnectionManager};
-use mc_consensus_enclave::ConsensusEnclaveProxy;
 use mc_consensus_scp::{scp_log::LoggingScpNode, Msg, Node, QuorumSet, ScpNode};
 use mc_crypto_keys::Ed25519Pair;
 use mc_ledger_db::Ledger;
@@ -52,16 +51,15 @@ pub struct ByzantineLedger {
 
 impl ByzantineLedger {
     pub fn new<
-        E: ConsensusEnclaveProxy,
         PC: BlockchainConnection + ConsensusConnection + 'static,
         L: Ledger + Sync + 'static,
-        UI: UntrustedInterfaces + Send + Sync + 'static,
+        TXM: TxManagerTrait + Send + Sync + 'static,
     >(
         node_id: NodeID,
         quorum_set: QuorumSet,
         peer_manager: ConnectionManager<PC>,
         ledger: L,
-        tx_manager: Arc<TxManager<E, UI>>,
+        tx_manager: Arc<TXM>,
         broadcaster: Arc<Mutex<dyn Broadcast>>,
         msg_signer_key: Arc<Ed25519Pair>,
         tx_source_urls: Vec<String>,
@@ -234,7 +232,7 @@ impl Drop for ByzantineLedger {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::validators::DefaultTxManagerUntrustedInterfaces;
+    use crate::{tx_manager::TxManager, validators::DefaultTxManagerUntrustedInterfaces};
     use hex;
     use mc_common::logger::test_with_logger;
     use mc_consensus_enclave_mock::ConsensusServiceMockEnclave;

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -6,7 +6,7 @@ use crate::{
         MAX_PENDING_VALUES_TO_NOMINATE,
     },
     counters,
-    tx_manager::{TxManagerError, TxManagerTrait},
+    tx_manager::{TxManager, TxManagerError},
 };
 use mc_common::{
     logger::{log, Logger},
@@ -40,7 +40,7 @@ pub struct ByzantineLedgerWorker<
     F: Fn(Msg<TxHash>),
     L: Ledger + 'static,
     PC: BlockchainConnection + ConsensusConnection + 'static,
-    TXM: TxManagerTrait,
+    TXM: TxManager,
 > {
     receiver: Receiver<TaskMessage>,
     scp: Box<dyn ScpNode<TxHash>>,
@@ -93,7 +93,7 @@ impl<
         L: Ledger + 'static,
         PC: BlockchainConnection + ConsensusConnection + 'static,
         // UI: UntrustedInterfaces + Send + 'static,
-        TXM: TxManagerTrait + Send + Sync,
+        TXM: TxManager + Send + Sync,
     > ByzantineLedgerWorker<F, L, PC, TXM>
 {
     pub fn start(

--- a/consensus/service/src/client_api_service.rs
+++ b/consensus/service/src/client_api_service.rs
@@ -6,7 +6,7 @@ use crate::{
     consensus_service::ProposeTxCallback,
     counters,
     grpc_error::ConsensusGrpcError,
-    tx_manager::{TxManager, TxManagerError, TxManagerTrait},
+    tx_manager::{TxManager, TxManagerError, TxManagerImpl},
     validators::DefaultTxManagerUntrustedInterfaces,
 };
 use grpcio::{RpcContext, UnarySink};
@@ -30,7 +30,7 @@ pub struct ClientApiService<E: ConsensusEnclaveProxy, L: Ledger + Clone> {
     enclave: E,
     scp_client_value_sender: ProposeTxCallback,
     ledger: L,
-    tx_manager: Arc<TxManager<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>>,
+    tx_manager: Arc<TxManagerImpl<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>>,
     is_serving_fn: Arc<(dyn Fn() -> bool + Sync + Send)>,
     logger: Logger,
 }
@@ -40,7 +40,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger + Clone> ClientApiService<E, L> {
         enclave: E,
         scp_client_value_sender: ProposeTxCallback,
         ledger: L,
-        tx_manager: Arc<TxManager<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>>,
+        tx_manager: Arc<TxManagerImpl<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>>,
         is_serving_fn: Arc<(dyn Fn() -> bool + Sync + Send)>,
         logger: Logger,
     ) -> Self {

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -11,7 +11,7 @@ use crate::{
     config::Config,
     counters, peer_api_service,
     peer_keepalive::PeerKeepalive,
-    tx_manager::{TxManager, TxManagerTrait},
+    tx_manager::{TxManager, TxManagerImpl},
     validators::DefaultTxManagerUntrustedInterfaces,
 };
 use failure::Fail;
@@ -101,7 +101,7 @@ pub struct ConsensusService<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync 
 
     peer_manager: ConnectionManager<PeerConnection<E>>,
     broadcaster: Arc<Mutex<ThreadedBroadcaster>>,
-    tx_manager: Arc<TxManager<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>>,
+    tx_manager: Arc<TxManagerImpl<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>>,
     peer_keepalive: Arc<Mutex<PeerKeepalive>>,
 
     admin_rpc_server: Option<AdminServer>,
@@ -157,7 +157,7 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
         )));
 
         // Tx Manager
-        let tx_manager = TxManager::new(
+        let tx_manager = TxManagerImpl::new(
             enclave.clone(),
             DefaultTxManagerUntrustedInterfaces::new(ledger_db.clone()),
             logger.clone(),

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -7,7 +7,7 @@ use crate::{
     consensus_service::{IncomingConsensusMsg, ProposeTxCallback},
     counters,
     grpc_error::ConsensusGrpcError,
-    tx_manager::{TxManager, TxManagerError, TxManagerTrait},
+    tx_manager::{TxManager, TxManagerError, TxManagerImpl},
     validators::DefaultTxManagerUntrustedInterfaces,
 };
 use grpcio::{RpcContext, UnarySink};
@@ -58,7 +58,7 @@ pub struct PeerApiService<E: ConsensusEnclaveProxy, L: Ledger> {
     ledger: L,
 
     /// Transactions Manager instance.
-    tx_manager: Arc<TxManager<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>>,
+    tx_manager: Arc<TxManagerImpl<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>>,
 
     /// Callback function for getting the latest SCP statement the local node has issued.
     fetch_latest_msg_fn: FetchLatestMsgFn,
@@ -79,7 +79,7 @@ impl<E: ConsensusEnclaveProxy, L: Ledger> PeerApiService<E, L> {
         incoming_consensus_msgs_sender: BackgroundWorkQueueSenderFn<IncomingConsensusMsg>,
         scp_client_value_sender: ProposeTxCallback,
         ledger: L,
-        tx_manager: Arc<TxManager<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>>,
+        tx_manager: Arc<TxManagerImpl<E, DefaultTxManagerUntrustedInterfaces<LedgerDB>>>,
         fetch_latest_msg_fn: FetchLatestMsgFn,
         known_responder_ids: Vec<ResponderId>,
         logger: Logger,

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -30,6 +30,9 @@ pub use error::{TxManagerError, TxManagerResult};
 pub use tx_manager_trait::TxManagerTrait;
 pub use untrusted_interfaces::UntrustedInterfaces;
 
+#[cfg(test)]
+pub use tx_manager_trait::MockTxManagerTrait;
+
 struct CacheEntry {
     /// An encrypted transaction that has been found to be well-formed.
     encrypted_tx: WellFormedEncryptedTx,

--- a/consensus/service/src/tx_manager/tx_manager_trait.rs
+++ b/consensus/service/src/tx_manager/tx_manager_trait.rs
@@ -20,11 +20,7 @@ pub trait TxManagerTrait {
     /// * `block_index` - Current block index.
     fn remove_expired(&self, block_index: u64) -> HashSet<TxHash>;
 
-    // /// Returns elements of `tx_hashes` that are not inside the cache.
-    // fn missing_hashes<T>(&self, tx_hashes: &T) -> Vec<TxHash>
-    // where
-    //     for<'a> &'a T: IntoIterator<Item = &'a TxHash>;
-
+    /// Returns true if the cache contains the corresponding transaction.
     fn contains(&self, tx_hash: &TxHash) -> bool;
 
     /// Number of cached entries.

--- a/consensus/service/src/tx_manager/tx_manager_trait.rs
+++ b/consensus/service/src/tx_manager/tx_manager_trait.rs
@@ -10,7 +10,7 @@ use mc_transaction_core::{tx::TxHash, Block, BlockContents, BlockSignature};
 use mockall::*;
 
 #[cfg_attr(test, automock)]
-pub trait TxManagerTrait {
+pub trait TxManager {
     /// Insert a transaction into the cache. The transaction must be well-formed.
     fn insert(&self, tx_context: TxContext) -> TxManagerResult<TxHash>;
 

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -27,6 +27,7 @@ crossbeam-channel = "0.3"
 ed25519 = { version = "1.0.1", default-features = false, features = ["serde"] }
 failure = "0.1.5"
 grpcio = "0.6.0"
+mockall = "0.7.2"
 protobuf = "2.12"
 retry = "0.5"
 sha2 = { version = "0.9", default-features = false }
@@ -37,6 +38,5 @@ url = "2.1"
 mc-connection-test-utils = { path = "../connection/test-utils" }
 mc-peers-test-utils = { path = "./test-utils" }
 
-mockall = "0.7.2"
 rand_hc = "0.2"
 rand = "0.7"

--- a/peers/src/broadcast.rs
+++ b/peers/src/broadcast.rs
@@ -4,11 +4,9 @@
 
 use crate::ConsensusMsg;
 use mc_common::ResponderId;
-
-#[cfg(test)]
 use mockall::*;
 
-#[cfg_attr(test, automock)]
+#[automock]
 pub trait Broadcast: Send {
     /// Broadcasts a consensus message.
     ///

--- a/peers/src/lib.rs
+++ b/peers/src/lib.rs
@@ -14,7 +14,7 @@ mod threaded_broadcaster_retry;
 mod traits;
 
 pub use crate::{
-    broadcast::Broadcast,
+    broadcast::{Broadcast, MockBroadcast},
     connection::PeerConnection,
     consensus_msg::{ConsensusMsg, ConsensusMsgError, TxProposeAAD, VerifiedConsensusMsg},
     error::{Error, Result},


### PR DESCRIPTION
Soundtrack of this PR: [Royals](https://www.youtube.com/watch?v=nlcIKh6sBtc)

### Motivation

ByzantineLedger currently has a single, large unit test that traces the "happy path" of a node reaching consensus on a single slot. We don't yet have unit test coverage for failure modes, catch-up, or broadcast.

### In this PR
* ByzantineLedger depend on the TxManager trait, instead of a concrete implementation. This will help with testing failure modes.
* Creates a simple unit test that uses the autogenerated mock for TxManager. This is mostly a proof-of-concept that sets up the pattern for further tests.
* Extracts some common setup code that will probably get reused in multiple unit tests.

### Future Work
* https://mobilecoin.atlassian.net/browse/MCC-480
* https://mobilecoin.atlassian.net/browse/MCC-486
* https://mobilecoin.atlassian.net/browse/MCC-498

