### PR TITLE
[MCC-1716] Untrusted well_formed_check should not return false if it previously returned true

### DIFF
--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -98,11 +98,9 @@ impl<E: ConsensusEnclave, UI: UntrustedInterfaces> TxManager for TxManagerImpl<E
         let timer = counters::WELL_FORMED_CHECK_TIME.start_timer();
 
         // The untrusted part of the well-formed check.
-        let (current_block_index, membership_proofs) = self.untrusted.well_formed_check(
-            &tx_context.highest_indices,
-            &tx_context.key_images,
-            &tx_context.output_public_keys,
-        )?;
+        let (current_block_index, membership_proofs) = self
+            .untrusted
+            .well_formed_check(&tx_context.highest_indices)?;
 
         // The enclave part of the well-formed check.
         let (well_formed_encrypted_tx, well_formed_tx_context) = self.enclave.tx_is_well_formed(
@@ -230,6 +228,10 @@ impl<E: ConsensusEnclave, UI: UntrustedInterfaces> TxManager for TxManagerImpl<E
     }
 
     /// Forms a Block containing the transactions that correspond to the given hashes.
+    ///
+    /// # Arguments
+    /// * `tx_hashes` - Hashes of well-formed transactions that are valid w.r.t. te current ledger.
+    /// * `parent_block` - The last block written to the ledger.
     fn tx_hashes_to_block(
         &self,
         tx_hashes: &[TxHash],
@@ -260,10 +262,9 @@ impl<E: ConsensusEnclave, UI: UntrustedInterfaces> TxManager for TxManagerImpl<E
             .map(|(_tx_hash, entry)| {
                 let entry = entry.unwrap();
 
+                // This probably shouldn't be here.
                 let (_current_block_index, membership_proofs) = self.untrusted.well_formed_check(
                     entry.context().highest_indices(),
-                    entry.context().key_images(),
-                    entry.context().output_public_keys(),
                 )?;
 
                 Ok((entry.encrypted_tx().clone(), membership_proofs))

--- a/consensus/service/src/tx_manager/untrusted_interfaces.rs
+++ b/consensus/service/src/tx_manager/untrusted_interfaces.rs
@@ -1,9 +1,7 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use mc_consensus_enclave::WellFormedTxContext;
-use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
-    ring_signature::KeyImage,
     tx::{TxHash, TxOutMembershipProof},
     validation::TransactionValidationResult,
 };
@@ -21,8 +19,6 @@ pub trait UntrustedInterfaces: Send + Sync {
     fn well_formed_check(
         &self,
         highest_indices: &[u64],
-        key_images: &[KeyImage],
-        output_public_keys: &[CompressedRistrettoPublic],
     ) -> TransactionValidationResult<(u64, Vec<TxOutMembershipProof>)>;
 
     /// Checks if a transaction is valid (see definition in validators.rs).

--- a/consensus/service/src/tx_manager/untrusted_interfaces.rs
+++ b/consensus/service/src/tx_manager/untrusted_interfaces.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
-use mc_consensus_enclave::WellFormedTxContext;
+use mc_consensus_enclave::{TxContext, WellFormedTxContext};
 use mc_transaction_core::{
     tx::{TxHash, TxOutMembershipProof},
     validation::TransactionValidationResult,
@@ -13,12 +13,12 @@ use mockall::*;
 /// The untrusted (i.e. non-enclave) part of validating and combining transactions.
 #[cfg_attr(test, automock)]
 pub trait UntrustedInterfaces: Send + Sync {
-    /// Performs the untrusted part of the well-formed check.
-    /// Returns current block index and membership proofs to be used by
-    /// the in-enclave well-formed check on success.
+    /// Performs **only** the untrusted part of the well-formed check.
+    ///
+    /// Returns the local ledger's block index and membership proofs for each highest index.
     fn well_formed_check(
         &self,
-        highest_indices: &[u64],
+        tx_context: &TxContext,
     ) -> TransactionValidationResult<(u64, Vec<TxOutMembershipProof>)>;
 
     /// Checks if a transaction is valid (see definition in validators.rs).

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -46,8 +46,6 @@ impl<L: Ledger + Sync> TxManagerUntrustedInterfaces for DefaultTxManagerUntruste
     fn well_formed_check(
         &self,
         highest_indices: &[u64],
-        _key_images: &[KeyImage],
-        _output_public_keys: &[CompressedRistrettoPublic],
     ) -> TransactionValidationResult<(u64, Vec<TxOutMembershipProof>)> {
         // The transaction's membership proofs must reference data contained in the ledger.
         // Note that this check could fail if the local ledger is behind the network's consensus ledger.
@@ -173,16 +171,9 @@ pub mod well_formed_tests {
         let mut rng = Hc128Rng::from_seed([77u8; 32]);
 
         let untrusted = DefaultTxManagerUntrustedInterfaces::new(ledger.clone());
-
-        let key_images: Vec<KeyImage> = tx.key_images();
         let membership_proof_highest_indices = tx.get_membership_proof_highest_indices();
-        let output_public_keys = tx.output_public_keys();
-
-        let (cur_block_index, membership_proofs) = untrusted.well_formed_check(
-            &membership_proof_highest_indices[..],
-            &key_images[..],
-            &output_public_keys[..],
-        )?;
+        let (cur_block_index, membership_proofs) =
+            untrusted.well_formed_check(&membership_proof_highest_indices[..])?;
 
         mc_transaction_core::validation::validate(
             &tx,


### PR DESCRIPTION
Soundtrack of this PR: [No New Friends](https://www.youtube.com/watch?v=kkUIdK9eaIk)

### Motivation
Some parts of transaction validation depend on the current ledger state (e.g. "has this key image been spent?"), while others don't (e.g. "is the transaction signature valid?"). In order to keep transaction validation efficient, we separate the two classes of checks, and only perform the checks that don't depend on the current ledger state once. For example, this means that if a transaction arrives circa block 7, and is considered by consensus for blocks 7, 8, and 9, that things like spent key images are re-checked for each block, but things like the transaction signature are only checked once.

We call a transaction "well-formed" if it passes all the checks that only need to be done once when the transaction is received. A transaction that passes these checks at one point in time **must always pass those checks in the future**. 

Right now, some of the checks implemented by is_well_formed do not have this property, and so a transaction that is considered well-formed at block N may not be considered well-formed at block N+1. This isn't too big of a deal -- we were basically over-zealous in checking things -- but it's hard to reason about the system if we don't follow our own definitions.


### In this PR
* Removes several checks that violate the well-formed-ness defnition from UntrustedInterfaces::is_well_formed.
* UntrustedInterfaces::is_well_formed takes a TxContext. Previously, we unnecessarily restricted the function to a subset of data from TxContext. TxContext is supposed to be all the info that the enclave provides about an encrypted transaction, so passing the full tx_context to the checks is the most general and flexible approach.
