### PR TITLE
[MCC-1701] Removes unused `_rng` from TxOut::new

### DIFF
--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -738,7 +738,6 @@ mod combine_tests {
             &alice.default_subaddress(),
             &tx_secret_key_for_txo,
             Default::default(),
-            &mut rng,
         )
         .unwrap();
 
@@ -808,7 +807,6 @@ mod combine_tests {
                     &alice.default_subaddress(),
                     &tx_secret_key_for_txo,
                     Default::default(),
-                    &mut rng,
                 )
                 .unwrap();
 
@@ -876,7 +874,6 @@ mod combine_tests {
             &alice.default_subaddress(),
             &RistrettoPrivate::from_random(&mut rng),
             Default::default(),
-            &mut rng,
         )
         .unwrap();
 
@@ -961,7 +958,6 @@ mod combine_tests {
                 &alice.default_subaddress(),
                 &tx_secret_key_for_txo,
                 Default::default(),
-                &mut rng,
             )
             .unwrap();
             let tx_public_key_for_txo = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
@@ -1027,7 +1023,6 @@ mod combine_tests {
             &alice.default_subaddress(),
             &RistrettoPrivate::from_random(&mut rng),
             Default::default(),
-            &mut rng,
         )
         .unwrap();
 
@@ -1036,7 +1031,6 @@ mod combine_tests {
             &alice.default_subaddress(),
             &RistrettoPrivate::from_random(&mut rng),
             Default::default(),
-            &mut rng,
         )
         .unwrap();
 
@@ -1129,7 +1123,6 @@ mod combine_tests {
                 &alice.default_subaddress(),
                 &tx_secret_key_for_txo,
                 Default::default(),
-                &mut rng,
             )
             .unwrap();
             let tx_public_key_for_txo = RistrettoPublic::try_from(&tx_out.public_key).unwrap();

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -674,7 +674,6 @@ mod ledger_db_test {
                         &account_key.default_subaddress(),
                         &RistrettoPrivate::from_random(&mut rng),
                         Default::default(),
-                        &mut rng,
                     )
                     .unwrap()
                 })
@@ -728,7 +727,6 @@ mod ledger_db_test {
             &account_key.default_subaddress(),
             &RistrettoPrivate::from_random(&mut rng),
             Default::default(),
-            &mut rng,
         )
         .unwrap();
 
@@ -784,7 +782,6 @@ mod ledger_db_test {
                     &recipient_account_key.default_subaddress(),
                     &RistrettoPrivate::from_random(&mut rng),
                     Default::default(),
-                    &mut rng,
                 )
                 .unwrap()
             })
@@ -865,7 +862,6 @@ mod ledger_db_test {
                     &recipient_account_key.default_subaddress(),
                     &RistrettoPrivate::from_random(&mut rng),
                     Default::default(),
-                    &mut rng,
                 )
                 .unwrap()
             })
@@ -1024,7 +1020,6 @@ mod ledger_db_test {
             &account_key.default_subaddress(),
             &RistrettoPrivate::from_random(&mut rng),
             Default::default(),
-            &mut rng,
         )
         .unwrap();
         let outputs = vec![tx_out];
@@ -1069,7 +1064,6 @@ mod ledger_db_test {
             &account_key.default_subaddress(),
             &RistrettoPrivate::from_random(&mut rng),
             Default::default(),
-            &mut rng,
         )
         .unwrap();
         let outputs = vec![tx_out];
@@ -1168,7 +1162,6 @@ mod ledger_db_test {
             &account_key.default_subaddress(),
             &RistrettoPrivate::from_random(&mut rng),
             Default::default(),
-            &mut rng,
         )
         .unwrap();
 
@@ -1225,7 +1218,6 @@ mod ledger_db_test {
                 &account_key.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
-                &mut rng,
             )
             .unwrap();
             let outputs = vec![tx_out];
@@ -1250,7 +1242,6 @@ mod ledger_db_test {
                 &account_key.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
-                &mut rng,
             )
             .unwrap();
             let outputs = vec![tx_out];
