### PR TITLE
MCC-959 side-channel resistant merkle proof validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,6 +3253,7 @@ dependencies = [
  "cfg-if",
  "curve25519-dalek",
  "digest 0.9.0",
+ "displaydoc",
  "failure",
  "generic-array 0.14.4",
  "hex_fmt",

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -55,6 +55,7 @@ sha2 = { version = "0.9", default-features = false, features = ["asm"] }
 [dev-dependencies]
 rand = "0.7"
 rand_hc = "0.2"
+mc-common = { path = "../../../common", features = ["loggers"] }
 mc-ledger-db = { path = "../../../ledger/db" }
 mc-transaction-core-test-utils = { path = "../../../transaction/core/test-utils" }
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -1058,6 +1058,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -690,7 +690,6 @@ mod is_valid_tests {
 #[cfg(test)]
 mod combine_tests {
     use super::*;
-    use mc_common::HashMap;
     use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
     use mc_ledger_db::test_utils::get_mock_ledger;
     use mc_transaction_core::{
@@ -757,7 +756,7 @@ mod combine_tests {
             .iter()
             .map(|_tx_out| {
                 // TODO: provide valid proofs for each tx_out.
-                TxOutMembershipProof::new(0, 0, HashMap::default())
+                TxOutMembershipProof::new(0, 0, Default::default())
             })
             .collect();
 
@@ -829,7 +828,7 @@ mod combine_tests {
                     .iter()
                     .map(|_tx_out| {
                         // TODO: provide valid proofs for each tx_out.
-                        TxOutMembershipProof::new(0, 0, HashMap::default())
+                        TxOutMembershipProof::new(0, 0, Default::default())
                     })
                     .collect();
 
@@ -891,7 +890,7 @@ mod combine_tests {
                 .iter()
                 .map(|_tx_out| {
                     // TODO: provide valid proofs for each tx_out.
-                    TxOutMembershipProof::new(0, 0, HashMap::default())
+                    TxOutMembershipProof::new(0, 0, Default::default())
                 })
                 .collect();
 
@@ -923,7 +922,7 @@ mod combine_tests {
                 .iter()
                 .map(|_tx_out| {
                     // TODO: provide valid proofs for each tx_out.
-                    TxOutMembershipProof::new(0, 0, HashMap::default())
+                    TxOutMembershipProof::new(0, 0, Default::default())
                 })
                 .collect();
 
@@ -976,7 +975,7 @@ mod combine_tests {
                 .iter()
                 .map(|_tx_out| {
                     // TODO: provide valid proofs for each tx_out.
-                    TxOutMembershipProof::new(0, 0, HashMap::default())
+                    TxOutMembershipProof::new(0, 0, Default::default())
                 })
                 .collect();
 
@@ -1054,7 +1053,7 @@ mod combine_tests {
                 .iter()
                 .map(|_tx_out| {
                     // TODO: provide valid proofs for each tx_out.
-                    TxOutMembershipProof::new(0, 0, HashMap::default())
+                    TxOutMembershipProof::new(0, 0, Default::default())
                 })
                 .collect();
 
@@ -1087,7 +1086,7 @@ mod combine_tests {
                 .iter()
                 .map(|_tx_out| {
                     // TODO: provide valid proofs for each tx_out.
-                    TxOutMembershipProof::new(0, 0, HashMap::default())
+                    TxOutMembershipProof::new(0, 0, Default::default())
                 })
                 .collect();
 
@@ -1141,7 +1140,7 @@ mod combine_tests {
                 .iter()
                 .map(|_tx_out| {
                     // TODO: provide valid proofs for each tx_out.
-                    TxOutMembershipProof::new(0, 0, HashMap::default())
+                    TxOutMembershipProof::new(0, 0, Default::default())
                 })
                 .collect();
 

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -1229,11 +1229,11 @@ pub mod tx_out_store_tests {
             /*
                 The proof-of-membership for TxOut 3 should include the following ranges/hashes:
 
-                               _____________H(0,7)_________
+                               _______________|____________
                                |                          |
-                         ____H(0,3)_____                H(4,7)
+                         ______|________               H(4,7)
                         |              |
-                     H(0,1)          H(2,3)
+                     H(0,1)          __.____
                                     |      |
                                  H(2,2)  H(3,3)
                                    |       |
@@ -1245,10 +1245,10 @@ pub mod tx_out_store_tests {
 
             let ranges: Vec<Range> = proof.elements.iter().map(|e| e.range).collect();
 
-            assert!(ranges.contains(&Range::new(3, 3).unwrap()));
-            assert!(ranges.contains(&Range::new(2, 2).unwrap()));
-            assert!(ranges.contains(&Range::new(0, 1).unwrap()));
-            assert!(ranges.contains(&Range::new(4, 7).unwrap()));
+            assert_eq!(ranges[0], Range::new(3, 3).unwrap());
+            assert_eq!(ranges[1], Range::new(2, 2).unwrap());
+            assert_eq!(ranges[2], Range::new(0, 1).unwrap());
+            assert_eq!(ranges[3], Range::new(4, 7).unwrap());
 
             for element in proof.elements {
                 let expected_hash = tx_out_store
@@ -1270,11 +1270,11 @@ pub mod tx_out_store_tests {
             /*
                 The proof-of-membership for TxOut 5 should include the following ranges/hashes:
 
-                               __________H(0,7)___________________
+                               _____________|_____________________
                                |                                  |
-                            H(0,3)                       ______ H(4,7)_____
+                            H(0,3)                       _________|________
                                                          |                |
-                                                   ___H(4,5)__          H(6,7) = H(Nil)
+                                                   ______|____          H(6,7) = H(Nil)
                                                    |         |
                                                  H(4,4)   H(5,5)
                                                    |        |
@@ -1287,10 +1287,10 @@ pub mod tx_out_store_tests {
             let ranges: Vec<Range> = proof.elements.iter().map(|e| e.range).collect();
 
             println!("{:?}", ranges);
-            assert!(ranges.contains(&Range::new(4, 4).unwrap()));
-            assert!(ranges.contains(&Range::new(5, 5).unwrap()));
-            assert!(ranges.contains(&Range::new(6, 7).unwrap()));
-            assert!(ranges.contains(&Range::new(0, 3).unwrap()));
+            assert_eq!(ranges[0], Range::new(5, 5).unwrap());
+            assert_eq!(ranges[1], Range::new(4, 4).unwrap());
+            assert_eq!(ranges[2], Range::new(6, 7).unwrap());
+            assert_eq!(ranges[3], Range::new(0, 3).unwrap());
 
             for element in proof.elements {
                 let expected_hash = if element.range.from >= num_tx_outs as u64 {

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -15,6 +15,7 @@ test-net-fee-keys = []
 # External dependencies
 cfg-if = "0.1"
 digest = { version = "0.9", default-features = false }
+displaydoc = { version = "0.1", default-features = false }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
 generic-array = { version = "0.14", features = ["serde"] }
 hex_fmt = "0.3"

--- a/transaction/core/src/membership_proofs/errors.rs
+++ b/transaction/core/src/membership_proofs/errors.rs
@@ -1,29 +1,31 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use crate::range;
-use failure::Fail;
+use displaydoc::Display;
 
 /// Reasons why a creating or validating a proof of membership might fail.
-#[derive(Debug, Fail, PartialEq)]
+#[derive(Debug, Display, PartialEq)]
 pub enum Error {
-    /// Contains incorrect leaf hash.
-    #[fail(display = "Incorrect hash for leaf: {}", 0)]
+    /// Contains incorrect leaf hash: {0}
     IncorrectLeafHash(u64),
 
-    /// Missing hash for leaf.
-    #[fail(display = "Missing hash for leaf: {}", 0)]
+    /// Missing hash for leaf: {0}
     MissingLeafHash(u64),
 
-    /// Invalid Range.
-    #[fail(display = "Invalid range")]
+    /// Invalid Range: {0}
     RangeError(range::RangeError),
 
+    /// An unexpected tx out membership element was provided, which was not adjacent to the preceding elements, at index {0}
+    UnexpectedMembershipElement(usize),
+
+    /// The value provided for proof.highest_index doesn't match the other data
+    HighestIndexMismatch,
+
     /// Failed to serialize a TxOut.
-    #[fail(display = "TxOutSerializationError")]
     TxOutSerializationError,
 
-    #[fail(display = "CapacityExceeded")]
-    CapacityExceeded,
+    /// Numeric limits exceeded
+    NumericLimitsExceeded,
 }
 
 impl From<mc_util_serial::encode::Error> for Error {

--- a/transaction/core/src/membership_proofs/errors.rs
+++ b/transaction/core/src/membership_proofs/errors.rs
@@ -21,6 +21,9 @@ pub enum Error {
     /// The value provided for proof.highest_index doesn't match the other data
     HighestIndexMismatch,
 
+    /// The implied merkle root's range doesn't cover 0
+    RootNotCoveringZero,
+
     /// Failed to serialize a TxOut.
     TxOutSerializationError,
 

--- a/transaction/core/src/range.rs
+++ b/transaction/core/src/range.rs
@@ -9,6 +9,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct RangeError {}
 
+impl core::fmt::Display for RangeError {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(fmt, "Invalid range")
+    }
+}
+
 /// A range [from,to] of indices.
 #[derive(Clone, Copy, Deserialize, Eq, Hash, PartialEq, Serialize, Message, Digestible)]
 pub struct Range {

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -302,16 +302,16 @@ fn validate_membership_proofs(
                 return Err(TransactionValidationError::InvalidLedgerContext);
             }
             Ok(derived_proof) => {
-                match derived_proof.elements.last() {
-                    None => {
+                match crate::membership_proofs::compute_implied_merkle_root(&derived_proof) {
+                    Err(_) => {
                         return Err(TransactionValidationError::InvalidLedgerContext);
                     }
-                    Some(element) => {
+                    Ok(root_element) => {
                         // Check the tx_out's membership proof against this root hash.
                         match is_membership_proof_valid(
                             tx_out_with_proofs.tx_out,
                             tx_out_with_proofs.membership_proof,
-                            element.hash.as_ref(),
+                            root_element.hash.as_ref(),
                         ) {
                             Err(_e) => {
                                 return Err(


### PR DESCRIPTION
The previous merkle proof has the following structure:

- index (indicates which number leaf this TxOut is in the merkle tree)
- highest_index (indicates how many TxOuts are in the merkle tree at time of proof)
- several TxOutMembershipElements, which include a hash corresponding to
  an internal node in the tree, and a range explaining which leafs
  are covered by this hash

The previous merkle proof validation routine assumes no particular structure
on the membership elements, it sorts them, throws them into hash maps,
etc. and as a result it is complicated and leaks information about the
path that the merkle proof is following over side channels. Because the
path determines the entire merkle proof, this means that we leak the
whole thing, in the SGX security model.

This PR does the following:

- Introduce a `compose_adjacent_membership_elements` function
  which takes two membership elements, checks if their ranges are
  adjacent in the tree, and computes the hash of their parent in
  the tree if so. This uses subtle constant time equality tests
  and conditional assignments to ensure that there are no branches
  at all, except leading to erroring code paths.
- Merkle proof validation then works strictly from the bottom up,
  using `try_fold` to fold successive membership elements from
  the membership proof together, and deducing the implied root
  element hash as a result.
  Finally we check the implied root element hash against the known
  root element hash.
- This imposes constraints on what protobufs are valid merkle proofs.
  The new routine won't accept proofs in arbitrary order, they must
  be in the order that makes validation easy. It is okay to push
  work from the server to the clients in this way. (IMO)
- This also changes the merkle proof generation code to follow this
  format. It turns out that generating the proofs in this order is
  quite easy as well -- the only reason they could end up in a wierd
  order is because of the hashmap or because of sorting ambiguities,
  for example, every proof should actually contain two leaves.

Not all the tests have been fixed yet, but this draft shows the basic idea.

One thing that we could do that might make this simpler still is,
in the TxOutMembershipProof, add a separate "leaf hash" field corresponding
to the hash of the leaf at `proof.index`, and don't make a separate membership
element for this leaf. This will make some types of invalid merkle proofs
unrepresentable, and so reduce the number of error conditions of the
validation routine, essentially pushing some of the error handling
into the protobuf layer. I tried to avoid changing any proto types
in this commit though.

---

One possibly significant motivation for this PR is that, after this PR, we no longer have the "internal nodes" in the merkle proof elements set, we only have the "other nodes" (see get_merkle_proof routine for variables with these names).
Basically, in the previous implementation, not only does the memebership proof contain the inputs to the hash function that are needed to verify the proof, it also contains all the intermediate hash values, which would be implied by the other data. This was needed to make the top-down validation approach work. But after the bottom-up validation approach is used, we don't need those hashes at all. This makes the proofs half the size, so if the tree has height 30, instead of 1800 bytes worth of merkle proof data, we only have 900 bytes worth of merkle proof data. This also allows to delete some unnecessary code when implementing the routine that "derives merkle proof at index"