### PR TITLE
MCC 692: Address NCC group cryptobox comments

### DIFF
--- a/crypto/box/src/fixed_buffer.rs
+++ b/crypto/box/src/fixed_buffer.rs
@@ -48,7 +48,7 @@ impl<'a> Buffer for FixedBuffer<'a> {
     }
 
     fn extend_from_slice(&mut self, other: &[u8]) -> Result<(), Error> {
-        if self.length + other.len() > self.buf.len() {
+        if other.len() > self.buf.len() - self.length {
             return Err(Error);
         }
         self.buf[self.length..self.length + other.len()].copy_from_slice(other);

--- a/crypto/box/src/versioned.rs
+++ b/crypto/box/src/versioned.rs
@@ -44,7 +44,7 @@ use rand_core::{CryptoRng, RngCore};
 pub type RistrettoHkdfBlake2bAes128Gcm = HkdfBox<Ristretto, Blake2b, Aes128Gcm>;
 
 /// A "magic byte" value checked during this process, but not interpretted.
-const MAJOR_VERSION: u8 = 0;
+const MAJOR_VERSION: u8 = 1;
 /// The "default" version that we would use for encryption lacking any version negotiation.
 const LATEST_MINOR_VERSION: u8 = 0;
 /// The versions that we would find "acceptable" during version negotiation.


### PR DESCRIPTION
There were four pieces of feedback:

(1) There was a subtle cryptogram malleability issue, where a
cryptogram could be modified to produce a new cryptogram which
would decrypt to the same message, but for a different private key.
It would be very difficult to exploit this without knowing the
private key that the original message targetted, but it is not very
hard to prevent this source of malleability.
(2) Use hkdf-expand step, not only the hkdf-extract step.
(3) Fix a possible numeric overflow in fixed-buffer
(4) Allow more flexibility in version negotiation than just "pick max version that is agreeable to both".

This commit addresses the first 3 issues, doesn't do anything with
version negotation, which we aren't really doing right now, the client
just always uses the latest version.

This commit also increases crypto-box major version to 1, to create
an explicit versioning message if new and old servers/clients are
mixed across this revision.

### In this PR

Address all NCC recommendations:
- We don't create an API in cryptobox trait for user-supplied AAD, simply because we don't need that
- We don't do anything with the version negotiation mechanism that they suggest, but create FOG-182 to track it

Bump cryptogram major version number to 1, since release is eminent and we don't want compatibility with the algo from the previous revision.

### Future Work
- Proper version negotiation