### PR TITLE
[MCC-1716] UntrustedInterfaces::is_well_formed

### DIFF
--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -101,11 +101,9 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
         let timer = counters::WELL_FORMED_CHECK_TIME.start_timer();
 
         // The untrusted part of the well-formed check.
-        let (current_block_index, membership_proofs) = self.untrusted.well_formed_check(
-            &tx_context.highest_indices,
-            &tx_context.key_images,
-            &tx_context.output_public_keys,
-        )?;
+        let (current_block_index, membership_proofs) = self
+            .untrusted
+            .well_formed_check(&tx_context.highest_indices)?;
 
         // The enclave part of the well-formed check.
         let (well_formed_encrypted_tx, well_formed_tx_context) = self.enclave.tx_is_well_formed(
@@ -233,6 +231,10 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
     }
 
     /// Forms a Block containing the transactions that correspond to the given hashes.
+    ///
+    /// # Arguments
+    /// * `tx_hashes` - Hashes of well-formed transactions that are valid w.r.t. te current ledger.
+    /// * `parent_block` - The last block written to the ledger.
     fn tx_hashes_to_block(
         &self,
         tx_hashes: &[TxHash],
@@ -263,10 +265,9 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
             .map(|(_tx_hash, entry)| {
                 let entry = entry.unwrap();
 
+                // This probably shouldn't be here.
                 let (_current_block_index, membership_proofs) = self.untrusted.well_formed_check(
                     entry.context().highest_indices(),
-                    entry.context().key_images(),
-                    entry.context().output_public_keys(),
                 )?;
 
                 Ok((entry.encrypted_tx().clone(), membership_proofs))

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -91,7 +91,7 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManagerImpl<E
         let (well_formed_encrypted_tx, well_formed_tx_context) = self.enclave.tx_is_well_formed(
             tx_context.locally_encrypted_tx,
             current_block_index,
-            highest_index_proofs.clone(),
+            highest_index_proofs,
         )?;
 
         Ok(CacheEntry {

--- a/consensus/service/src/tx_manager/untrusted_interfaces.rs
+++ b/consensus/service/src/tx_manager/untrusted_interfaces.rs
@@ -1,9 +1,7 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use mc_consensus_enclave::WellFormedTxContext;
-use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
-    ring_signature::KeyImage,
     tx::{TxHash, TxOutMembershipProof},
     validation::TransactionValidationResult,
 };
@@ -21,8 +19,6 @@ pub trait UntrustedInterfaces: Send + Sync {
     fn well_formed_check(
         &self,
         highest_indices: &[u64],
-        key_images: &[KeyImage],
-        output_public_keys: &[CompressedRistrettoPublic],
     ) -> TransactionValidationResult<(u64, Vec<TxOutMembershipProof>)>;
 
     /// Checks if a transaction is valid (see definition in validators.rs).

--- a/consensus/service/src/tx_manager/untrusted_interfaces.rs
+++ b/consensus/service/src/tx_manager/untrusted_interfaces.rs
@@ -34,4 +34,9 @@ pub trait UntrustedInterfaces: Send + Sync {
     /// Returns a bounded, deterministically-ordered list of transactions that are safe to append to the ledger.
     fn combine(&self, tx_contexts: &[Arc<WellFormedTxContext>], max_elements: usize)
         -> Vec<TxHash>;
+
+    fn get_tx_out_proof_of_memberships(
+        &self,
+        indexes: &[u64],
+    ) -> TransactionValidationResult<Vec<TxOutMembershipProof>>;
 }

--- a/consensus/service/src/tx_manager/untrusted_interfaces.rs
+++ b/consensus/service/src/tx_manager/untrusted_interfaces.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
-use mc_consensus_enclave::WellFormedTxContext;
+use mc_consensus_enclave::{TxContext, WellFormedTxContext};
 use mc_transaction_core::{
     tx::{TxHash, TxOutMembershipProof},
     validation::TransactionValidationResult,
@@ -13,12 +13,12 @@ use mockall::*;
 /// The untrusted (i.e. non-enclave) part of validating and combining transactions.
 #[cfg_attr(test, automock)]
 pub trait UntrustedInterfaces: Send + Sync {
-    /// Performs the untrusted part of the well-formed check.
-    /// Returns current block index and membership proofs to be used by
-    /// the in-enclave well-formed check on success.
+    /// Performs **only** the untrusted part of the well-formed check.
+    ///
+    /// Returns the local ledger's block index and membership proofs for each highest index.
     fn well_formed_check(
         &self,
-        highest_indices: &[u64],
+        tx_context: &TxContext,
     ) -> TransactionValidationResult<(u64, Vec<TxOutMembershipProof>)>;
 
     /// Checks if a transaction is valid (see definition in validators.rs).

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -71,7 +71,7 @@ impl<L: Ledger + Sync> TxManagerUntrustedInterfaces for DefaultTxManagerUntruste
             .num_blocks()
             .map_err(|e| TransactionValidationError::Ledger(e.to_string()))?;
 
-        // The transaction must not have expired.
+        // The transaction must not have expired, and the tombstone block must not be too far in the future.
         validate_tombstone(current_block_index, context.tombstone_block())?;
 
         // The `key_images` must not have already been spent.

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -49,10 +49,8 @@ impl<L: Ledger + Sync> TxManagerUntrustedInterfaces for DefaultTxManagerUntruste
     ) -> TransactionValidationResult<(u64, Vec<TxOutMembershipProof>)> {
         // The transaction's membership proofs must reference data contained in the ledger.
         // This check could fail if the local ledger is behind the network's consensus ledger.
-        let membership_proofs = self
-            .ledger
-            .get_tx_out_proof_of_memberships(&tx_context.highest_indices)
-            .map_err(|e| TransactionValidationError::Ledger(e.to_string()))?;
+        let membership_proofs =
+            self.get_tx_out_proof_of_memberships(&tx_context.highest_indices)?;
 
         // Note: It is possible that the proofs above are obtained for a different block index as a
         // new block could be written between getting the proofs and the call to num_blocks().
@@ -147,6 +145,15 @@ impl<L: Ledger + Sync> TxManagerUntrustedInterfaces for DefaultTxManagerUntruste
         }
 
         allowed_hashes
+    }
+
+    fn get_tx_out_proof_of_memberships(
+        &self,
+        indexes: &[u64],
+    ) -> TransactionValidationResult<Vec<TxOutMembershipProof>> {
+        self.ledger
+            .get_tx_out_proof_of_memberships(indexes)
+            .map_err(|e| TransactionValidationError::Ledger(e.to_string()))
     }
 }
 

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -46,8 +46,6 @@ impl<L: Ledger + Sync> TxManagerUntrustedInterfaces for DefaultTxManagerUntruste
     fn well_formed_check(
         &self,
         highest_indices: &[u64],
-        _key_images: &[KeyImage],
-        _output_public_keys: &[CompressedRistrettoPublic],
     ) -> TransactionValidationResult<(u64, Vec<TxOutMembershipProof>)> {
         // The transaction's membership proofs must reference data contained in the ledger.
         // Note that this check could fail if the local ledger is behind the network's consensus ledger.
@@ -173,16 +171,9 @@ pub mod well_formed_tests {
         let mut rng = Hc128Rng::from_seed([77u8; 32]);
 
         let untrusted = DefaultTxManagerUntrustedInterfaces::new(ledger.clone());
-
-        let key_images: Vec<KeyImage> = tx.key_images();
         let membership_proof_highest_indices = tx.get_membership_proof_highest_indices();
-        let output_public_keys = tx.output_public_keys();
-
-        let (cur_block_index, membership_proofs) = untrusted.well_formed_check(
-            &membership_proof_highest_indices[..],
-            &key_images[..],
-            &output_public_keys[..],
-        )?;
+        let (cur_block_index, membership_proofs) =
+            untrusted.well_formed_check(&membership_proof_highest_indices[..])?;
 
         mc_transaction_core::validation::validate(
             &tx,


### PR DESCRIPTION
### Motivation
Some parts of transaction validation depend on the current ledger state (e.g. "has this key image been spent?"), while others don't (e.g. "is the transaction signature valid?"). In order to keep transaction validation efficient, we separate the two classes of checks, and only perform the checks that don't depend on the current ledger state once. For example, this means that if a transaction arrives circa block 7, and is considered by consensus for blocks 7, 8, and 9, that things like spent key images are re-checked for each block, but things like the transaction signature are only checked once.

We call a transaction "well-formed" if it passes all the checks that only need to be done once when the transaction is received. A transaction that passes these checks at one point in time must always pass those checks in the future.

Right now, some of the checks implemented by is_well_formed do not have this property, and so a transaction that is considered well-formed at block N may not be considered well-formed at block N+1. This isn't too big of a deal -- we were basically over-zealous and checked some things in multiple places -- but it's hard to reason about the system if we don't follow our own definitions.

### In this PR
- Removes several checks that violate the well-formed-ness definition from UntrustedInterfaces::is_well_formed.
- UntrustedInterfaces::is_well_formed takes a TxContext. Previously, we unnecessarily restricted the function to a subset of data from TxContext. TxContext is supposed to be all the info that the enclave provides about an encrypted transaction, so passing the full tx_context to the checks is the most general and flexible approach.
- Unit test cleanup. Uses MockLedger which, I think, makes the tests much more direct and makes expectations about how UntrustedInterfaces interacts with its Ledger into testable conditions.