### PR TITLE
MCC-1727 Log the verifier used when connecting to an enclave.

### DIFF
--- a/ledger/sync/src/test_app/main.rs
+++ b/ledger/sync/src/test_app/main.rs
@@ -100,6 +100,8 @@ fn main() {
     let mut verifier = Verifier::default();
     verifier.mr_signer(mr_signer_verifier).debug(DEBUG_ENCLAVE);
 
+    log::debug!(logger, "Verifier: {:?}", verifier);
+
     let peers = vec!["1", "2", "3", "4"]
         .into_iter()
         .map(|node_id| {

--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -30,6 +30,8 @@ fn main() {
     let mut verifier = Verifier::default();
     verifier.mr_signer(mr_signer_verifier).debug(DEBUG_ENCLAVE);
 
+    log::debug!(logger, "Verifier: {:?}", verifier);
+
     // Create peer manager.
     let peer_manager = config.peers_config.create_peer_manager(verifier, &logger);
 


### PR DESCRIPTION
### Motivation

mobilecoind is currently unable to verify a remote enclave, this logs a debug print of the verifier being used in the connection.

### In this PR
* Do a `log::debug!()` of the verifier being used.