### PR TITLE
[MCC-487] Unit test ClientApiService's gRPC endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,8 +2467,8 @@ dependencies = [
  "rand_hc 0.2.0",
  "serde",
  "serde_json",
- "serial_test",
- "serial_test_derive",
+ "serial_test 0.1.0",
+ "serial_test_derive 0.1.0",
  "sha3",
 ]
 
@@ -2539,6 +2539,8 @@ dependencies = [
  "retry",
  "serde",
  "serde_json",
+ "serial_test 0.5.0",
+ "serial_test_derive 0.5.0",
  "structopt",
  "tempdir",
  "toml 0.5.6",
@@ -5141,6 +5143,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b15f74add9a9d4a3eb2bf739c9a427d266d3895b53d992c3a7c234fec2ff1f1"
+dependencies = [
+ "lazy_static",
+ "parking_lot 0.10.2",
+ "serial_test_derive 0.5.0",
+]
+
+[[package]]
 name = "serial_test_derive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5148,6 +5161,17 @@ checksum = "2cdabca97cecf57fa82170ca1689ead2933f38f106a5a91a947a0ca156c6d39d"
 dependencies = [
  "quote 0.6.13",
  "syn 0.15.44",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65f59259be9fc1bf677d06cc1456e97756004a1a5a577480f71430bd7c17ba33"
+dependencies = [
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.18",
 ]
 
 [[package]]

--- a/consensus/api/Cargo.toml
+++ b/consensus/api/Cargo.toml
@@ -20,5 +20,3 @@ mc-util-build-grpc = { path = "../../util/build/grpc" }
 mc-util-build-script = { path = "../../util/build/script" }
 
 cargo-emit = "0.1.1"
-
-

--- a/consensus/api/Cargo.toml
+++ b/consensus/api/Cargo.toml
@@ -15,9 +15,10 @@ futures = "0.3"
 grpcio = "0.6.0"
 protobuf = "2.12"
 
-
 [build-dependencies]
 mc-util-build-grpc = { path = "../../util/build/grpc" }
 mc-util-build-script = { path = "../../util/build/script" }
 
 cargo-emit = "0.1.1"
+
+

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -71,6 +71,8 @@ mc-util-logger-macros = { path = "../../util/logger-macros" }
 mockall = "0.7.2"
 rand_core = { version = "0.5", default-features = false }
 rand_hc = "0.2.0"
+serial_test = "0.5"
+serial_test_derive = "0.5"
 tempdir = "0.3"
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dev-dependencies]

--- a/consensus/service/src/client_api_service.rs
+++ b/consensus/service/src/client_api_service.rs
@@ -10,13 +10,12 @@ use crate::{
 };
 use grpcio::{RpcContext, UnarySink};
 use mc_attest_api::attest::Message;
-use mc_common::logger::{log, Logger};
+use mc_common::logger::Logger;
 use mc_consensus_api::{
     consensus_client_grpc::ConsensusClientApi, consensus_common::ProposeTxResponse,
 };
 use mc_consensus_enclave::ConsensusEnclave;
 use mc_ledger_db::Ledger;
-use mc_transaction_core::validation::TransactionValidationError;
 use mc_util_grpc::{rpc_logger, send_result};
 use mc_util_metrics::{self, SVC_COUNTERS};
 use std::sync::Arc;
@@ -29,7 +28,9 @@ pub struct ClientApiService {
     enclave: Arc<dyn ConsensusEnclave + Send + Sync>,
     tx_manager: Arc<dyn TxManager + Send + Sync>,
     ledger: Arc<dyn Ledger + Send + Sync>,
-    scp_client_value_sender: ProposeTxCallback,
+    /// Passes proposed transactions to the consensus service.
+    propose_tx_callback: ProposeTxCallback,
+    /// Returns true if this node is able to process proposed transactions.
     is_serving_fn: Arc<(dyn Fn() -> bool + Sync + Send)>,
     logger: Logger,
 }
@@ -47,88 +48,51 @@ impl ClientApiService {
             enclave,
             tx_manager,
             ledger,
-            scp_client_value_sender,
+            propose_tx_callback: scp_client_value_sender,
             is_serving_fn,
             logger,
         }
     }
 
