### PR TITLE
MCC-1705: Fix subtraction overflow for blocks behind

### DIFF
--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -622,11 +622,8 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
                             )
                         })
                         .ok();
-                    blocks_behind = if peer_block_height > b {
-                        Some(peer_block_height - b)
-                    } else {
-                        Some(0)
-                    };
+                    // peer_block_height - b, unless overflow, then 0
+                    blocks_behind = Some(peer_block_height.saturating_sub(b));
                 }
                 Err(e) => {
                     log::error!(logger, "Error getting block height {:?}", e);

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -622,7 +622,11 @@ impl<E: ConsensusEnclaveProxy, R: RaClient + Send + Sync + 'static> ConsensusSer
                             )
                         })
                         .ok();
-                    blocks_behind = Some(std::cmp::min(peer_block_height - b, 0));
+                    blocks_behind = if peer_block_height > b {
+                        Some(peer_block_height - b)
+                    } else {
+                        Some(0)
+                    };
                 }
                 Err(e) => {
                     log::error!(logger, "Error getting block height {:?}", e);


### PR DESCRIPTION
### Motivation

Fix bug which encounters overflow if peer block height is behind current block height when calculating "blocks behind."

### In this PR
* Fixes bug described above

[MCC-1705](https://mobilecoin.atlassian.net/browse/MCC-1705)

