### PR TITLE
MCC-613 Reduce encrypted fog hint size to what is actually needed

### DIFF
--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -194,7 +194,7 @@ message TxOut {
     // Encrypted fog hint payload.
     // This is an mc-crypto-box cryptogram for the fog ingest server,
     // or a random cryptogram indistinguishable from a real one.
-    EncryptedFogHint e_account_hint = 4;
+    EncryptedFogHint e_fog_hint = 4;
 }
 
 message TxIn {

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -191,7 +191,9 @@ message TxOut {
     // Public key.
     CompressedRistretto public_key = 3;
 
-    // 128 byte encrypted fog hint
+    // Encrypted fog hint payload.
+    // This is an mc-crypto-box cryptogram for the fog ingest server,
+    // or a random cryptogram indistinguishable from a real one.
     EncryptedFogHint e_account_hint = 4;
 }
 

--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -494,8 +494,8 @@ impl From<&tx::TxOut> for external::TxOut {
         let public_key_bytes = source.public_key.as_bytes().to_vec();
         tx_out.mut_public_key().set_data(public_key_bytes);
 
-        let hint_bytes = source.e_account_hint.as_ref().to_vec();
-        tx_out.mut_e_account_hint().set_data(hint_bytes);
+        let hint_bytes = source.e_fog_hint.as_ref().to_vec();
+        tx_out.mut_e_fog_hint().set_data(hint_bytes);
 
         tx_out
     }
@@ -518,14 +518,14 @@ impl TryFrom<&external::TxOut> for tx::TxOut {
             .map_err(|_| ConversionError::KeyCastError)?
             .into();
 
-        let e_account_hint = EncryptedFogHint::try_from(source.get_e_account_hint().get_data())
+        let e_fog_hint = EncryptedFogHint::try_from(source.get_e_fog_hint().get_data())
             .map_err(|_| ConversionError::ArrayCastError)?;
 
         let tx_out = tx::TxOut {
             amount,
             target_key,
             public_key,
-            e_account_hint,
+            e_fog_hint,
         };
         Ok(tx_out)
     }
@@ -1106,7 +1106,7 @@ mod conversion_tests {
             amount: Amount::new(1u64 << 13, &RistrettoPublic::from_random(&mut rng)).unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
-            e_account_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
+            e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
         };
 
         let converted = external::TxOut::from(&source);

--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -905,6 +905,7 @@ mod conversion_tests {
     use super::*;
     use mc_crypto_keys::Ed25519Private;
     use mc_transaction_core::{
+        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN,
         onetime_keys::recover_onetime_private_key,
         tx::{Tx, TxOut, TxOutMembershipProof},
     };
@@ -1105,7 +1106,7 @@ mod conversion_tests {
             amount: Amount::new(1u64 << 13, &RistrettoPublic::from_random(&mut rng)).unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
-            e_account_hint: (&[0u8; 128]).into(),
+            e_account_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
         };
 
         let converted = external::TxOut::from(&source);

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -540,7 +540,7 @@ fn mint_aggregate_fee(tx_private_key: &RistrettoPrivate, total_fee: u64) -> Resu
             amount,
             target_key,
             public_key,
-            e_account_hint: Default::default(),
+            e_fog_hint: Default::default(),
         }
     };
 

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -804,7 +804,7 @@ pub mod tx_out_store_tests {
                 amount,
                 target_key: target_key.into(),
                 public_key: public_key.into(),
-                e_account_hint: EncryptedFogHint::new(&[7u8; ENCRYPTED_FOG_HINT_LEN]),
+                e_fog_hint: EncryptedFogHint::new(&[7u8; ENCRYPTED_FOG_HINT_LEN]),
             };
             tx_outs.push(tx_out);
         }

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -752,7 +752,7 @@ pub mod tx_out_store_tests {
     use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
     use mc_transaction_core::{
         amount::Amount,
-        encrypted_fog_hint::EncryptedFogHint,
+        encrypted_fog_hint::{EncryptedFogHint, ENCRYPTED_FOG_HINT_LEN},
         membership_proofs::{hash_leaf, hash_nodes, NIL_HASH},
         onetime_keys::*,
         range::Range,
@@ -804,7 +804,7 @@ pub mod tx_out_store_tests {
                 amount,
                 target_key: target_key.into(),
                 public_key: public_key.into(),
-                e_account_hint: EncryptedFogHint::new(&[7u8; 128]),
+                e_account_hint: EncryptedFogHint::new(&[7u8; ENCRYPTED_FOG_HINT_LEN]),
             };
             tx_outs.push(tx_out);
         }

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -187,7 +187,7 @@ mod test {
             amount: Amount::new(1u64 << 13, &RistrettoPublic::from_random(&mut rng)).unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
-            e_account_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
+            e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
         };
 
         let subaddress_index = 123;
@@ -271,7 +271,7 @@ mod test {
                 amount: Amount::new(1u64 << 13, &RistrettoPublic::from_random(&mut rng)).unwrap(),
                 target_key: RistrettoPublic::from_random(&mut rng).into(),
                 public_key: RistrettoPublic::from_random(&mut rng).into(),
-                e_account_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
+                e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
             };
 
             let subaddress_index = 123;

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -171,7 +171,7 @@ mod test {
     use super::*;
     use mc_crypto_keys::RistrettoPublic;
     use mc_ledger_db::Ledger;
-    use mc_transaction_core::amount::Amount;
+    use mc_transaction_core::{amount::Amount, encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN};
     use mc_transaction_core_test_utils::{
         create_ledger, create_transaction, initialize_ledger, AccountKey,
     };
@@ -187,7 +187,7 @@ mod test {
             amount: Amount::new(1u64 << 13, &RistrettoPublic::from_random(&mut rng)).unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
-            e_account_hint: (&[0u8; 128]).into(),
+            e_account_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
         };
 
         let subaddress_index = 123;
@@ -271,7 +271,7 @@ mod test {
                 amount: Amount::new(1u64 << 13, &RistrettoPublic::from_random(&mut rng)).unwrap(),
                 target_key: RistrettoPublic::from_random(&mut rng).into(),
                 public_key: RistrettoPublic::from_random(&mut rng).into(),
-                e_account_hint: (&[0u8; 128]).into(),
+                e_account_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
             };
 
             let subaddress_index = 123;

--- a/transaction/core/src/encrypted_fog_hint.rs
+++ b/transaction/core/src/encrypted_fog_hint.rs
@@ -10,7 +10,7 @@
 use alloc::{vec, vec::Vec};
 use core::{convert::TryFrom, fmt};
 use generic_array::{
-    typenum::{Diff, Unsigned, U128},
+    typenum::{Diff, Unsigned, U90},
     GenericArray,
 };
 use mc_crypto_box::{CryptoBox, VersionedCryptoBox};
@@ -26,9 +26,9 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 // The length of the encrypted fog hint field in the ledger.
-// Must be at least as large as McRistrettoBox::FooterSize, or it can't hold a
-// Ristretto-Box encryption.
-pub type EncryptedFogHintSize = U128;
+// Must be at least as large as mc_crypto_box::VersionedCryptoBox::FooterSize.
+// Footersize = 50, + 32 for one curve point, + 8 bytes of magic / padding space for future needs
+pub type EncryptedFogHintSize = U90;
 pub const ENCRYPTED_FOG_HINT_LEN: usize = EncryptedFogHintSize::USIZE;
 
 type Bytes = GenericArray<u8, EncryptedFogHintSize>;

--- a/transaction/core/src/encrypted_fog_hint.rs
+++ b/transaction/core/src/encrypted_fog_hint.rs
@@ -10,7 +10,7 @@
 use alloc::{vec, vec::Vec};
 use core::{convert::TryFrom, fmt};
 use generic_array::{
-    typenum::{Diff, Unsigned, U90},
+    typenum::{Diff, Unsigned, U84},
     GenericArray,
 };
 use mc_crypto_box::{CryptoBox, VersionedCryptoBox};
@@ -27,8 +27,8 @@ use serde::{Deserialize, Serialize};
 
 // The length of the encrypted fog hint field in the ledger.
 // Must be at least as large as mc_crypto_box::VersionedCryptoBox::FooterSize.
-// Footersize = 50, + 32 for one curve point, + 8 bytes of magic / padding space for future needs
-pub type EncryptedFogHintSize = U90;
+// Footersize = 50, + 32 for one curve point, + 2 bytes of magic / padding space for future needs
+pub type EncryptedFogHintSize = U84;
 pub const ENCRYPTED_FOG_HINT_LEN: usize = EncryptedFogHintSize::USIZE;
 
 type Bytes = GenericArray<u8, EncryptedFogHintSize>;

--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -74,7 +74,7 @@ impl FogHint {
     /// * ingest_server_pubkey (to encrypt against)
     ///
     /// # Returns
-    /// * 128 byte payload, cannot fail
+    /// * Encrypted fog hint payload, cannot fail
     pub fn encrypt<T: RngCore + CryptoRng>(
         &self,
         ingest_server_pubkey: &RistrettoPublic,
@@ -101,7 +101,7 @@ impl FogHint {
     ///
     /// # Arguments
     /// * acct_server_private_key
-    /// * 128 byte encrypted payload
+    /// * EncryptedFogHint payload
     ///
     /// # Returns
     /// * Fog hint on success, cryptobox error otherwise
@@ -127,7 +127,7 @@ impl FogHint {
     ///
     /// # Arguments
     /// * ingest_server_private_key
-    /// * 128 byte encrypted payload
+    /// * encrypted fog hint payload
     ///
     /// # Returns
     /// * (Fog hint, true) on success (Default Fog hint, false) otherwise

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -246,7 +246,7 @@ pub struct TxOut {
 
     /// The encrypted account hint for the account server.
     #[prost(message, required, tag = "4")]
-    pub e_account_hint: EncryptedFogHint,
+    pub e_fog_hint: EncryptedFogHint,
 }
 
 impl TxOut {
@@ -275,7 +275,7 @@ impl TxOut {
             amount,
             target_key,
             public_key,
-            e_account_hint: hint,
+            e_fog_hint: hint,
         })
     }
 
@@ -490,7 +490,7 @@ mod tests {
                 amount,
                 target_key,
                 public_key,
-                e_account_hint: EncryptedFogHint::from(&[1u8; ENCRYPTED_FOG_HINT_LEN]),
+                e_fog_hint: EncryptedFogHint::from(&[1u8; ENCRYPTED_FOG_HINT_LEN]),
             }
         };
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -490,7 +490,7 @@ mod tests {
                 amount,
                 target_key,
                 public_key,
-                e_account_hint: EncryptedFogHint::from(&[1u8; 128]),
+                e_account_hint: EncryptedFogHint::from(&[1u8; ENCRYPTED_FOG_HINT_LEN]),
             }
         };
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -467,7 +467,7 @@ mod tests {
     use crate::{
         amount::Amount,
         constants::MINIMUM_FEE,
-        encrypted_fog_hint::EncryptedFogHint,
+        encrypted_fog_hint::{EncryptedFogHint, ENCRYPTED_FOG_HINT_LEN},
         ring_signature::SignatureRctBulletproofs,
         tx::{Tx, TxIn, TxOut, TxPrefix},
     };


### PR DESCRIPTION
Previously it was 128 bytes, because it needed to accomodate two
elliptic curve points in the payload in very early drafts.

In this commit we reduce it to 90 bytes, with explanation:
- 50 bytes for mc-crypto-box header
- 32 bytes for curve point
- 8 bytes of magic / extra padding for future use, filled with
  magic number for now

This is a breaking change for the clients, but it doesn't break the software API I think, they will just have to recompile the SDK to get the new size constant