### PR TITLE
b58 style Address Codes

### DIFF
--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -27,11 +27,13 @@ service MobilecoindAPI {
     rpc GetAccountKey (GetAccountKeyRequest) returns (GetAccountKeyResponse) {}
     rpc GetPublicAddress (GetPublicAddressRequest) returns (GetPublicAddressResponse) {}
 
-    // QR-code
+    // b58 Codes
     rpc ReadRequestCode (ReadRequestCodeRequest) returns (ReadRequestCodeResponse) {}
     rpc GetRequestCode (GetRequestCodeRequest) returns (GetRequestCodeResponse) {}
     rpc ReadTransferCode (ReadTransferCodeRequest) returns (ReadTransferCodeResponse) {}
     rpc GetTransferCode (GetTransferCodeRequest) returns (GetTransferCodeResponse) {}
+    rpc ReadAddressCode (ReadAddressCodeRequest) returns (ReadAddressCodeResponse) {}
+    rpc GetAddressCode (GetAddressCodeRequest) returns (GetAddressCodeResponse) {}
 
     // Txs
     rpc GenerateTx (GenerateTxRequest) returns (GenerateTxResponse) {}
@@ -311,11 +313,10 @@ message GetPublicAddressResponse {
 }
 
 //
-// QR-code
+// b58 Codes
 //
 
-// Decode a base-58 encoded "MobileCoin Request Code" into receiver/value/memo.
-// This code provides a mobile client with everything required to construct a payment, allowing funds to be deposited to an exchange or paid to a merchant by scanning a QR code.
+// Decode a base-58 encoded "MobileCoin Request Code" into receiver's public address, value, and memo.
 message ReadRequestCodeRequest {
     string b58_code = 1;
 }
@@ -325,7 +326,7 @@ message ReadRequestCodeResponse {
     string memo = 3;
 }
 
-// Encode receiver/value/memo into a base-58 "MobileCoin Request Code".
+// Encode receiver's public address, value, and memo into a base-58 "MobileCoin Request Code".
 message GetRequestCodeRequest {
     external.PublicAddress receiver = 1;
     uint64 value = 2;
@@ -336,7 +337,7 @@ message GetRequestCodeResponse {
 }
 
 // Decode a base-58 encoded "MobileCoin Transfer Code" into entropy/tx_public_key/memo.
-// This code provides a mobile client with everything required to construct a self-payment, allowing funds to be withdrawn from an exchange or ATM by scanning a QR code.
+// This code provides a mobile client with everything required to construct a self-payment, allowing funds to be withdrawn from a gift card.
 message ReadTransferCodeRequest {
     string b58_code = 1;
 }
@@ -354,6 +355,22 @@ message GetTransferCodeRequest {
     string memo = 3;
 }
 message GetTransferCodeResponse {
+    string b58_code = 1;
+}
+
+// Decode a base-58 encoded "MobileCoin Address Code" into the receiver's public address.
+message ReadAddressCodeRequest {
+    string b58_code = 1;
+}
+message ReadAddressCodeResponse {
+    external.PublicAddress receiver = 1;
+}
+
+// Encode receiver's public address into a base-58 "MobileCoin Address Code".
+message GetAddressCodeRequest {
+    external.PublicAddress receiver = 1;
+}
+message GetAddressCodeResponse {
     string b58_code = 1;
 }
 
@@ -407,7 +424,7 @@ message GenerateOptimizationTxResponse {
     TxProposal tx_proposal = 1;
 }
 
-// Generate a transaction that can be used for a "MobileCoin Transfer Code" QR.
+// Generate a transaction that can be used for a "MobileCoin Transfer Code"
 message GenerateTransferCodeTxRequest {
     bytes sender_monitor_id = 1;
     uint64 change_subaddress = 2;

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3362,7 +3362,7 @@ mod test {
                 receiver
             );
         }
-        
+
         // Attempting to decode junk data should fail
         {
             let mut request = mc_mobilecoind_api::ReadAddressCodeRequest::new();

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -520,6 +520,47 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         Ok(response)
     }
 
+    fn read_address_code_impl(
+        &mut self,
+        request: mc_mobilecoind_api::ReadAddressCodeRequest,
+    ) -> Result<mc_mobilecoind_api::ReadAddressCodeResponse, RpcStatus> {
+        let request_wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
+            request.get_b58_code().to_string(),
+        )
+        .map_err(|err| rpc_internal_error("PrintableWrapper_b58_decode", err, &self.logger))?;
+
+        if request_wrapper.has_public_address() {
+            let public_address = request_wrapper.get_public_address();
+            let mut response = mc_mobilecoind_api::ReadAddressCodeResponse::new();
+            response.set_receiver(public_address.clone());
+            Ok(response)
+        } else {
+            Err(RpcStatus::new(
+                RpcStatusCode::INVALID_ARGUMENT,
+                Some("invalid address code".to_string()),
+            ))
+        }
+    }
+
+    fn get_address_code_impl(
+        &mut self,
+        request: mc_mobilecoind_api::GetAddressCodeRequest,
+    ) -> Result<mc_mobilecoind_api::GetAddressCodeResponse, RpcStatus> {
+        let receiver = PublicAddress::try_from(request.get_receiver())
+            .map_err(|err| rpc_internal_error("PublicAddress.try_from", err, &self.logger))?;
+
+        let mut request_wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
+        request_wrapper.set_public_address((&receiver).into());
+
+        let encoded = request_wrapper
+            .b58_encode()
+            .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
+
+        let mut response = mc_mobilecoind_api::GetAddressCodeResponse::new();
+        response.set_b58_code(encoded);
+        Ok(response)
+    }
+
     fn generate_tx_impl(
         &mut self,
         request: mc_mobilecoind_api::GenerateTxRequest,
@@ -1339,6 +1380,8 @@ build_api! {
     get_request_code GetRequestCodeRequest GetRequestCodeResponse get_request_code_impl,
     read_transfer_code ReadTransferCodeRequest ReadTransferCodeResponse read_transfer_code_impl,
     get_transfer_code GetTransferCodeRequest GetTransferCodeResponse get_transfer_code_impl,
+    read_address_code ReadAddressCodeRequest ReadAddressCodeResponse read_address_code_impl,
+    get_address_code GetAddressCodeRequest GetAddressCodeResponse get_address_code_impl,
     generate_tx GenerateTxRequest GenerateTxResponse generate_tx_impl,
     generate_optimization_tx GenerateOptimizationTxRequest GenerateOptimizationTxResponse generate_optimization_tx_impl,
     generate_transfer_code_tx GenerateTransferCodeTxRequest GenerateTransferCodeTxResponse generate_transfer_code_tx_impl,
@@ -3285,6 +3328,47 @@ mod test {
             let proto_utxo: mc_mobilecoind_api::UnspentTxOut = (&utxos[0]).into();
 
             assert_eq!(&proto_utxo, response.get_utxo());
+        }
+    }
+
+    #[test_with_logger]
+    fn test_address_code(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([23u8; 32]);
+
+        // no known recipient, 3 random recipients and no monitors.
+        let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
+            get_testing_environment(3, &vec![], &vec![], logger.clone(), &mut rng);
+
+        // Random receiver address.
+        let receiver = AccountKey::random(&mut rng).default_subaddress();
+
+        {
+            // Generate a request code
+            let mut request = mc_mobilecoind_api::GetAddressCodeRequest::new();
+            request.set_receiver(mc_api::external::PublicAddress::from(&receiver));
+
+            let response = client.get_address_code(&request).unwrap();
+            let b58_code = response.get_b58_code();
+
+            // Attempt to decode it.
+            let mut request = mc_mobilecoind_api::ReadAddressCodeRequest::new();
+            request.set_b58_code(b58_code.to_owned());
+
+            let response = client.read_address_code(&request).unwrap();
+
+            // Check that input equals output.
+            assert_eq!(
+                PublicAddress::try_from(response.get_receiver()).unwrap(),
+                receiver
+            );
+        }
+        
+        // Attempting to decode junk data should fail
+        {
+            let mut request = mc_mobilecoind_api::ReadAddressCodeRequest::new();
+            request.set_b58_code("junk".to_owned());
+
+            assert!(client.read_address_code(&request).is_err());
         }
     }
 


### PR DESCRIPTION
### Motivation

Address Codes are Payment Request codes that do not have an attached amount or memo (or implicitly, a zero amount and an empty memo). Rather than doom ourselves to explaining this thousands of times, we may as well add extra API to match user expectations.

The b58 string returned in the `GetAddressCodeResponse` message should match the preferred export for a "Public Address" within the mobile SDKs.

### In this PR
* Introduces "Address Code" to mobilecoind

### Future Work
* add mob-url construction and export to mobilecoind

