### PR TITLE
Elevate log

### DIFF
--- a/attest/net/src/ias.rs
+++ b/attest/net/src/ias.rs
@@ -84,7 +84,7 @@ impl RaClient for IasClient {
             None => json!({"isvEnclaveQuote": quote_base64,}),
         };
 
-        global_log::info!(
+        global_log::trace!(
             "Submitting JSON request for {:?} to IAS: '{}' at {}",
             quote,
             jsvalue.to_string(),
@@ -129,7 +129,7 @@ impl RaClient for IasClient {
             http_body,
         };
 
-        global_log::info!("Received report from IAS: {:?}", &retval);
+        global_log::trace!("Received report from IAS: {:?}", &retval);
 
         Ok(retval)
     }

--- a/attest/net/src/ias.rs
+++ b/attest/net/src/ias.rs
@@ -84,7 +84,7 @@ impl RaClient for IasClient {
             None => json!({"isvEnclaveQuote": quote_base64,}),
         };
 
-        global_log::trace!(
+        global_log::info!(
             "Submitting JSON request for {:?} to IAS: '{}' at {}",
             quote,
             jsvalue.to_string(),
@@ -129,7 +129,7 @@ impl RaClient for IasClient {
             http_body,
         };
 
-        global_log::trace!("Received report from IAS: {:?}", &retval);
+        global_log::info!("Received report from IAS: {:?}", &retval);
 
         Ok(retval)
     }

--- a/sgx/report-cache/untrusted/src/lib.rs
+++ b/sgx/report-cache/untrusted/src/lib.rs
@@ -175,7 +175,24 @@ impl<E: ReportableEnclave, R: RaClient> ReportCache<E, R> {
         let retval = self.ra_client.verify_quote(&quote, Some(ias_nonce))?;
         log::debug!(
             self.logger,
-            "Quote verified by remote attestation service..."
+            "Quote verified by remote attestation service {:?}...",
+            retval,
+        );
+        log::info!(
+            self.logger,
+            "Measurements: MrEnclave: {} MrSigner: {}",
+            VerificationReportData::try_from(&retval)
+                .expect("Could not get verification report data from verification report")
+                .quote
+                .report_body()
+                .expect("Could not get report_body from verification report data")
+                .mr_enclave(),
+            VerificationReportData::try_from(&retval)
+                .expect("Could not get verification report data from verification report")
+                .quote
+                .report_body()
+                .expect("Could not get report_body from verification report data")
+                .mr_signer()
         );
         Ok(retval)
     }

--- a/sgx/report-cache/untrusted/src/lib.rs
+++ b/sgx/report-cache/untrusted/src/lib.rs
@@ -178,21 +178,16 @@ impl<E: ReportableEnclave, R: RaClient> ReportCache<E, R> {
             "Quote verified by remote attestation service {:?}...",
             retval,
         );
+        let report_body = VerificationReportData::try_from(&retval)
+            .expect("Could not get verification report data from verification report")
+            .quote
+            .report_body()
+            .expect("Could not get report_body from verification report data");
         log::info!(
             self.logger,
             "Measurements: MrEnclave: {} MrSigner: {}",
-            VerificationReportData::try_from(&retval)
-                .expect("Could not get verification report data from verification report")
-                .quote
-                .report_body()
-                .expect("Could not get report_body from verification report data")
-                .mr_enclave(),
-            VerificationReportData::try_from(&retval)
-                .expect("Could not get verification report data from verification report")
-                .quote
-                .report_body()
-                .expect("Could not get report_body from verification report data")
-                .mr_signer()
+            report_body.mr_enclave(),
+            report_body.mr_signer()
         );
         Ok(retval)
     }


### PR DESCRIPTION
### Motivation

Currently the log level for IAS reports is trace, but we would like more visibility into the attestation evidence on startup.

### In this PR
* Adds info log for MrEnclave and MrSigner as hex strings
* Add debug log for IAS report

[MCC-1717](https://mobilecoin.atlassian.net/browse/MCC-1717)

### Future Work
* [FOG-180](https://mobilecoin.atlassian.net/browse/FOG-180) Reduce report caching frequency on Ingest. This will follow soon after, as this will flood the logs with info level logs for ingest on every cache update.

