### PR TITLE
[MCC-1700] Mocks Ledger trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2746,6 +2746,7 @@ dependencies = [
  "mc-util-lmdb",
  "mc-util-metrics",
  "mc-util-serial",
+ "mockall",
  "prost",
  "rand 0.7.3",
  "rand_core 0.5.1",

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -52,7 +52,7 @@ pub struct ByzantineLedger {
 impl ByzantineLedger {
     pub fn new<
         PC: BlockchainConnection + ConsensusConnection + 'static,
-        L: Ledger + Sync + 'static,
+        L: Ledger + Clone + Sync + 'static,
         TXM: TxManager + Send + Sync + 'static,
     >(
         node_id: NodeID,

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -88,11 +88,9 @@ pub struct ByzantineLedgerWorker<
 }
 
 impl<
-        // E: ConsensusEnclaveProxy,
         F: Fn(Msg<TxHash>),
-        L: Ledger + 'static,
+        L: Ledger + Clone + 'static,
         PC: BlockchainConnection + ConsensusConnection + 'static,
-        // UI: UntrustedInterfaces + Send + 'static,
         TXM: TxManager + Send + Sync,
     > ByzantineLedgerWorker<F, L, PC, TXM>
 {

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -521,7 +521,7 @@ impl<
             );
 
             self.ledger
-                .append_block(&block, &block_contents, Some(&signature))
+                .append_block(&block, &block_contents, Some(signature))
                 .expect("failed appending block");
 
             counters::TX_EXTERNALIZED_COUNT.inc_by(ext_vals.len() as i64);

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -23,6 +23,7 @@ mc-util-serial = { path = "../../util/serial", features = ["std"] }
 failure = "0.1.5"
 lazy_static = "1.4"
 lmdb-rkv = "0.14.0"
+mockall = "0.7.2"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand = { version = "0.7", optional = true }
 rand_core = "0.5"

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -8,16 +8,16 @@ use mc_transaction_core::{
     tx::{TxOut, TxOutMembershipProof},
     Block, BlockContents, BlockSignature,
 };
-// use mockall::*;
+use mockall::*;
 
-// #[automock]
+#[automock]
 pub trait Ledger: Send {
     /// Appends a block along with transactions.
     fn append_block(
         &mut self,
         block: &Block,
         block_contents: &BlockContents,
-        signature: Option<&BlockSignature>,
+        signature: Option<BlockSignature>,
     ) -> Result<(), Error>;
 
     /// Get the total number of blocks in the ledger.

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -8,8 +8,10 @@ use mc_transaction_core::{
     tx::{TxOut, TxOutMembershipProof},
     Block, BlockContents, BlockSignature,
 };
+// use mockall::*;
 
-pub trait Ledger: Clone + Send {
+// #[automock]
+pub trait Ledger: Send {
     /// Appends a block along with transactions.
     fn append_block(
         &mut self,

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -34,7 +34,7 @@ use metrics::LedgerMetrics;
 use std::{fs, path::PathBuf, sync::Arc, time::Instant};
 
 pub use error::Error;
-pub use ledger_trait::Ledger;
+pub use ledger_trait::{Ledger, MockLedger};
 pub use mc_util_lmdb::MetadataStore;
 pub use tx_out_store::TxOutStore;
 
@@ -143,7 +143,7 @@ impl Ledger for LedgerDB {
         &mut self,
         block: &Block,
         block_contents: &BlockContents,
-        signature: Option<&BlockSignature>,
+        signature: Option<BlockSignature>,
     ) -> Result<(), Error> {
         let start_time = Instant::now();
 
@@ -160,7 +160,7 @@ impl Ledger for LedgerDB {
         self.write_tx_outs(block.index, &block_contents.outputs, &mut db_transaction)?;
 
         // Write block.
-        self.write_block(block, signature, &mut db_transaction)?;
+        self.write_block(block, signature.as_ref(), &mut db_transaction)?;
 
         // Commit.
         db_transaction.commit()?;

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -88,7 +88,7 @@ impl Ledger for MockLedger {
         &mut self,
         block: &Block,
         block_contents: &BlockContents,
-        _signature: Option<&BlockSignature>,
+        _signature: Option<BlockSignature>,
     ) -> Result<(), Error> {
         assert_eq!(block.index, self.num_blocks().unwrap());
         self.set_block(block, block_contents);

--- a/ledger/from-archive/src/main.rs
+++ b/ledger/from-archive/src/main.rs
@@ -71,7 +71,7 @@ fn main() {
                     .append_block(
                         &s3_block_data.block,
                         &s3_block_data.block_contents,
-                        s3_block_data.signature.as_ref(),
+                        s3_block_data.signature,
                     )
                     .unwrap_or_else(|_| panic!("Could not append block {:?}", block_index))
             }

--- a/ledger/sync/src/ledger_sync_service_thread.rs
+++ b/ledger/sync/src/ledger_sync_service_thread.rs
@@ -27,7 +27,7 @@ pub struct LedgerSyncServiceThread {
 
 impl LedgerSyncServiceThread {
     pub fn new<
-        L: Ledger + 'static,
+        L: Ledger + Clone + 'static,
         BC: BlockchainConnection + 'static,
         TF: TransactionsFetcher + 'static,
     >(


### PR DESCRIPTION
### Motivation

The Ledger trait / LedgerDB are used by a lot of things, which makes those things tedious to test.

### In this PR
* A few tweaks to the Ledger trait so that it is compatible with automock.

### Future Work
* Use MockLedger in unit tests.


