### PR TITLE
[MCC-695] Unit tests for onetime_keys

### DIFF
--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -525,7 +525,7 @@ fn mint_aggregate_fee(tx_private_key: &RistrettoPrivate, total_fee: u64) -> Resu
 
     // Create a single TxOut
     let fee_output: TxOut = {
-        let target_key = create_onetime_public_key(&fee_recipient, tx_private_key).into();
+        let target_key = create_onetime_public_key(tx_private_key, &fee_recipient).into();
         let public_key =
             create_tx_public_key(&tx_private_key, fee_recipient.spend_public_key()).into();
         let amount = {

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -793,12 +793,11 @@ pub mod tx_out_store_tests {
             let tx_private_key = RistrettoPrivate::from_random(&mut rng);
             let target_key =
                 create_onetime_public_key(&recipient_account.default_subaddress(), &tx_private_key);
-            let public_key = compute_tx_pubkey(
+            let public_key = create_tx_public_key(
                 &tx_private_key,
                 recipient_account.default_subaddress().spend_public_key(),
             );
-            let shared_secret: RistrettoPublic =
-                compute_shared_secret(&target_key, &tx_private_key);
+            let shared_secret: RistrettoPublic = create_shared_secret(&target_key, &tx_private_key);
             let amount = Amount::new(value, &shared_secret).unwrap();
             let tx_out = TxOut {
                 amount,

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -792,7 +792,7 @@ pub mod tx_out_store_tests {
         for _i in 0..num_tx_outs {
             let tx_private_key = RistrettoPrivate::from_random(&mut rng);
             let target_key =
-                create_onetime_public_key(&recipient_account.default_subaddress(), &tx_private_key);
+                create_onetime_public_key(&tx_private_key, &recipient_account.default_subaddress());
             let public_key = create_tx_public_key(
                 &tx_private_key,
                 recipient_account.default_subaddress().spend_public_key(),

--- a/mobilecoind/src/sync.rs
+++ b/mobilecoind/src/sync.rs
@@ -32,7 +32,7 @@ use mc_crypto_keys::RistrettoPublic;
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_transaction_core::{
     get_tx_out_shared_secret,
-    onetime_keys::{recover_onetime_private_key, subaddress_for_key},
+    onetime_keys::{recover_onetime_private_key, recover_public_subaddress_spend_key},
     ring_signature::KeyImage,
     tx::TxOut,
 };
@@ -348,7 +348,7 @@ fn match_tx_outs_into_utxos(
         let tx_out_target_key = RistrettoPublic::try_from(&tx_out.target_key)?;
         let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key)?;
 
-        let subaddress_spk = SubaddressSPKId::from(&subaddress_for_key(
+        let subaddress_spk = SubaddressSPKId::from(&recover_public_subaddress_spend_key(
             &view_key.view_private_key,
             &tx_out_target_key,
             &tx_public_key,

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -12,7 +12,7 @@ extern crate std;
 #[macro_use]
 extern crate lazy_static;
 
-use crate::onetime_keys::compute_shared_secret;
+use crate::onetime_keys::create_shared_secret;
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 
 pub mod amount;
@@ -47,5 +47,5 @@ pub fn get_tx_out_shared_secret(
     view_key: &RistrettoPrivate,
     tx_public_key: &RistrettoPublic,
 ) -> RistrettoPublic {
-    compute_shared_secret(tx_public_key, view_key)
+    create_shared_secret(tx_public_key, view_key)
 }

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -180,20 +180,20 @@ pub fn recover_onetime_private_key(
     RistrettoPrivate::from(x)
 }
 
-/// Computes the shared secret `aB` from a private key `a` and a public key `B`.
+/// Computes the shared secret `xY` from a private key `x` and a public key `Y`.
 ///
 /// # Arguments
-/// * `public_key` - A public key `B`.
-/// * `private_key` - A private key `a`
+/// * `public_key` - A public key `Y`.
+/// * `private_key` - A private key `x`
 pub fn compute_shared_secret(
     public_key: &RistrettoPublic,
     private_key: &RistrettoPrivate,
 ) -> RistrettoPublic {
-    let a = private_key.as_ref();
-    let B = public_key.as_ref();
-    let aB = a * B;
+    let x = private_key.as_ref();
+    let Y = public_key.as_ref();
+    // let xY = x * Y;
 
-    RistrettoPublic::from(aB)
+    RistrettoPublic::from(x * Y)
 }
 
 /// Generate a tx keypair for a subaddress transaction

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -369,8 +369,6 @@ mod tests {
         ));
     }
 
-    // TODO: test recover_onetime_private_key
-
     #[test]
     // Returns the private key corresponding to `onetime_public_key`.
     fn test_recover_onetime_private_key_valid_keypair() {
@@ -426,5 +424,19 @@ mod tests {
         assert!(onetime_public_key != RistrettoPublic::from(&onetime_private_key));
     }
 
-    // TODO: test create_shared_secret
+    #[test]
+    // shared_secret(a,B) should equal shared_secret(b,A)
+    fn test_create_shared_secret_is_symmetric() {
+        let mut rng = McRng::default();
+        let a = RistrettoPrivate::from_random(&mut rng);
+        let A = RistrettoPublic::from(&a);
+
+        let b = RistrettoPrivate::from_random(&mut rng);
+        let B = RistrettoPublic::from(&b);
+
+        let aB = create_shared_secret(&B, &a);
+        let bA = create_shared_secret(&A, &b);
+
+        assert_eq!(aB, bA);
+    }
 }

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -242,8 +242,6 @@ mod tests {
         (c, d, subaddress)
     }
 
-    // TODO: test hash_to_scalar
-
     #[test]
     // `create_onetime_public_key` should produce a public key that agrees with the recipient's view key.
     fn test_create_onetime_public_key() {
@@ -270,7 +268,22 @@ mod tests {
         );
     }
 
-    // TODO: test_create_tx_public_key
+    #[test]
+    // Should return `r * D`.
+    fn test_create_tx_public_key() {
+        let mut rng = McRng::default();
+        let r = Scalar::random(&mut rng);
+        let D = RistrettoPoint::random(&mut rng);
+
+        let expected = RistrettoPublic::from(r * D);
+
+        let tx_private_key = RistrettoPrivate::from(r);
+        let recipient_spend_key = RistrettoPublic::from(D);
+        assert_eq!(
+            expected,
+            create_tx_public_key(&tx_private_key, &recipient_spend_key)
+        );
+    }
 
     #[test]
     // Should recover the correct public subaddress spend key D_i when the output belongs to the recipient.

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -239,17 +239,16 @@ mod tests {
         (c, d, subaddress)
     }
 
-    // hash_to_scalar should agree with test vectors
+    // TODO: test hash_to_scalar
 
     #[test]
     // `create_onetime_public_key` should produce a public key that agrees with the recipient's view key.
     fn test_create_onetime_public_key() {
         let mut rng = McRng::default();
-        let tx_private_key = RistrettoPrivate::from_random(&mut rng);
-
         let account: AccountKey = AccountKey::random(&mut rng);
         let recipient = account.default_subaddress();
 
+        let tx_private_key = RistrettoPrivate::from_random(&mut rng);
         let (onetime_public_key, tx_public_key) =
             get_output_public_keys(&tx_private_key, &recipient);
 
@@ -267,6 +266,8 @@ mod tests {
             "The one-time public key should not match other view keys."
         );
     }
+
+    // TODO: test_create_tx_public_key
 
     #[test]
     // Should recover the correct public subaddress spend key D_i when the output belongs to the recipient.
@@ -332,6 +333,10 @@ mod tests {
         assert!(D_prime != *recipient.spend_public_key());
     }
 
+    // TODO: test view_key_matches_output
+
+    // TODO: test recover_onetime_private_key
+
     #[test]
     // `recover_onetime_private_key` should return a valid Public/Private key pair.
     fn test_recover_onetime_private_key_valid_keypair() {
@@ -357,4 +362,6 @@ mod tests {
             RistrettoPublic::from(&onetime_private_key)
         );
     }
+
+    // TODO: test create_shared_secret
 }

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -55,7 +55,7 @@
 
 #![allow(non_snake_case)]
 
-use crate::domain_separators::{HASH_TO_POINT_DOMAIN_TAG, HASH_TO_SCALAR_DOMAIN_TAG};
+use crate::domain_separators::HASH_TO_SCALAR_DOMAIN_TAG;
 use blake2::{Blake2b, Digest};
 use curve25519_dalek::{
     constants::RISTRETTO_BASEPOINT_POINT, ristretto::RistrettoPoint, scalar::Scalar,
@@ -66,14 +66,6 @@ use mc_util_from_random::FromRandom;
 use rand_core::{CryptoRng, RngCore};
 
 const G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
-
-/// Applies a hash function and returns a RistrettoPoint.
-pub fn hash_to_point(ristretto_public: &RistrettoPublic) -> RistrettoPoint {
-    let mut hasher = Blake2b::new();
-    hasher.update(&HASH_TO_POINT_DOMAIN_TAG);
-    hasher.update(&ristretto_public.to_bytes());
-    RistrettoPoint::from_hash(hasher)
-}
 
 /// Applies a hash function and returns a Scalar.
 pub fn hash_to_scalar<B: AsRef<[u8]>>(data: B) -> Scalar {

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -78,10 +78,10 @@ fn hash_to_scalar(point: RistrettoPoint) -> Scalar {
     Scalar::from_hash::<Blake2b>(hasher)
 }
 
-/// Creates the onetime public key `Hs( r * C ) * G + D`.
+/// Creates onetime_public_key `Hs( r * C ) * G + D` for an output sent to subaddress (C, D).
 ///
 /// # Arguments
-/// * `tx_private_key` - The transaction private key `r`. Must be unique for each output.
+/// * `tx_private_key` - The output's tx_private_key `r`. Must be unique for each output.
 /// * `recipient` - The recipient subaddress `(C,D)`.
 ///
 pub fn create_onetime_public_key(
@@ -124,7 +124,7 @@ pub fn create_tx_public_key(
 ///
 /// # Arguments
 /// * `view_private_key` - The recipient's view private key `a`.
-/// * `onetime_public_key` - The output's onetime public key.
+/// * `onetime_public_key` - The output's onetime_public_key.
 /// * `tx_public_key` - The output's tx_public_key.
 ///
 pub fn recover_public_subaddress_spend_key(
@@ -147,7 +147,7 @@ pub fn recover_public_subaddress_spend_key(
 ///
 /// # Arguments
 /// * `recipient` - The recipient's i^th subaddress view key `(a, D_i)`.
-/// * `onetime_public_key` - The output's onetime_key
+/// * `onetime_public_key` - The output's onetime_public_key
 /// * `tx_public_key` - The output's tx_public_key `R`.
 ///
 pub fn view_key_matches_output(
@@ -265,71 +265,4 @@ mod tests {
             RistrettoPublic::from(&onetime_private_key)
         );
     }
-
-    //    #[bench]
-    //    // Microbenchmark `view_key_matches_output` with a non-matching view key.
-    //    fn bench_tx_target_miss(bencher: &mut Bencher) {
-    //        let mut rng = McRng::default();
-    //        let account_key = AccountKey::random(&mut rng);
-    //        let view_key = account_key.view_key();
-    //        let miss_key = AccountKey::random(&mut rng);
-    //        let tx_key = generate_keypair(&mut rng);
-    //        let output_key = create_onetime_public_key(&miss_key.address(), 0, &tx_key.1);
-    //
-    //        bencher.iter(|| {
-    //            let res = view_key_matches_output(&view_key, &output_key, 0, &tx_key.0);
-    //            assert_eq!(res, false);
-    //        });
-    //    }
-    //
-    //    #[bench]
-    //    // Microbenchmark `view_key_matches_output` with a matching a view key.
-    //    fn bench_tx_target_hit(bencher: &mut Bencher) {
-    //        let mut rng = McRng::default();
-    //        let account_key = AccountKey::random(&mut rng);
-    //        let view_key = account_key.view_key();
-    //        let tx_key = generate_keypair(&mut rng);
-    //        let output_key = create_onetime_public_key(&account_key.address(), 0, &tx_key.1);
-    //
-    //        bencher.iter(|| {
-    //            let res = view_key_matches_output(&view_key, &output_key, 0, &tx_key.0);
-    //            assert_eq!(res, true);
-    //        });
-    //    }
-    //
-    //    #[bench]
-    //    // Benchmark `view_key_matches_output` with non-matching view keys in a batch setting.
-    //    fn bench_tx_target_miss_batch(bencher: &mut Bencher) {
-    //        let mut rng = McRng::default();
-    //        let NUM_ACCTS = 2;
-    //        let NUM_OUTPUTS = 2;
-    //
-    //        let account_keys = (0..NUM_ACCTS).map(|_| AccountKey::random(&mut rng));
-    //        let view_keys: Vec<ViewKey> = account_keys.map(|acct| acct.view_key()).collect();
-    //        let miss_key = AccountKey::random(&mut rng);
-    //        let mut tx_pub_keys = vec![];
-    //        let mut tx_secret_keys = vec![];
-    //        (0..NUM_OUTPUTS).for_each(|_| {
-    //            let tx_key = generate_keypair(&mut rng);
-    //            tx_pub_keys.push(tx_key.0);
-    //            tx_secret_keys.push(tx_key.1);
-    //        });
-    //        let output_keys: Vec<RistrettoPublic> = (0..NUM_OUTPUTS)
-    //            .map(|i| create_onetime_public_key(&miss_key.address(), 0, &tx_secret_keys[i]))
-    //            .collect();
-    //
-    //        bencher.iter(|| {
-    //            for (output_index, output_key) in output_keys.iter().enumerate() {
-    //                for view_key in view_keys.iter() {
-    //                    let res = view_key_matches_output(
-    //                        &view_key,
-    //                        output_key,
-    //                        0,
-    //                        &tx_pub_keys[output_index],
-    //                    );
-    //                    assert_eq!(res, false);
-    //                }
-    //            }
-    //        });
-    //    }
 }

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -236,7 +236,7 @@ mod tests {
 
         // (View, Spend)
         let (C, D) = (RistrettoPublic::from(&c), RistrettoPublic::from(&d));
-        // Look out! The argument ordering here ie weird.
+        // Look out! The argument ordering here is weird.
         let subaddress = PublicAddress::new(&D, &C);
 
         (c, d, subaddress)

--- a/transaction/core/src/ring_signature/key_image.rs
+++ b/transaction/core/src/ring_signature/key_image.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use super::Error;
-use crate::{onetime_keys::hash_to_point, ring_signature::Scalar};
+use crate::ring_signature::{hash_to_point, Scalar};
 use core::{convert::TryFrom, fmt};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use mc_crypto_digestible::Digestible;

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -18,8 +18,7 @@ use crate::{
     commitment::Commitment,
     compressed_commitment::CompressedCommitment,
     domain_separators::RING_MLSAG_CHALLENGE_DOMAIN_TAG,
-    onetime_keys::hash_to_point,
-    ring_signature::{CurveScalar, Error, KeyImage, Scalar, GENERATORS},
+    ring_signature::{hash_to_point, CurveScalar, Error, KeyImage, Scalar, GENERATORS},
 };
 
 /// MLSAG for a ring of public keys and amount commitments.

--- a/transaction/core/src/ring_signature/mod.rs
+++ b/transaction/core/src/ring_signature/mod.rs
@@ -4,11 +4,15 @@
 #![macro_use]
 extern crate alloc;
 
+use crate::domain_separators::HASH_TO_POINT_DOMAIN_TAG;
+use blake2::{Blake2b, Digest};
 use bulletproofs::{BulletproofGens, PedersenGens};
+use curve25519_dalek::ristretto::RistrettoPoint;
 pub use curve25519_dalek::scalar::Scalar;
 pub use curve_scalar::*;
 pub use error::Error;
 pub use key_image::*;
+use mc_crypto_keys::RistrettoPublic;
 pub use mlsag::*;
 pub use rct_bulletproofs::*;
 
@@ -27,4 +31,12 @@ lazy_static! {
     /// be at least 2 * MAX_INPUTS + MAX_OUTPUTS, which allows for inputs, pseudo outputs, and outputs.
     pub static ref BP_GENERATORS: BulletproofGens =
         BulletproofGens::new(64, 64);
+}
+
+/// Applies a hash function and returns a RistrettoPoint.
+pub fn hash_to_point(ristretto_public: &RistrettoPublic) -> RistrettoPoint {
+    let mut hasher = Blake2b::new();
+    hasher.update(&HASH_TO_POINT_DOMAIN_TAG);
+    hasher.update(&ristretto_public.to_bytes());
+    RistrettoPoint::from_hash(hasher)
 }

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -263,7 +263,7 @@ impl TxOut {
         tx_private_key: &RistrettoPrivate,
         hint: EncryptedFogHint,
     ) -> Result<Self, AmountError> {
-        let target_key = create_onetime_public_key(recipient, tx_private_key).into();
+        let target_key = create_onetime_public_key(tx_private_key, recipient).into();
         let public_key = create_tx_public_key(tx_private_key, recipient.spend_public_key()).into();
 
         let amount = {

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -23,7 +23,7 @@ use crate::{
     domain_separators::TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG,
     encrypted_fog_hint::EncryptedFogHint,
     get_tx_out_shared_secret,
-    onetime_keys::{compute_shared_secret, compute_tx_pubkey, create_onetime_public_key},
+    onetime_keys::{create_onetime_public_key, create_shared_secret, create_tx_public_key},
     range::Range,
     ring_signature::{KeyImage, SignatureRctBulletproofs},
     CompressedCommitment,
@@ -264,10 +264,10 @@ impl TxOut {
         hint: EncryptedFogHint,
     ) -> Result<Self, AmountError> {
         let target_key = create_onetime_public_key(recipient, tx_private_key).into();
-        let public_key = compute_tx_pubkey(tx_private_key, recipient.spend_public_key()).into();
+        let public_key = create_tx_public_key(tx_private_key, recipient.spend_public_key()).into();
 
         let amount = {
-            let shared_secret = compute_shared_secret(recipient.view_public_key(), tx_private_key);
+            let shared_secret = create_shared_secret(recipient.view_public_key(), tx_private_key);
             Amount::new(value, &shared_secret)
         }?;
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -12,7 +12,7 @@ use mc_transaction_core::{
     constants::MINIMUM_FEE,
     encrypted_fog_hint::EncryptedFogHint,
     fog_hint::FogHint,
-    onetime_keys::compute_shared_secret,
+    onetime_keys::create_shared_secret,
     ring_signature::SignatureRctBulletproofs,
     tx::{Tx, TxIn, TxOut, TxOutConfirmationNumber, TxPrefix},
     CompressedCommitment,
@@ -166,7 +166,7 @@ impl TransactionBuilder {
         for input_credential in &self.input_credentials {
             let onetime_private_key = input_credential.onetime_private_key;
             let amount = &input_credential.ring[input_credential.real_index].amount;
-            let shared_secret = compute_shared_secret(
+            let shared_secret = create_shared_secret(
                 &input_credential.real_output_public_key,
                 &input_credential.view_private_key,
             );
@@ -215,7 +215,7 @@ fn create_output<RNG: CryptoRng + RngCore>(
     let private_key = RistrettoPrivate::from_random(rng);
     let hint = create_fog_hint(recipient, ingest_pubkey, rng)?;
     let tx_out = TxOut::new(value, recipient, &private_key, hint)?;
-    let shared_secret = compute_shared_secret(recipient.view_public_key(), &private_key);
+    let shared_secret = create_shared_secret(recipient.view_public_key(), &private_key);
     Ok((tx_out, shared_secret))
 }
 


### PR DESCRIPTION
Soundtrack of this PR: [Raio](https://www.youtube.com/watch?v=i3Z4isDQaiw)

### Motivation

onetime_keys.rs defines several functions used by a sender to create a transaction output, and used by the receiver to determine that they own the output and spend it. The code here has gone through a few a few stages, and so some names and doc comments are out of date or inconsistent. It is also thin on unit tests.

### In this PR
* Adds a module-level doc comment explaining how account keys, subaddresses, and output public keys are related.
* Removes an unused function.
* Moves a function that is not used when working with onetime keys.
* Lots of tweaks for clarity, brevity, and consistency.
* Adds unit tests

### Future Work
* Use proptest to increase testing coverage.

