### PR TITLE
Creates a new RPC endpoint for spending a TXO without a monitor

### DIFF
--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -464,6 +464,9 @@ message GenerateTxFromTxOutListRequest {
 
     // Address to transfer coins to
     external.PublicAddress receiver = 3;
+
+    // Fee
+    uint64 fee = 4;
 }
 
 message GenerateTxFromTxOutListResponse {

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -39,6 +39,7 @@ service MobilecoindAPI {
     rpc GenerateTx (GenerateTxRequest) returns (GenerateTxResponse) {}
     rpc GenerateOptimizationTx (GenerateOptimizationTxRequest) returns (GenerateOptimizationTxResponse) {}
     rpc GenerateTransferCodeTx (GenerateTransferCodeTxRequest) returns (GenerateTransferCodeTxResponse) {}
+    rpc GenerateTxFromTxOutList (GenerateTxFromTxOutListRequest) returns (GenerateTxFromTxOutListResponse) {}
     rpc SubmitTx (SubmitTxRequest) returns (SubmitTxResponse) {}
 
     // Databases
@@ -449,6 +450,24 @@ message GenerateTransferCodeTxResponse {
 
     // The b58-encoded Transfer Code
     string b58_code = 5;
+}
+
+// Generate a transaction without a monitor, requires an account key and 
+// a list of UnspentTxOuts. All coins (minus the fee) are transferred to 
+// a single recipient. Used for temporary accounts like gift codes.
+message GenerateTxFromTxOutListRequest {
+    // Account key that owns the transactions
+    external.AccountKey account_key = 1;
+
+    // List of TxOuts to spend
+    repeated UnspentTxOut input_list = 2;
+
+    // Address to transfer coins to
+    external.PublicAddress receiver = 3;
+}
+
+message GenerateTxFromTxOutListResponse {
+    TxProposal tx_proposal = 1;
 }
 
 // Submits a transaction to the network.

--- a/mobilecoind/clients/python/mob_client/mob_client.py
+++ b/mobilecoind/clients/python/mob_client/mob_client.py
@@ -225,11 +225,12 @@ class mob_client:
         response = self.stub.GenerateTransferCodeTx(request)
         return response.tx_proposal, response.entropy
 
-    def generate_tx_from_tx_out_list(self, account_key, input_list, receiver):
+    def generate_tx_from_tx_out_list(self, account_key, input_list, receiver, fee):
         request = api.GenerateTxFromTxOutListRequest(
             account_key=account_key,
             input_list=input_list,
             receiver=receiver,
+            fee=fee,
         )
         response = self.stub.GenerateTxFromTxOutList(request)
         return response.tx_proposal

--- a/mobilecoind/clients/python/mob_client/mob_client.py
+++ b/mobilecoind/clients/python/mob_client/mob_client.py
@@ -164,7 +164,7 @@ class mob_client:
         """
         request = api.ReadTransferCodeRequest(b58_code=b58_code)
         response = self.stub.ReadTransferCode(request)
-        return response.entropy, response.tx_public_key, response.memo, response.utxo
+        return response
 
     def get_transfer_code(self, entropy, tx_public_key, memo=""):
         """ Prepare a "transfer code" used to generate a QR code for wallet apps.

--- a/mobilecoind/clients/python/mob_client/mob_client.py
+++ b/mobilecoind/clients/python/mob_client/mob_client.py
@@ -163,7 +163,7 @@ class mob_client:
         """
         request = api.ReadTransferCodeRequest(b58_code=b58_code)
         response = self.stub.ReadTransferCode(request)
-        return response.entropy, response.tx_public_key, response.memo
+        return response.entropy, response.tx_public_key, response.memo, response.utxo
 
     def get_transfer_code(self, entropy, tx_public_key, memo=""):
         """ Prepare a "transfer code" used to generate a QR code for wallet apps.

--- a/mobilecoind/clients/python/mob_client/mob_client.py
+++ b/mobilecoind/clients/python/mob_client/mob_client.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2018-2020 MobileCoin Inc.
 
+from requests.api import request
 import external_pb2
 import blockchain_pb2
 from google.protobuf import empty_pb2
@@ -223,6 +224,15 @@ class mob_client:
             memo=memo)
         response = self.stub.GenerateTransferCodeTx(request)
         return response.tx_proposal, response.entropy
+
+    def generate_tx_from_tx_out_list(self, account_key, input_list, receiver):
+        request = api.GenerateTxFromTxOutListRequest(
+            account_key=account_key,
+            input_list=input_list,
+            receiver=receiver,
+        )
+        response = self.stub.GenerateTxFromTxOutList(request)
+        return response.tx_proposal
 
     def submit_tx(self, tx_proposal):
         """ Submit a prepared transaction, optionall requesting a tombstone block.

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -322,12 +322,19 @@ impl<T: UserTxConnection + 'static> TransactionsManager<T> {
         let logger = self.logger.new(o!("receiver" => receiver.to_string()));
         log::trace!(logger, "Generating txo list transaction...");
 
+        let fee = if fee == 0 { MINIMUM_FEE } else { fee };
+
         // All inputs are to be spent
         let total_value: u64 = input_list.iter().map(|utxo| utxo.value).sum();
+
+        if total_value < fee {
+            return Err(Error::InsufficientFunds);
+        }
+
         log::trace!(
             logger,
             "Total transaction value excluding fees: {}",
-            total_value
+            total_value - fee
         );
 
         // Get the proofs and the rings

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -317,9 +317,8 @@ impl<T: UserTxConnection + 'static> TransactionsManager<T> {
         account_key: &AccountKey,
         input_list: &[UnspentTxOut],
         receiver: &PublicAddress,
+        fee: u64,
     ) -> Result<TxProposal, Error> {
-        let fee = MINIMUM_FEE;
-
         let logger = self.logger.new(o!("receiver" => receiver.to_string()));
         log::trace!(logger, "Generating txo list transaction...");
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -715,7 +715,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
 
         let tx_proposal = self
             .transactions_manager
-            .generate_tx_from_tx_list(&account_key, &input_list, &receiver)
+            .generate_tx_from_tx_list(&account_key, &input_list, &receiver, request.fee)
             .map_err(|err| {
                 rpc_internal_error(
                     "transactions_manager.generate_tx_from_tx_list",
@@ -2758,6 +2758,73 @@ mod test {
             tx_proposal.tx.prefix.tombstone_block,
             num_blocks + DEFAULT_NEW_TX_BLOCK_ATTEMPTS
         );
+    }
+
+    #[test_with_logger]
+    fn test_generate_tx_from_tx_out_list(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([23u8; 32]);
+
+        let sender = AccountKey::random(&mut rng);
+        let _sender_default_subaddress = sender.default_subaddress();
+        let data = MonitorData::new(
+            sender.clone(),
+            0,  // first_subaddress
+            20, // num_subaddresses
+            0,  // first_block
+            "", // name
+        )
+        .unwrap();
+
+        // 1 known recipient, 3 random recipients and no monitors.
+        let (ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
+            get_testing_environment(
+                3,
+                &vec![sender.default_subaddress()],
+                &vec![],
+                logger.clone(),
+                &mut rng,
+            );
+
+        // Insert into database.
+        let monitor_id = mobilecoind_db.add_monitor(&data).unwrap();
+
+        // Allow the new monitor to process the ledger.
+        wait_for_monitors(&mobilecoind_db, &ledger_db, &logger);
+
+        // Get list of unspent tx outs
+        let utxos = mobilecoind_db
+            .get_utxos_for_subaddress(&monitor_id, 0)
+            .unwrap();
+        assert!(!utxos.is_empty());
+
+        // Build a request to transfer the first two TxOuts
+        let tx_utxos = utxos[0..2].to_vec();
+        let mut request = mc_mobilecoind_api::GenerateTxFromTxOutListRequest::new();
+        request.set_account_key((&sender).into());
+        request.set_input_list(RepeatedField::from_vec(
+            tx_utxos
+                .iter()
+                .map(mc_mobilecoind_api::UnspentTxOut::from)
+                .collect(),
+        ));
+        let receiver = AccountKey::random(&mut rng);
+        request.set_receiver((&receiver.default_subaddress()).into());
+        request.set_fee(MINIMUM_FEE);
+
+        let response = client.generate_tx_from_tx_out_list(&request).unwrap();
+        let tx_proposal = TxProposal::try_from(response.get_tx_proposal()).unwrap();
+
+        // We should end up with one output
+        assert_eq!(tx_proposal.tx.prefix.outputs.len(), 1);
+
+        // It should equal the sum of the inputs minus the fee
+        let expected_value = tx_utxos.iter().map(|utxo| utxo.value).sum::<u64>() - MINIMUM_FEE;
+
+        let tx_out = &tx_proposal.tx.prefix.outputs[0];
+        let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
+        let shared_secret = get_tx_out_shared_secret(receiver.view_private_key(), &tx_public_key);
+        let (value, _blinding) = tx_out.amount.get_value(&shared_secret).unwrap();
+        assert_eq!(value, expected_value);
     }
 
     #[test_with_logger]


### PR DESCRIPTION
Soundtrack of this PR: [I'm Free](https://www.youtube.com/watch?v=S6InAX5IAQM)

### Motivation

Currently there is no way to generate a transaction in mobilecoind without first setting up a monitor which then must view-key scan the entire ledger. In certain instances, for example gift codes, a caller may already know which UTXO they wish to spend, making scanning unnecessary. This PR adds a new RPC endpoint allowing a client to spend UTXOs with an account key without creating a monitor.

### In this PR
* Adds and implements `GenerateTxFromTxOutList` to the gRPC endpoint
* Adds a new function `generate_tx_from_tx_list` to `payments.rs`
* Tests for the above
* update python library support these endpoints

