### PR TITLE
BetaNet fee account

### DIFF
--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -4,6 +4,15 @@ version = "0.6.0"
 authors = ["MobileCoin"]
 edition = "2018"
 
+[features]
+default = ["test-net-fee-keys"]
+
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = []
+
 [lib]
 path = "src/lib.rs"
 

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -4,6 +4,15 @@ version = "0.6.0"
 authors = ["MobileCoin"]
 edition = "2018"
 
+[features]
+default = ["test-net-fee-keys"]
+
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = []
+
 [[bin]]
 name = "mobilecoind"
 path = "src/bin/main.rs"

--- a/transaction/core/src/constants.rs
+++ b/transaction/core/src/constants.rs
@@ -35,20 +35,26 @@ lazy_static! {
 
 cfg_if::cfg_if! {
     if #[cfg(any(test, feature="test-net-fee-keys"))] {
-        /// Internal testnet fee recipient account, generated via
+        /// Internal TestNet fee recipient account, generated via
         ///
         ///   let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         ///   let foundation_account_key = AccountKey::random(&mut rng);
         pub const FEE_SPEND_PUBLIC_KEY: [u8; 32] = [38, 181, 7, 198, 49, 36, 162, 245, 233, 64, 180, 251, 137, 228, 178, 187, 10, 32, 120, 237, 12, 142, 85, 26, 213, 146, 104, 185, 100, 110, 194, 65];
 
-        /// Testnet fee recipient view public key.
+        /// TestNet fee recipient view public key.
         pub const FEE_VIEW_PUBLIC_KEY: [u8; 32] = [82, 34, 161, 233, 174, 50, 210, 28, 35, 17, 74, 92, 230, 187, 57, 224, 203, 86, 174, 163, 80, 212, 97, 157, 67, 177, 32, 112, 97, 177, 3, 70];
 
         /// The private key is only used by tests. This does not need to be specified for main net.
         pub const FEE_VIEW_PRIVATE_KEY: [u8; 32] = [21, 152, 99, 251, 140, 2, 50, 154, 2, 171, 188, 60, 163, 243, 204, 195, 241, 78, 204, 85, 202, 52, 250, 242, 215, 247, 175, 59, 121, 185, 111, 8];
 
     } else if #[cfg(feature="main-net-fee-keys")] {
-        compile_error!("main net keys are not available yet");
+        /// BetaNet Fee Account Key
+        /// Generated with mc-util-keyfile/sample-keys on an airgapped machine, then pubkey copied
+        /// and read with mc-util-keyfile/read-pubfile.
+        pub const FEE_SPEND_PUBLIC_KEY: [u8; 32] = [68, 53, 73, 223, 240, 207, 203, 209, 138, 92, 5, 107, 179, 135, 234, 177, 251, 188, 157, 48, 75, 160, 226, 198, 191, 125, 70, 138, 18, 7, 159, 68];
+
+        /// BetaNet fee recipient view public key
+        pub const FEE_VIEW_PUBLIC_KEY: [u8; 32] = [126, 55, 144, 45, 119, 126, 43, 192, 109, 216, 110, 115, 15, 234, 184, 168, 39, 186, 136, 98, 62, 77, 236, 177, 65, 6, 157, 147, 134, 249, 96, 4];
     } else {
         compile_error!("must specify either main-net-fee-keys or test-net-fee-keys feature");
     }

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -19,6 +19,10 @@ path = "src/bin/keygen_main.rs"
 name = "sample-keys"
 path = "src/bin/sample_keys_main.rs"
 
+[[bin]]
+name = "read-pubfile"
+path = "src/bin/read_pubfile.rs"
+
 [dependencies]
 mc-account-keys = { path = "../../account-keys" }
 mc-crypto-rand = { path = "../../crypto/rand" }

--- a/util/keyfile/src/bin/read_pubfile.rs
+++ b/util/keyfile/src/bin/read_pubfile.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+use mc_util_keyfile::read_pubfile;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Config {
+    /// Path to pubfile
+    #[structopt(long)]
+    pub pubfile: PathBuf,
+}
+
+fn main() {
+    let config = Config::from_args();
+
+    let pubaddress = read_pubfile(config.pubfile.clone()).expect("Could not read pubfile");
+
+    println!(
+        "Public address for {:?}: \n\t {:?}",
+        config.pubfile, pubaddress
+    );
+
+    println!(
+        "View Public Bytes: {:?}",
+        pubaddress.view_public_key().to_bytes()
+    );
+
+    println!(
+        "Spend Public Bytes: {:?}",
+        pubaddress.spend_public_key().to_bytes()
+    );
+}


### PR DESCRIPTION
### Motivation

Add BetaNet Fee Account.

### In this PR
* Adds BetaNet fee pubkeys.
* Adds a super simple utility to read pubfile contents and print out bytes.

First part of [MCC-1733](https://mobilecoin.atlassian.net/browse/MCC-1733)

### Future Work
* Update to MainNet Fee Public Keys.
