### PR TITLE
Info Endpoint Updates

### DIFF
--- a/admin-http-gateway/Cargo.toml
+++ b/admin-http-gateway/Cargo.toml
@@ -16,3 +16,6 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 structopt = "0.3"
+
+[build-dependencies]
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -609,9 +609,11 @@ impl<
 
                     latest_block_timestamp = match ledger_db.get_block_signature(b - 1) {
                         Ok(x) => Some(x.signed_at()),
-                        // Note, a node may not write a block signature for the case where it is not
-                        // trusted by any peers, so it does not participate in consensus, or if it
-                        // enters into catchup.
+                        // Note, a block signature will be missing if the corresponding block was not
+                        // processed by an enclave participating in consensus. For example, unsigned
+                        // blocks can be created by a validator node that falls behind its peers and
+                        // enters into catchup. Another scenario would be if a validator node is not
+                        // trusted by sufficient peers to participate in quorum.
                         Err(LedgerDbError::NotFound) => {
                             log::debug!(logger, "Block signature not found for block {}", b - 1);
                             None

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -21,6 +21,7 @@ use mc_common::{
 use mc_connection::{Connection, ConnectionManager};
 use mc_consensus_api::{consensus_client_grpc, consensus_common_grpc, consensus_peer_grpc};
 use mc_consensus_enclave::ConsensusEnclave;
+use mc_crypto_keys::DistinguishedEncoding;
 use mc_ledger_db::{Error as LedgerDbError, Ledger, LedgerDB};
 use mc_peers::{PeerConnection, ThreadedBroadcaster, VerifiedConsensusMsg};
 use mc_sgx_report_cache_untrusted::{Error as ReportCacheError, ReportCacheThread};
@@ -604,7 +605,7 @@ impl<
                     block_height = Some(b);
                     latest_block_hash = ledger_db
                         .get_block(b - 1)
-                        .map(|x| format!("{:X?}", x.id.0))
+                        .map(|x| format!("{}", hex::encode(x.id.0)))
                         .map_err(|e| log::error!(logger, "Error getting block {} {:?}", b - 1, e))
                         .ok();
 
@@ -645,7 +646,7 @@ impl<
                     "public_key": config.node_id().public_key,
                     "peer_responder_id": config.peer_responder_id,
                     "client_responder_id": config.client_responder_id,
-                    "message_pubkey": encode_config(&config.msg_signer_key.public_key(), URL_SAFE),
+                    "message_pubkey": encode_config(&config.msg_signer_key.public_key().to_der(), URL_SAFE),
                     "network": config.network_path,
                     "peer_listen_uri": config.peer_listen_uri,
                     "client_listen_uri": config.client_listen_uri,

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -7,6 +7,7 @@ use crate::{
     blockchain_api_service, byzantine_ledger::ByzantineLedger, client_api_service, config::Config,
     counters, peer_api_service, peer_keepalive::PeerKeepalive, tx_manager::TxManager,
 };
+use base64::{encode_config, URL_SAFE};
 use failure::Fail;
 use futures::executor::block_on;
 use grpcio::{EnvBuilder, Environment, Server, ServerBuilder};
@@ -644,7 +645,7 @@ impl<
                     "public_key": config.node_id().public_key,
                     "peer_responder_id": config.peer_responder_id,
                     "client_responder_id": config.client_responder_id,
-                    "message_pubkey": config.msg_signer_key.public_key(),
+                    "message_pubkey": encode_config(&config.msg_signer_key.public_key(), URL_SAFE),
                     "network": config.network_path,
                     "peer_listen_uri": config.peer_listen_uri,
                     "client_listen_uri": config.client_listen_uri,

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -605,7 +605,7 @@ impl<
                     block_height = Some(b);
                     latest_block_hash = ledger_db
                         .get_block(b - 1)
-                        .map(|x| format!("{}", hex::encode(x.id.0)))
+                        .map(|x| hex::encode(x.id.0))
                         .map_err(|e| log::error!(logger, "Error getting block {} {:?}", b - 1, e))
                         .ok();
 

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -614,10 +614,9 @@ impl<
                         // Note, a block signature will be missing if the corresponding block was not
                         // processed by an enclave participating in consensus. For example, unsigned
                         // blocks can be created by a validator node that falls behind its peers and
-                        // enters into catchup. Another scenario would be if a validator node is not
-                        // trusted by sufficient peers to participate in quorum.
+                        // enters into catchup.
                         Err(LedgerDbError::NotFound) => {
-                            log::debug!(logger, "Block signature not found for block {}", b - 1);
+                            log::trace!(logger, "Block signature not found for block {}", b - 1);
                             None
                         }
                         Err(e) => {


### PR DESCRIPTION
### Motivation

The block signature may be empty when a node is behind, or if the node is configured as read-only (it is not trusted by any other quorum sets). The current info endpoint errors if this is the case, but that is not an error to be concerned about. I also took this opportunity to fix up the last_block_timestamp to be empty string if not found, rather than json null, and to make the format of the message signer pubkey something meaningful, rather than a bytevec.

### In this PR
* Processes the error and permits NotFound
* Updates last_block_timestamp to empty string
* URL-safe base64-encodes the message signer pubkey, to match the representation in the network.toml
* Fixes hex representation of last block hash

[MCC-1741](https://mobilecoin.atlassian.net/browse/MCC-1741)
[MCC-1739](https://mobilecoin.atlassian.net/browse/MCC-1739)
[MCC-1742](https://mobilecoin.atlassian.net/browse/MCC-1742)
 



