### PR TITLE
[MCC-1693] Removes is_valid check when reinserting 

### DIFF
--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -115,7 +115,6 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
         {
             let cache = self.lock_cache();
             if let Some(entry) = cache.get(&tx_context.tx_hash) {
-                self.untrusted.is_valid(entry.context().clone())?;
                 // The transaction is well-formed and is in the cache.
                 return Ok(*entry.context.tx_hash());
             }
@@ -406,12 +405,6 @@ mod tests {
             .expect_well_formed_check()
             .times(1)
             .return_const(Ok((0, vec![])));
-
-        // Not sure that this should happen...
-        mock_untrusted
-            .expect_is_valid()
-            .times(1)
-            .return_const(Ok(()));
 
         // The enclave's well-formed check also ought to be called, and should return Ok.
         let mut mock_enclave = MockConsensusEnclave::new();


### PR DESCRIPTION
Soundtrack of this PR: [Be Together](https://www.youtube.com/watch?v=GZSsOEqgm0c)

### Motivation

TxManager should maintain a cache of well-formed transactions. Previously, it also checked for validity (which is funky and unnecessary) because other things incorrectly required the transactions in its cache to be valid.

### In this PR
* Removes is_valid check when reinserting a transaction into the cache.