@@ -1294,7 +1285,6 @@ mod ledger_db_test {
                 &account_key.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
-                &mut rng,
             )
             .unwrap();
             tx_out.public_key = existing_tx_out.public_key.clone();
@@ -1356,7 +1346,6 @@ mod ledger_db_test {
                 &account_key.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
-                &mut rng,
             )
             .unwrap();
 

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -215,7 +215,6 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
                 &account_key.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
-                &mut rng,
             )
             .unwrap();
 
@@ -231,7 +230,6 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
                 &account_key.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
-                &mut rng,
             )
             .unwrap();
 

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -762,7 +762,6 @@ mod test {
             &alice.default_subaddress(),
             &tx_secret_key_for_txo,
             Default::default(),
-            &mut rng,
         )
         .unwrap();
 

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -155,7 +155,6 @@ pub fn add_block_to_ledger_db(
                 recipient,
                 &RistrettoPrivate::from_random(rng),
                 Default::default(),
-                rng,
             )
             .unwrap()
         })

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -222,7 +222,6 @@ mod block_tests {
                     &recipient.default_subaddress(),
                     &RistrettoPrivate::from_random(rng),
                     Default::default(),
-                    rng,
                 )
                 .unwrap()
             })

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -16,7 +16,6 @@ use mc_util_repr_bytes::{
     derive_prost_message_from_repr_bytes, typenum::U32, GenericArray, ReprBytes,
 };
 use prost::Message;
-use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -257,14 +256,12 @@ impl TxOut {
     /// * `value` - Value of the output.
     /// * `recipient` - Recipient's address.
     /// * `tx_private_key` - The transaction's private key
-    /// * `hint` -
-    /// * `rng` - A cryptographic pseudorandom number generator.
-    pub fn new<RNG: CryptoRng + RngCore>(
+    /// * `hint` - Encrypted Fog hint.
+    pub fn new(
         value: u64,
         recipient: &PublicAddress,
         tx_private_key: &RistrettoPrivate,
         hint: EncryptedFogHint,
-        _rng: &mut RNG,
     ) -> Result<Self, AmountError> {
         let target_key = create_onetime_public_key(recipient, tx_private_key).into();
         let public_key = compute_tx_pubkey(tx_private_key, recipient.spend_public_key()).into();

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -206,7 +206,6 @@ pub fn initialize_ledger<L: Ledger, R: RngCore + CryptoRng>(
                             &account_key.default_subaddress(),
                             &RistrettoPrivate::from_random(rng),
                             Default::default(),
-                            rng,
                         )
                         .unwrap()
                     })
@@ -296,7 +295,6 @@ pub fn get_outputs<T: RngCore + CryptoRng>(
                 recipient,
                 &RistrettoPrivate::from_random(rng),
                 Default::default(),
-                rng,
             )
             .unwrap()
         })

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -214,7 +214,7 @@ fn create_output<RNG: CryptoRng + RngCore>(
 ) -> Result<(TxOut, RistrettoPublic), TxBuilderError> {
     let private_key = RistrettoPrivate::from_random(rng);
     let hint = create_fog_hint(recipient, ingest_pubkey, rng)?;
-    let tx_out = TxOut::new(value, recipient, &private_key, hint, rng)?;
+    let tx_out = TxOut::new(value, recipient, &private_key, hint)?;
     let shared_secret = compute_shared_secret(recipient.view_public_key(), &private_key);
     Ok((tx_out, shared_secret))
 }

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -97,5 +97,5 @@ pub fn bootstrap_ledger(
 fn create_output(recipient: &PublicAddress, value: u64, rng: &mut FixedRng) -> TxOut {
     let tx_private_key = RistrettoPrivate::from_random(rng);
     let hint = EncryptedFogHint::fake_onetime_hint(rng);
-    TxOut::new(value, recipient, &tx_private_key, hint, rng).unwrap()
+    TxOut::new(value, recipient, &tx_private_key, hint).unwrap()
 }


### PR DESCRIPTION
### In this PR
* Removes unused `_rng` argument in TxOut::new