-    fn real_client_tx_propose(
+    /// Handles a client's proposed transaction.
+    ///
+    /// # Arguments
+    /// `msg` - An encrypted message from a client to the enclave.
+    /// `logger` - Logger
+    fn handle_proposed_tx(
         &mut self,
-        request: Message,
-        logger: &Logger,
+        msg: Message,
     ) -> Result<ProposeTxResponse, ConsensusGrpcError> {
         counters::ADD_TX_INITIATED.inc();
 
         if counters::CUR_NUM_PENDING_VALUES.get() > PENDING_LIMIT {
-            self.enclave.client_discard_message(request.into())?;
-
-            log::trace!(
-                logger,
-                "Ignoring add transaction call, node is over capacity."
-            );
+            // This node is over capacity, and is not accepting proposed transaction.
+            self.enclave.client_discard_message(msg.into())?;
             return Err(ConsensusGrpcError::OverCapacity);
         }
 
-        // Check if node is accepting requests.
         if !(self.is_serving_fn)() {
-            self.enclave.client_discard_message(request.into())?;
-
-            log::info!(
-                logger,
-                "Ignoring add transaction call, not currently serving requests."
-            );
+            // This node is unable to process transactions (e.g. is syncing its ledger).
+            self.enclave.client_discard_message(msg.into())?;
             return Err(ConsensusGrpcError::NotServing);
         }
 
-        let tx_context = self.enclave.client_tx_propose(request.into())?;
-        let tx_hash = tx_context.tx_hash;
+        let tx_context = self.enclave.client_tx_propose(msg.into())?;
 
-        match self.tx_manager.insert(tx_context) {
-            Ok(tx_hash) => {
+        self.tx_manager
+            .insert(tx_context)
+            .map(|tx_hash| {
                 // Submit for consideration in next SCP slot.
-                (*self.scp_client_value_sender)(tx_hash, None, None);
-
+                (*self.propose_tx_callback)(tx_hash, None, None);
                 counters::ADD_TX.inc();
-
-                // Return success.
                 Ok(ProposeTxResponse::new())
-            }
-
-            Err(TxManagerError::TransactionValidation(err)) => {
-                // These errors are common, so only trace them
-                if err == TransactionValidationError::TombstoneBlockExceeded
-                    || err == TransactionValidationError::ContainsSpentKeyImage
-                    || err == TransactionValidationError::ContainsExistingOutputPublicKey
-                {
-                    log::trace!(
-                        logger,
-                        "Error validating transaction {tx_hash}: {err}",
-                        tx_hash = tx_hash.to_string(),
-                        err = format!("{:?}", err)
-                    );
-                } else {
-                    log::debug!(
-                        logger,
-                        "Error validating transaction {tx_hash}: {err}",
-                        tx_hash = tx_hash.to_string(),
-                        err = format!("{:?}", err)
-                    );
+            })
+            .map_err(|err| {
+                if let TxManagerError::TransactionValidation(cause) = &err {
+                    counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{:?}", cause));
                 }
-                counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{:?}", err));
-                Err(err.into())
-            }
-
-            Err(err) => {
-                log::info!(
-                    logger,
-                    "tx_propose failed for {tx_hash}: {err}",
-                    tx_hash = tx_hash.to_string(),
-                    err = format!("{:?}", err)
-                );
-                Err(err.into())
-            }
-        }
+                err
+            })?
     }
 }
 
@@ -140,20 +104,17 @@ impl ConsensusClientApi for ClientApiService {
         sink: UnarySink<ProposeTxResponse>,
     ) {
         let _timer = SVC_COUNTERS.req(&ctx);
+
+        let response = self
+            .handle_proposed_tx(request)
+            .or_else(ConsensusGrpcError::into)
+            .and_then(|mut resp| {
+                resp.set_num_blocks(self.ledger.num_blocks().map_err(ConsensusGrpcError::from)?);
+                Ok(resp)
+            });
+
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
-            send_result(
-                ctx,
-                sink,
-                self.real_client_tx_propose(request, &logger)
-                    .or_else(ConsensusGrpcError::into)
-                    .and_then(|mut resp| {
-                        resp.set_num_blocks(
-                            self.ledger.num_blocks().map_err(ConsensusGrpcError::from)?,
-                        );
-                        Ok(resp)
-                    }),
-                &logger,
-            )
+            send_result(ctx, sink, response, &logger)
         });
     }
 }
