### PR TITLE
MCC-1702 Protobuf serialization of IAS reports used in kex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,7 +2120,7 @@ dependencies = [
  "mc-sgx-build",
  "mc-util-encodings",
  "mc-util-from-random",
- "mc-util-serial",
+ "prost",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
  "serde",

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -20,11 +20,11 @@ mc-attest-core = { path = "../../attest/core", default-features = false }
 mc-common = { path = "../../common", default-features = false }
 mc-crypto-keys = { path = "../../crypto/keys", default-features = false }
 mc-crypto-noise = { path = "../../crypto/noise", default-features = false }
-mc-util-serial = { path = "../../util/serial", default-features = false }
 
 aead = "0.3"
 digest = { version = "0.9", default-features = false }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
+prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand_core = "0.5"
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
 

--- a/attest/ake/src/initiator.rs
+++ b/attest/ake/src/initiator.rs
@@ -18,7 +18,7 @@ use mc_crypto_noise::{
     HandshakeIX, HandshakeNX, HandshakeOutput, HandshakePattern, HandshakeState, HandshakeStatus,
     NoiseCipher, ProtocolName,
 };
-use mc_util_serial::{deserialize, serialize};
+use prost::Message;
 use rand_core::{CryptoRng, RngCore};
 
 /// Helper function to create the output for an initiate
@@ -145,9 +145,11 @@ where
         )
         .map_err(Error::HandshakeInit)?;
 
-        // FIXME: MC-72
-        let serialized_report =
-            serialize(&input.ias_report).map_err(|_e| Error::ReportSerialization)?;
+        let mut serialized_report = Vec::with_capacity(input.ias_report.encoded_len());
+        input
+            .ias_report
+            .encode(&mut serialized_report)
+            .expect("Invariants failure, encoded_len insufficient to encode IAS report");
 
         parse_handshake_output(
             handshake_state
@@ -184,8 +186,8 @@ where
         match output.status {
             HandshakeStatus::InProgress(_state) => Err(Error::HandshakeNotComplete),
             HandshakeStatus::Complete(result) => {
-                let remote_report: VerificationReport =
-                    deserialize(&output.payload).map_err(|_e| Error::ReportDeserialization)?;
+                let remote_report = VerificationReport::decode(output.payload.as_slice())
+                    .map_err(|_e| Error::ReportDeserialization)?;
                 remote_report.verify(
                     self.trust_anchors,
                     None,

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
  "mc-crypto-keys 0.6.0",
  "mc-crypto-noise 0.6.0",
  "mc-sgx-build 0.6.0",
- "mc-util-serial 0.6.0",
+ "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]


### PR DESCRIPTION
### Motivation

The last remaining use of serde in our external wire formats is the IAS reports transmitted as Noise payloads during key exchange.

### In this PR
* Change the encoding of the `VerificationReport` structure to use the derived `prost::Message`.

### Future Work
* Replacing untrusted-to-enclave use of serde with protobuf.
