### PR TITLE
add utxo to ReadTransferCodeResponse so Gift Codes can be spent

### DIFF
--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -344,6 +344,7 @@ message ReadTransferCodeResponse {
     bytes entropy = 1;
     external.CompressedRistretto tx_public_key = 2;
     string memo = 3;
+    UnspentTxOut utxo = 4;
 }
 
 // Encode entropy/tx_public_key/memo into a base-58 "MobileCoin Transfer Code".

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2532,7 +2532,8 @@ mod test {
                 .unwrap();
 
             // Use root entropy to construct AccountKey.
-            let root_entropy = [0u8; 32];
+            let mut root_entropy = [0u8; 32];
+            root_entropy.copy_from_slice(response.get_entropy());
             let root_id = RootIdentity::from(&root_entropy);
             let account_key = AccountKey::from(&root_id);
 
@@ -2551,9 +2552,9 @@ mod test {
             // Wait for sync to complete.
             wait_for_monitors(&mobilecoind_db, &ledger_db, &logger);
 
-            // Get utxos for the new account and verify we only have the one utxo we are looking forc.
+            // Get utxos for the new account and verify we only have one utxo.
             let utxos = mobilecoind_db
-                .get_utxos_for_subaddress(&monitor_id, 0)
+                .get_utxos_for_subaddress(&monitor_id, DEFAULT_SUBADDRESS_INDEX)
                 .unwrap();
             assert_eq!(utxos.len(), 1);
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3228,7 +3228,7 @@ mod test {
         // An invalid request should fail.
         {
             let mut request = mc_mobilecoind_api::GetTransferCodeRequest::new();
-            request.set_entropy(&root_entropy);
+            request.set_entropy(root_entropy.to_vec());
             request.set_tx_public_key((&tx_public_key).into());
             request.set_memo("memo".to_owned());
             assert!(client.get_transfer_code(&request).is_err());
@@ -3242,7 +3242,7 @@ mod test {
         {
             // Encode
             let mut request = mc_mobilecoind_api::GetTransferCodeRequest::new();
-            request.set_entropy(&root_entropy);
+            request.set_entropy(root_entropy.to_vec());
             request.set_tx_public_key((&tx_public_key).into());
             request.set_memo("test memo".to_owned());
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -427,7 +427,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         }
         let transfer_payload = request_wrapper.get_transfer_payload();
 
-        let compressed_tx_public_key = CompressedRistrettoPublic::try_from(&transfer_payload.get_tx_public_key())
+        let compressed_tx_public_key = CompressedRistrettoPublic::try_from(transfer_payload.get_tx_public_key())
             .map_err(|err| {
                 rpc_internal_error("CompressedRistrettoPublic.try_from", err, &self.logger)
             })?;

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3284,9 +3284,9 @@ mod test {
             assert_eq!(utxos.len(), 1);
 
             // Convert to proto utxo.
-            let proto_utxo: mc_mobilecoind_api::UnspentTxOut = utxos[0].into();
+            let proto_utxo: mc_mobilecoind_api::UnspentTxOut = (&utxos[0]).into();
 
-            assert_eq!(proto_utxo, response.get_utxo());
+            assert_eq!(&proto_utxo, response.get_utxo());
         }
     }
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1385,7 +1385,6 @@ mod test {
         Block, BlockContents, BLOCK_VERSION,
     };
     use mc_transaction_std::TransactionBuilder;
-    use mc_util_from_random::FromRandom;
     use mc_util_repr_bytes::{typenum::U32, GenericArray, ReprBytes};
     use rand::{rngs::StdRng, SeedableRng};
     use std::{
@@ -3211,7 +3210,7 @@ mod test {
         let tx_out = ledger_db.get_tx_out_by_index(0).unwrap();
 
         // Text public key
-        let tx_public_key = RistrettoPublic::from(&tx_out.public_key);
+        let tx_public_key = CompressedRistrettoPublic::try_from(&tx_out.public_key).unwrap();
 
         // An invalid request should fail.
         {

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -427,7 +427,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         }
         let transfer_payload = request_wrapper.get_transfer_payload();
 
-        let tx_public_key = RistrettoPublic::try_from(&transfer_payload.get_tx_public_key())
+        let tx_public_key = RistrettoPublic::try_from(transfer_payload.get_tx_public_key())
             .map_err(|err| rpc_internal_error("RistrettoPublic.try_from", err, &self.logger))?;
 
         let compressed_tx_public_key = CompressedRistrettoPublic::from(&tx_public_key);

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3210,7 +3210,7 @@ mod test {
         let tx_out = ledger_db.get_tx_out_by_index(0).unwrap();
 
         // Text public key
-        let tx_public_key = CompressedRistrettoPublic::try_from(&tx_out.public_key).unwrap();
+        let tx_public_key = tx_out.public_key;
 
         // An invalid request should fail.
         {

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -432,9 +432,6 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
 
         let compressed_tx_public_key = CompressedRistrettoPublic::from(&tx_public_key);
 
-        let tx_public_key = RistrettoPublic::try_from(&compressed_tx_public_key)
-            .map_err(|err| rpc_internal_error("RistrettoPublic.try_from", err, &self.logger))?;
-
         // build and include a UnspentTxOut that can be immediately spent
 
         let index = self

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -32,7 +32,7 @@ use mc_transaction_core::{
     get_tx_out_shared_secret,
     onetime_keys::recover_onetime_private_key,
     ring_signature::KeyImage,
-    tx::{TxOut, TxOutConfirmationNumber},
+    tx::TxOutConfirmationNumber,
 };
 
 use mc_util_from_random::FromRandom;
@@ -433,10 +433,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
 
         // build and include a UnspentTxOut that can be immediately spent
 
-        let tx_out = ledger_db.get_tx_out_index_by_public_key(tx_public_key)
+        let tx_out = self.ledger_db.get_tx_out_index_by_public_key(tx_public_key)
             .map_err(|err| rpc_internal_error("ledger_db.get_tx_out_index_by_public_key", err, &self.logger))?;
 
-        let entropy = transfer_payload.get_entropy().to_vec()
+        let root_entropy = transfer_payload.get_entropy().to_vec()
 
         // Use root entropy to construct AccountKey.
         let root_id = RootIdentity::from(&root_entropy);
@@ -471,7 +471,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         }
 
         let mut response = mc_mobilecoind_api::ReadTransferCodeResponse::new();
-        response.set_entropy(entropy);
+        response.set_entropy(root_entropy);
         response.set_tx_public_key((&tx_public_key).into());
         response.set_memo(transfer_payload.get_memo().to_string());
         response.set_utxo((&utxo).into());

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -433,8 +433,11 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
 
         // build and include a UnspentTxOut that can be immediately spent
 
-        let tx_out = self.ledger_db.get_tx_out_index_by_public_key(tx_public_key)
+        let index = self.ledger_db.get_tx_out_index_by_public_key(tx_public_key)
             .map_err(|err| rpc_internal_error("ledger_db.get_tx_out_index_by_public_key", err, &self.logger))?;
+
+        let tx_out = self.ledger_db.get_tx_out_by_index(index)
+            .map_err(|err| rpc_internal_error("ledger_db.get_tx_out_by_index", err, &self.logger))?;
 
         let root_entropy = transfer_payload.get_entropy().to_vec()
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -432,7 +432,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
 
         let compressed_tx_public_key = CompressedRistrettoPublic::try_from(&tx_public_key)
             .map_err(|err| {
-                  rpc_internal_error("CompressedRistrettoPublic.try_from", err, &self.logger)
+                rpc_internal_error("CompressedRistrettoPublic.try_from", err, &self.logger)
             })?;
 
         // build and include a UnspentTxOut that can be immediately spent

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3202,13 +3202,13 @@ mod test {
         let mut rng: StdRng = SeedableRng::from_seed([23u8; 32]);
 
         // no known recipient, 3 random recipients and no monitors.
-        let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
+        let (mut ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
             get_testing_environment(3, &vec![], &vec![], logger.clone(), &mut rng);
 
         // a valid transfer code must reference a tx_public_key that appears in the ledger
         // that is controlled by the root_entropy included in the code
 
-        let mut root_entropy = [3u8; 32];
+        let root_entropy = [3u8; 32];
 
         // Use root entropy to construct AccountKey.
         let root_id = RootIdentity::from(&root_entropy);
@@ -3217,7 +3217,7 @@ mod test {
         let receiver = AccountKey::from(&root_id);
 
         let mut transaction_builder = TransactionBuilder::new();
-        let (tx_out, tx_confirmation) = transaction_builder
+        let (tx_out, _tx_confirmation) = transaction_builder
             .add_output(10, &receiver.subaddress(DEFAULT_SUBADDRESS_INDEX), None, &mut rng)
             .unwrap();
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -427,13 +427,13 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         }
         let transfer_payload = request_wrapper.get_transfer_payload();
 
-        let tx_public_key = RistrettoPublic::try_from(transfer_payload.get_tx_public_key())
-            .map_err(|err| rpc_internal_error("RistrettoPublic.try_from", err, &self.logger))?;
-
-        let compressed_tx_public_key = CompressedRistrettoPublic::try_from(&tx_public_key)
+        let compressed_tx_public_key = CompressedRistrettoPublic::try_from(&transfer_payload.get_tx_public_key())
             .map_err(|err| {
                 rpc_internal_error("CompressedRistrettoPublic.try_from", err, &self.logger)
             })?;
+
+        let tx_public_key = RistrettoPublic::try_from(&compressed_tx_public_key)
+            .map_err(|err| rpc_internal_error("RistrettoPublic.try_from", err, &self.logger))?;
 
         // build and include a UnspentTxOut that can be immediately spent
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -427,10 +427,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         }
         let transfer_payload = request_wrapper.get_transfer_payload();
 
-        let compressed_tx_public_key = CompressedRistrettoPublic::try_from(transfer_payload.get_tx_public_key())
-            .map_err(|err| {
-                rpc_internal_error("CompressedRistrettoPublic.try_from", err, &self.logger)
-            })?;
+        let tx_public_key = RistrettoPublic::try_from(&transfer_payload.get_tx_public_key())
+            .map_err(|err| rpc_internal_error("RistrettoPublic.try_from", err, &self.logger))?;
+
+        let compressed_tx_public_key = CompressedRistrettoPublic::from(&tx_public_key);
 
         let tx_public_key = RistrettoPublic::try_from(&compressed_tx_public_key)
             .map_err(|err| rpc_internal_error("RistrettoPublic.try_from", err, &self.logger))?;

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -458,9 +458,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         let (value, _blinding) = tx_out
             .amount
             .get_value(&shared_secret)
-            .map_err(|err| {
-                rpc_internal_error("amount.get_value", err, &self.logger)
-            })?;
+            .map_err(|err| rpc_internal_error("amount.get_value", err, &self.logger))?;
 
         let onetime_private_key = recover_onetime_private_key(
             &tx_public_key,

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1706,7 +1706,6 @@ mod test {
 
         // Use root entropy to construct AccountKey.
         let mut root_entropy = [123u8; 32];
-        root_entropy.copy_from_slice(request.get_entropy());
         let root_id = RootIdentity::from(&root_entropy);
         let account_key = AccountKey::from(&root_id);
 
@@ -2534,7 +2533,6 @@ mod test {
 
             // Use root entropy to construct AccountKey.
             let mut root_entropy = [0u8; 32];
-            root_entropy.copy_from_slice(request.get_entropy());
             let root_id = RootIdentity::from(&root_entropy);
             let account_key = AccountKey::from(&root_id);
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3283,15 +3283,10 @@ mod test {
                 .unwrap();
             assert_eq!(utxos.len(), 1);
 
-            let utxo = &utxos[0];
+            // Convert to proto utxo.
+            let proto_utxo: mc_mobilecoind_api::UnspentTxOut = utxos[0].into();
 
-            assert_eq!(utxo, response.get_utxo());
-            assert_eq!(
-                utxo.tx_out.public_key,
-                RistrettoPublic::try_from(response.get_tx_public_key())
-                    .unwrap()
-                    .into()
-            );
+            assert_eq!(proto_utxo, response.get_utxo());
         }
     }
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3228,12 +3228,22 @@ mod test {
         // An invalid request should fail.
         {
             let mut request = mc_mobilecoind_api::GetTransferCodeRequest::new();
-            request.set_entropy(root_entropy.to_vec());
+            request.set_entropy(vec![3u8; 8]); // key is wrong size
             request.set_tx_public_key((&tx_public_key).into());
             request.set_memo("memo".to_owned());
             assert!(client.get_transfer_code(&request).is_err());
 
             let mut request = mc_mobilecoind_api::GetTransferCodeRequest::new();
+            request.set_entropy(vec![4u8; 32]); // key doesn't match tx_public_key
+            request.set_tx_public_key((&tx_public_key).into());
+            request.set_memo("memo".to_owned());
+            assert!(client.get_transfer_code(&request).is_err());
+
+            let bad_tx_public_key = RistrettoPublic::from_random(&mut rng);
+
+            let mut request = mc_mobilecoind_api::GetTransferCodeRequest::new();
+            request.set_entropy(vec![4u8; 32]); // bad_tx_public_key doesn't exist in ledger
+            request.set_tx_public_key((&bad_tx_public_key).into());
             request.set_memo("memo".to_owned());
             assert!(client.get_transfer_code(&request).is_err());
         }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -458,7 +458,9 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         let (value, _blinding) = tx_out
             .amount
             .get_value(&shared_secret)
-            .expect("Malformed amount"); // TODO
+            .map_err(|err| {
+                rpc_internal_error("amount.get_value", err, &self.logger)
+            })?;
 
         let onetime_private_key = recover_onetime_private_key(
             &tx_public_key,

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -428,18 +428,19 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             ));
         }
         let transfer_payload = request_wrapper.get_transfer_payload();
-        let tx_public_key = RistrettoPublic::try_from(transfer_payload.get_tx_public_key())
-            .map_err(|err| rpc_internal_error("RistrettoPublic.try_from", err, &self.logger))?;
+        let tx_public_key = CompressedRistretto::try_from(transfer_payload.get_tx_public_key())
+            .map_err(|err| rpc_internal_error("CompressedRistretto.try_from", err, &self.logger))?;
 
         // build and include a UnspentTxOut that can be immediately spent
 
-        let index = self.ledger_db.get_tx_out_index_by_public_key(tx_public_key)
+        let index = self.ledger_db.get_tx_out_index_by_public_key(&tx_public_key)
             .map_err(|err| rpc_internal_error("ledger_db.get_tx_out_index_by_public_key", err, &self.logger))?;
 
         let tx_out = self.ledger_db.get_tx_out_by_index(index)
             .map_err(|err| rpc_internal_error("ledger_db.get_tx_out_by_index", err, &self.logger))?;
 
-        let root_entropy = transfer_payload.get_entropy().to_vec()
+        let mut root_entropy = [0u8; 32];
+        root_entropy.copy_from_slice(transfer_payload.get_entropy());
 
         // Use root entropy to construct AccountKey.
         let root_id = RootIdentity::from(&root_entropy);
@@ -471,7 +472,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             value,
             attempted_spend_height: 0,
             attempted_spend_tombstone: 0,
-        }
+        };
 
         let mut response = mc_mobilecoind_api::ReadTransferCodeResponse::new();
         response.set_entropy(root_entropy);

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3246,7 +3246,7 @@ mod test {
             assert_eq!(vec![3; 32], response.get_entropy());
             assert_eq!(
                 tx_public_key,
-                RistrettoPublic::try_from(response.get_tx_public_key()).unwrap()
+                CompressedRistrettoPublic::try_from(response.get_tx_public_key()).unwrap()
             );
             assert_eq!(response.get_memo(), "test memo");
         }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1705,7 +1705,7 @@ mod test {
             get_testing_environment(3, &vec![], &vec![], logger.clone(), &mut rng);
 
         // Use root entropy to construct AccountKey.
-        let mut root_entropy = [123u8; 32];
+        let root_entropy = [123u8; 32];
         let root_id = RootIdentity::from(&root_entropy);
         let account_key = AccountKey::from(&root_id);
 
@@ -2532,7 +2532,7 @@ mod test {
                 .unwrap();
 
             // Use root entropy to construct AccountKey.
-            let mut root_entropy = [0u8; 32];
+            let root_entropy = [0u8; 32];
             let root_id = RootIdentity::from(&root_entropy);
             let account_key = AccountKey::from(&root_id);
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -15,7 +15,7 @@ use crate::{
     utxo_store::{UnspentTxOut, UtxoId},
 };
 use grpcio::{EnvBuilder, RpcContext, RpcStatus, RpcStatusCode, ServerBuilder, UnarySink};
-use mc_account_keys::{AccountKey, PublicAddress, RootIdentity};
+use mc_account_keys::{AccountKey, PublicAddress, RootIdentity, DEFAULT_SUBADDRESS_INDEX};
 use mc_common::{
     logger::{log, Logger},
     HashMap,
@@ -426,10 +426,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             .map_err(|err| rpc_internal_error("RistrettoPublic.try_from", err, &self.logger))?;
 
         // build and include a UnspentTxOut that can be immediately spent
-        
+
         let tx_out = ledger_db.get_tx_out_index_by_public_key(tx_public_key)
             .map_err(|err| rpc_internal_error("ledger_db.get_tx_out_index_by_public_key", err, &self.logger))?;
-        
+
         let entropy = transfer_payload.get_entropy().to_vec()
 
         // Use root entropy to construct AccountKey.
@@ -437,7 +437,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
 
         // TODO: change to production AccountKey derivation
         let account_key = AccountKey::from(&root_id);
-        
+
         let shared_secret =
             get_tx_out_shared_secret(account_key.view_private_key(), &tx_public_key);
 
@@ -454,7 +454,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
 
         let key_image = KeyImage::from(&onetime_private_key);
 
-        
+
         let utxo = UnspentTxOut {
             tx_out,
             subaddress_index: DEFAULT_SUBADDRESS_INDEX,
@@ -468,7 +468,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         response.set_entropy(entropy);
         response.set_tx_public_key((&tx_public_key).into());
         response.set_memo(transfer_payload.get_memo().to_string());
-        response.set_utxo(utxo);
+        response.set_utxo((&utxo).into());
 
         Ok(response)
     }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -29,9 +29,7 @@ use mc_mobilecoind_api::{
     MobilecoindUri,
 };
 use mc_transaction_core::{
-    get_tx_out_shared_secret,
-    onetime_keys::recover_onetime_private_key,
-    ring_signature::KeyImage,
+    get_tx_out_shared_secret, onetime_keys::recover_onetime_private_key, ring_signature::KeyImage,
     tx::TxOutConfirmationNumber,
 };
 
@@ -432,18 +430,25 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         let tx_public_key = RistrettoPublic::try_from(transfer_payload.get_tx_public_key())
             .map_err(|err| rpc_internal_error("RistrettoPublic.try_from", err, &self.logger))?;
 
-
         let compressed_tx_public_key = CompressedRistrettoPublic::try_from(&tx_public_key)
             .map_err(|err| rpc_internal_error("CompressedRistrettoPublic.try_from", err, &self.logger))?;
 
-
         // build and include a UnspentTxOut that can be immediately spent
 
-        let index = self.ledger_db.get_tx_out_index_by_public_key(&compressed_tx_public_key)
-            .map_err(|err| rpc_internal_error("ledger_db.get_tx_out_index_by_public_key", err, &self.logger))?;
+        let index = self
+            .ledger_db
+            .get_tx_out_index_by_public_key(&compressed_tx_public_key)
+            .map_err(|err| {
+                  rpc_internal_error(
+                      "ledger_db.get_tx_out_index_by_public_key",
+                      err,
+                      &self.logger,
+                )
+            })?;
 
-        let tx_out = self.ledger_db.get_tx_out_by_index(index)
-            .map_err(|err| rpc_internal_error("ledger_db.get_tx_out_by_index", err, &self.logger))?;
+        let tx_out = self.ledger_db.get_tx_out_by_index(index).map_err(|err| {
+            rpc_internal_error("ledger_db.get_tx_out_by_index", err, &self.logger)
+        })?;
 
         let mut root_entropy = [0u8; 32];
         root_entropy.copy_from_slice(transfer_payload.get_entropy());
@@ -469,7 +474,6 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         );
 
         let key_image = KeyImage::from(&onetime_private_key);
-
 
         let utxo = UnspentTxOut {
             tx_out,

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -28,7 +28,13 @@ use mc_mobilecoind_api::{
     mobilecoind_api_grpc::{create_mobilecoind_api, MobilecoindApi},
     MobilecoindUri,
 };
-use mc_transaction_core::{ring_signature::KeyImage, tx::TxOutConfirmationNumber};
+use mc_transaction_core::{
+    get_tx_out_shared_secret,
+    onetime_keys::recover_onetime_private_key,
+    ring_signature::KeyImage,
+    tx::{TxOut, TxOutConfirmationNumber},
+};
+
 use mc_util_from_random::FromRandom;
 use mc_util_grpc::{
     rpc_internal_error, rpc_logger, send_result, BuildInfoService, ConnectionUriGrpcioServer,


### PR DESCRIPTION
### Motivation

In order to spend a Transfer/Gift Code, we need to construct a `UnspentTxOut` for the referenced `tx_public_key` in the code.

### In this PR
* Adds a new `utxo` return field to the response `ReadTransferCodeResponse`

### Future Work
* wire this up to the terminal wallet client