@@ -180,6 +141,7 @@ mod tests {
     use std::sync::Arc;
 
     #[test_with_logger]
+
     fn test_client_tx_propose_ok(logger: Logger) {
         let mut consensus_enclave = MockConsensusEnclave::new();
         consensus_enclave

--- a/consensus/service/src/client_api_service.rs
+++ b/consensus/service/src/client_api_service.rs
@@ -194,7 +194,6 @@ mod tests {
         );
 
         // Local ledger
-        // TODO: mock this, because it's only used to get num_blocks.
         let mut ledger = create_ledger();
         let mut rng: StdRng = SeedableRng::from_seed([62u8; 32]);
         let sender = AccountKey::random(&mut rng);
@@ -240,13 +239,5 @@ mod tests {
             }
             Err(e) => panic!("unexpected error: {:?}", e),
         }
-
-        // let mut req = HealthCheckRequest::default();
-        // req.set_service("not-exist".to_owned());
-        // let err = client.check(&req).unwrap_err();
-        // match err {
-        //     Error::RpcFailure(s) => assert_eq!(s.status, RpcStatusCode::NOT_FOUND),
-        //     e => panic!("unexpected error: {:?}", e),
-        // }
     }
 }

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -290,7 +290,7 @@ impl<
             client_api_service::ClientApiService::new(
                 Arc::new(self.enclave.clone()),
                 self.create_scp_client_value_sender_fn(),
-                self.ledger_db.clone(),
+                Arc::new(self.ledger_db.clone()),
                 self.tx_manager.clone(),
                 self.create_is_serving_user_requests_fn(),
                 self.logger.clone(),

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -51,7 +51,7 @@ impl CacheEntry {
     }
 }
 
-pub struct TxManagerImpl<E: ConsensusEnclave, UI: UntrustedInterfaces> {
+pub struct TxManagerImpl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> {
     /// Enclave.
     enclave: E,
 
@@ -66,7 +66,7 @@ pub struct TxManagerImpl<E: ConsensusEnclave, UI: UntrustedInterfaces> {
     logger: Logger,
 }
 
-impl<E: ConsensusEnclave, UI: UntrustedInterfaces> TxManagerImpl<E, UI> {
+impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManagerImpl<E, UI> {
     /// Construct a new TxManager instance.
     pub fn new(enclave: E, untrusted: UI, logger: Logger) -> Self {
         Self {
@@ -82,7 +82,9 @@ impl<E: ConsensusEnclave, UI: UntrustedInterfaces> TxManagerImpl<E, UI> {
     }
 }
 
-impl<E: ConsensusEnclave, UI: UntrustedInterfaces> TxManager for TxManagerImpl<E, UI> {
+impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
+    for TxManagerImpl<E, UI>
+{
     /// Insert a transaction into the cache. The transaction must be well-formed.
     fn insert(&self, tx_context: TxContext) -> TxManagerResult<TxHash> {
         {

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -51,6 +51,7 @@ impl CacheEntry {
     }
 }
 
+#[derive(Clone)]
 pub struct TxManagerImpl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> {
     /// Enclave.
     enclave: E,
@@ -60,7 +61,7 @@ pub struct TxManagerImpl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + S
     untrusted: UI,
 
     /// Well-formed transactions, keyed by hash.
-    cache: Mutex<HashMap<TxHash, CacheEntry>>,
+    cache: Arc<Mutex<HashMap<TxHash, CacheEntry>>>,
 
     /// Logger.
     logger: Logger,
@@ -73,7 +74,7 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManagerImpl<E
             enclave,
             untrusted,
             logger,
-            cache: Mutex::new(HashMap::default()),
+            cache: Arc::new(Mutex::new(HashMap::default())),
         }
     }
 

--- a/consensus/service/src/tx_manager/tx_manager_trait.rs
+++ b/consensus/service/src/tx_manager/tx_manager_trait.rs
@@ -10,7 +10,7 @@ use mc_transaction_core::{tx::TxHash, Block, BlockContents, BlockSignature};
 use mockall::*;
 
 #[cfg_attr(test, automock)]
-pub trait TxManager {
+pub trait TxManager: Send {
     /// Insert a transaction into the cache. The transaction must be well-formed.
     fn insert(&self, tx_context: TxContext) -> TxManagerResult<TxHash>;
 


### PR DESCRIPTION
### Motivation

We do not currently have unit test coverage for the consensus node's gRPC APIs, but we should. This service also relies on TxManager::insert to perform spent key image checks, which is incorrect and is blocking us from fixing TxManager.

### In this PR
* Replaces several uses of ConsensusEnclaveProxy (which can't be mocked) with ConsensusEnclave (which can).
* Checks for spent key images. Previously, this relied on TxManager::insert, which confused things because it mixed key image checking in with the is_well_formed check.
* Adds unit tests

