### PR TITLE
Add offline tx endpoints to mobilecoind-json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,9 +2915,15 @@ dependencies = [
  "hex 0.4.2",
  "mc-api",
  "mc-common",
+ "mc-crypto-keys",
+ "mc-ledger-db",
  "mc-mobilecoind-api",
+ "mc-transaction-core",
+ "mc-transaction-core-test-utils",
+ "mc-util-from-random",
  "mc-util-grpc",
  "protobuf",
+ "rand 0.7.3",
  "rocket",
  "rocket_contrib",
  "serde",
@@ -6424,9 +6430,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "1.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
+checksum = "00ffb05621d7d051df0f020edf3e5db20797a4e522bf1f9c5dfa20603f1c85f6"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -23,6 +23,15 @@ serde_derive = "1.0"
 structopt = "0.3"
 protobuf = "2.12"
 
+[dev-dependencies]
+mc-crypto-keys = { path = "../crypto/keys" }
+mc-ledger-db = { path = "../ledger/db" }
+mc-util-from-random = { path = "../util/from-random" }
+mc-transaction-core = { path = "../transaction/core" }
+mc-transaction-core-test-utils = { path = "../transaction/core/test-utils" }
+
+rand = "0.7"
+
 [build-dependencies]
 # Even though this is unused, it needs to be here otherwise Cargo brings in some weird mixture of packages/features that refuses to compile.
 # Go figure ¯\_(ツ)_/¯

--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -81,9 +81,9 @@ $ curl localhost:9090/codes/request/HUGpTreNKe4ziGAwDNYeW1iayWJgZ4DgiYRk9fw8E7f2
 This JSON can be passed directly to `build-and-submit` or you can change the amount if desired.
 
 #### Build and submit a payment from a monitor/subaddress to a request code
-Using the information in the `read-request`, make creates and submits a transaction. If this succeeds, funds will be transferred.
+Using the information in the `read-request`, creates and submits a transaction. If this succeeds, funds will be transferred.
 ```
-$ curl localhost:9090/monitors/fca4ffa1a1b1faf8ad775d0cf020426ba7f161720403a76126bc8e40550d9872/subaddresses/0/build-tx-and-submit -d '{"receiver":{"view_public_key":"40f884563ff10fb1b37b589036db9abbf1ab7afcf88f17a4ea6ec0077e883263","spend_public_key":"ecf9f2fdb8714afd16446d530cf27f2775d9e356e17a6bba8ad395d16d1bbd45","fog_url":""},"value":"10","memo":"Please pay me"}' -X POST -H 'Content-Type: application/json'
+$ curl localhost:9090/monitors/fca4ffa1a1b1faf8ad775d0cf020426ba7f161720403a76126bc8e40550d9872/subaddresses/0/build-and-submit -d '{"receiver":{"view_public_key":"40f884563ff10fb1b37b589036db9abbf1ab7afcf88f17a4ea6ec0077e883263","spend_public_key":"ecf9f2fdb8714afd16446d530cf27f2775d9e356e17a6bba8ad395d16d1bbd45","fog_url":""},"value":"10","memo":"Please pay me"}' -X POST -H 'Content-Type: application/json'
 
 {"sender_tx_receipt":{"key_images":["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132","7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"],"tombstone":2121}, ,"receiver_tx_receipt_list":[{"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71","spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""},"tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b","tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112","tombstone":2329,"confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}]}
 ```
@@ -92,7 +92,7 @@ This returns receipt information that can be used by the sender to verify their 
 proving that you initiated the transaction
 
 #### Check the status of a transfer with a key image and tombstone block
-The return value from `build-tx-and-submit` can be passed directly directly to `status-as-sender`
+The return value from `build-and-submit` can be passed directly directly to `status-as-sender`
 ```
 $ curl localhost:9090/tx/status-as-sender -d '{"sender_tx_receipt":{"key_images":["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132","7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"],"tombstone":2121}}'  -X POST -H 'Content-Type: application/json'
 
@@ -129,4 +129,29 @@ $ curl localhost:9090/ledger/blocks/1/header
 $ curl localhost:9090/ledger/blocks/1
 
 {"block_id":"7b06f8d069f7c169a5a2be51b24331394af832b1453d679e0cca502d3b131bf1","version":0,"parent_id":"e498010ee6a19b4ac9313af43d8274c53d54a1bbc275c06374dbe0095872a6ee","index":"1","cumulative_txo_count":"10003","contents_hash":"c0486e70c50055ecb54ca1f2e8b02fabd1b2322dcd2c133710c3e3149359adec"}
+```
+
+### Offline Transactions
+
+First, run the mobilecoind binary in offline mode, and run mobilecoind-json, both on the airgapped machine.
+
+#### Get UnspentTxos
+On the airgapped machine, get the utxos in the local ledger.
+
+```
+$ curl localhost:9090/monitors/<monitor_id>/subaddresses/0/utxos
+```
+
+### GenerateTx
+On the airgapped machine, generate a tx proposal.
+
+```
+$ curl localhost:9090/monitors/<monitor-id>/subaddresses/0/generate-tx -d ‘{“input_list”: [<paste output of utxos response>], “transfer”: ‘$(cat request_code.json)’}’ -X POST -H ‘Content-Type: application/json’ > tx_proposal.json
+```
+
+### Submit Propsoal
+Copy the tx_proposal.json to the internet connected machine, and submit.
+
+```
+$ curl localhost:9090/submit -d $(cat tx_propsoal.json) -X POST -H 'Content-Type: application/json'
 ```

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -90,8 +90,18 @@ fn add_monitor(
 
     let mut req = mc_mobilecoind_api::AddMonitorRequest::new();
     req.set_account_key(account_key);
-    req.set_first_subaddress(monitor.first_subaddress);
-    req.set_num_subaddresses(monitor.num_subaddresses);
+    req.set_first_subaddress(
+        monitor
+            .first_subaddress
+            .parse::<u64>()
+            .map_err(|err| format!("Failed to parse u64 from first subaddress: {}", err))?,
+    );
+    req.set_num_subaddresses(
+        monitor
+            .num_subaddresses
+            .parse::<u64>()
+            .map_err(|err| format!("Failed to parse u64 from num subaddresses: {}", err))?,
+    );
     req.set_first_block(0);
 
     let monitor_response = state
@@ -169,6 +179,27 @@ fn balance(
         .map_err(|err| format!("Failed getting balance: {}", err))?;
 
     Ok(Json(JsonBalanceResponse::from(&resp)))
+}
+
+#[get("/monitors/<monitor_hex>/subaddresses/<subaddress_index>/utxos")]
+fn utxos(
+    state: rocket::State<State>,
+    monitor_hex: String,
+    subaddress_index: u64,
+) -> Result<Json<JsonUtxosResponse>, String> {
+    let monitor_id =
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+
+    let mut req = mc_mobilecoind_api::GetUnspentTxOutListRequest::new();
+    req.set_monitor_id(monitor_id);
+    req.set_subaddress_index(subaddress_index);
+
+    let resp = state
+        .mobilecoind_api_client
+        .get_unspent_tx_out_list(&req)
+        .map_err(|err| format!("Failed getting utxos: {}", err))?;
+
+    Ok(Json(JsonUtxosResponse::from(&resp)))
 }
 
 /// Balance check using a created monitor and subaddress index
@@ -319,6 +350,82 @@ fn transfer(
 
     // The receipt from the payment request can be used by the status check below
     Ok(Json(JsonTransferResponse::from(&resp)))
+}
+
+/// Creates a transaction proposal. This can be used in an offline transaction construction
+/// flow, where the proposal is created on the offline machine, and copied to the connected
+/// machine for submission, via submit-tx.
+#[post(
+    "/monitors/<monitor_hex>/subaddresses/<subaddress_index>/generate-request-code-transaction",
+    format = "json",
+    data = "<request>"
+)]
+fn generate_request_code_transaction(
+    state: rocket::State<State>,
+    monitor_hex: String,
+    subaddress_index: u64,
+    request: Json<JsonCreateTxProposalRequest>,
+) -> Result<Json<JsonCreateTxProposalResponse>, String> {
+    let monitor_id =
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+
+    let public_address = PublicAddress::try_from(&request.transfer.receiver)?;
+
+    // Generate an outlay
+    let mut outlay = mc_mobilecoind_api::Outlay::new();
+    outlay.set_receiver(public_address);
+    outlay.set_value(
+        request
+            .transfer
+            .value
+            .parse::<u64>()
+            .map_err(|err| format!("Failed to parse amount: {}", err))?,
+    );
+
+    let inputs: Vec<mc_mobilecoind_api::UnspentTxOut> = request
+        .input_list
+        .iter()
+        .map(|input| {
+            mc_mobilecoind_api::UnspentTxOut::try_from(input)
+                .map_err(|err| format!("Failed to convert input: {}", err))
+        })
+        .collect::<Result<_, String>>()?;
+
+    // Get a tx proposal
+    let mut req = mc_mobilecoind_api::GenerateTxRequest::new();
+    req.set_sender_monitor_id(monitor_id);
+    req.set_change_subaddress(subaddress_index);
+    req.set_outlay_list(RepeatedField::from_vec(vec![outlay]));
+    req.set_input_list(RepeatedField::from_vec(inputs));
+
+    let resp = state
+        .mobilecoind_api_client
+        .generate_tx(&req)
+        .map_err(|err| format!("Failed to generate tx: {}", err))?;
+
+    Ok(Json(JsonCreateTxProposalResponse::from(&resp)))
+}
+
+/// Submit a prepared TxProposal
+#[post("/submit-tx", format = "json", data = "<proposal>")]
+fn submit_tx(
+    state: rocket::State<State>,
+    proposal: Json<JsonTxProposalRequest>,
+) -> Result<Json<JsonSubmitTxResponse>, String> {
+    // Send the payment request
+    let mut req = mc_mobilecoind_api::SubmitTxRequest::new();
+    req.set_tx_proposal(
+        mc_mobilecoind_api::TxProposal::try_from(&proposal.tx_proposal)
+            .map_err(|err| format!("Failed to convert tx proposal: {}", err))?,
+    );
+
+    let resp = state
+        .mobilecoind_api_client
+        .submit_tx(&req)
+        .map_err(|err| format!("Failed to send payment: {}", err))?;
+
+    // The receipt from the payment request can be used by the status check below
+    Ok(Json(JsonSubmitTxResponse::from(&resp)))
 }
 
 /// Checks the status of a transfer given a key image and tombstone block
@@ -486,12 +593,15 @@ fn main() {
                 monitors,
                 monitor_status,
                 balance,
+                utxos,
                 public_address,
                 get_request_code,
                 read_request_code,
                 get_address_code,
                 read_address_code,
                 transfer,
+                generate_request_code_transaction,
+                submit_tx,
                 check_transfer_status,
                 check_receiver_transfer_status,
                 ledger_info,

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -90,18 +90,8 @@ fn add_monitor(
 
     let mut req = mc_mobilecoind_api::AddMonitorRequest::new();
     req.set_account_key(account_key);
-    req.set_first_subaddress(
-        monitor
-            .first_subaddress
-            .parse::<u64>()
-            .map_err(|err| format!("Failed to parse u64 from first subaddress: {}", err))?,
-    );
-    req.set_num_subaddresses(
-        monitor
-            .num_subaddresses
-            .parse::<u64>()
-            .map_err(|err| format!("Failed to parse u64 from num subaddresses: {}", err))?,
-    );
+    req.set_first_subaddress(monitor.first_subaddress);
+    req.set_num_subaddresses(monitor.num_subaddresses);
     req.set_first_block(0);
 
     let monitor_response = state

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -2,9 +2,14 @@
 
 //! Serializeable data types that wrap the mobilecoind API.
 
-use mc_api::external::{CompressedRistretto, PublicAddress};
+use mc_api::external::{
+    Amount, CompressedRistretto, EncryptedFogHint, KeyImage, PublicAddress, RingMLSAG,
+    SignatureRctBulletproofs, Tx, TxIn, TxOutMembershipElement, TxOutMembershipHash,
+    TxOutMembershipProof, TxPrefix,
+};
+use protobuf::RepeatedField;
 use serde_derive::{Deserialize, Serialize};
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom, iter::FromIterator};
 
 #[derive(Serialize, Default)]
 pub struct JsonEntropyResponse {
@@ -39,8 +44,8 @@ impl From<&mc_mobilecoind_api::GetAccountKeyResponse> for JsonAccountKeyResponse
 #[derive(Deserialize, Default)]
 pub struct JsonMonitorRequest {
     pub account_key: JsonAccountKeyResponse,
-    pub first_subaddress: u64,
-    pub num_subaddresses: u64,
+    pub first_subaddress: String,
+    pub num_subaddresses: String,
 }
 
 #[derive(Serialize, Default)]
@@ -99,6 +104,83 @@ impl From<&mc_mobilecoind_api::GetBalanceResponse> for JsonBalanceResponse {
     fn from(src: &mc_mobilecoind_api::GetBalanceResponse) -> Self {
         Self {
             balance: src.balance.to_string(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct JsonUnspentTxOut {
+    pub tx_out: JsonTxOut,
+    pub subaddress_index: u64,
+    pub key_image: String,
+    pub value: String, // Needs to be String since Javascript ints are not 64 bit.
+    pub attempted_spend_height: u64,
+    pub attempted_spend_tombstone: u64,
+    pub monitor_id: String,
+}
+
+impl From<&mc_mobilecoind_api::UnspentTxOut> for JsonUnspentTxOut {
+    fn from(src: &mc_mobilecoind_api::UnspentTxOut) -> Self {
+        Self {
+            tx_out: src.get_tx_out().into(),
+            subaddress_index: src.get_subaddress_index(),
+            key_image: hex::encode(&src.get_key_image().get_data()),
+            value: src.value.to_string(),
+            attempted_spend_height: src.get_attempted_spend_height(),
+            attempted_spend_tombstone: src.get_attempted_spend_tombstone(),
+            monitor_id: hex::encode(&src.get_monitor_id()),
+        }
+    }
+}
+
+// Helper conversion between json and protobuf
+impl TryFrom<&JsonUnspentTxOut> for mc_mobilecoind_api::UnspentTxOut {
+    type Error = String;
+
+    fn try_from(src: &JsonUnspentTxOut) -> Result<mc_mobilecoind_api::UnspentTxOut, String> {
+        let mut key_image = KeyImage::new();
+        key_image.set_data(
+            hex::decode(&src.key_image)
+                .map_err(|err| format!("Failed to decode key image hex: {}", err))?,
+        );
+
+        // Reconstruct the public address as a protobuf
+        let mut utxo = mc_mobilecoind_api::UnspentTxOut::new();
+        utxo.set_tx_out(
+            mc_api::external::TxOut::try_from(&src.tx_out)
+                .map_err(|err| format!("Failed to get TxOut: {}", err))?,
+        );
+        utxo.set_subaddress_index(src.subaddress_index);
+        utxo.set_key_image(key_image);
+        utxo.set_value(
+            src.value
+                .parse::<u64>()
+                .map_err(|err| format!("Failed to parse u64 from value: {}", err))?,
+        );
+        utxo.set_attempted_spend_height(src.attempted_spend_height);
+        utxo.set_attempted_spend_tombstone(src.attempted_spend_tombstone);
+        utxo.set_monitor_id(
+            hex::decode(&src.monitor_id)
+                .map_err(|err| format!("Failed to decode monitor id hex: {}", err))?,
+        );
+
+        Ok(utxo)
+    }
+}
+
+#[derive(Serialize, Default)]
+pub struct JsonUtxosResponse {
+    pub output_list: Vec<JsonUnspentTxOut>,
+}
+
+impl From<&mc_mobilecoind_api::GetUnspentTxOutListResponse> for JsonUtxosResponse {
+    fn from(src: &mc_mobilecoind_api::GetUnspentTxOutListResponse) -> Self {
+        Self {
+            output_list: src
+                .get_output_list()
+                .iter()
+                .map(JsonUnspentTxOut::from)
+                .collect(),
         }
     }
 }
@@ -292,6 +374,560 @@ impl From<&mc_mobilecoind_api::SendPaymentResponse> for JsonTransferResponse {
     }
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct JsonOutlay {
+    pub value: String,
+    pub receiver: JsonPublicAddress,
+}
+
+impl From<&mc_mobilecoind_api::Outlay> for JsonOutlay {
+    fn from(src: &mc_mobilecoind_api::Outlay) -> Self {
+        Self {
+            value: src.get_value().to_string(),
+            receiver: src.get_receiver().into(),
+        }
+    }
+}
+
+impl TryFrom<&JsonOutlay> for mc_mobilecoind_api::Outlay {
+    type Error = String;
+
+    fn try_from(src: &JsonOutlay) -> Result<mc_mobilecoind_api::Outlay, String> {
+        let mut outlay = mc_mobilecoind_api::Outlay::new();
+        outlay.set_value(
+            src.value
+                .parse::<u64>()
+                .map_err(|err| format!("Failed to parse u64 from value: {}", err))?,
+        );
+        outlay.set_receiver(
+            PublicAddress::try_from(&src.receiver)
+                .map_err(|err| format!("Could not convert receiver: {}", err))?,
+        );
+
+        Ok(outlay)
+    }
+}
+
+#[derive(Deserialize, Serialize, Default)]
+pub struct JsonAmount {
+    pub commitment: String,
+    pub masked_value: String,
+}
+
+impl From<&Amount> for JsonAmount {
+    fn from(src: &Amount) -> Self {
+        Self {
+            commitment: hex::encode(src.get_commitment().get_data()),
+            masked_value: src.get_masked_value().to_string(),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Default)]
+pub struct JsonTxOut {
+    pub amount: JsonAmount,
+    pub target_key: String,
+    pub public_key: String,
+    pub e_fog_hint: String,
+}
+
+impl From<&mc_api::external::TxOut> for JsonTxOut {
+    fn from(src: &mc_api::external::TxOut) -> Self {
+        Self {
+            amount: src.get_amount().into(),
+            target_key: hex::encode(src.get_target_key().get_data()),
+            public_key: hex::encode(src.get_public_key().get_data()),
+            e_fog_hint: hex::encode(src.get_e_fog_hint().get_data()),
+        }
+    }
+}
+
+// Helper conversion between json and protobuf
+impl TryFrom<&JsonTxOut> for mc_api::external::TxOut {
+    type Error = String;
+
+    fn try_from(src: &JsonTxOut) -> Result<mc_api::external::TxOut, String> {
+        let mut commitment = CompressedRistretto::new();
+        commitment.set_data(
+            hex::decode(&src.amount.commitment)
+                .map_err(|err| format!("Failed to decode commitment hex: {}", err))?,
+        );
+        let mut amount = Amount::new();
+        amount.set_commitment(commitment);
+        amount.set_masked_value(
+            src.amount
+                .masked_value
+                .parse::<u64>()
+                .map_err(|err| format!("Failed to parse u64 from value: {}", err))?,
+        );
+        let mut target_key = CompressedRistretto::new();
+        target_key.set_data(
+            hex::decode(&src.target_key)
+                .map_err(|err| format!("Failed to decode target key hex: {}", err))?,
+        );
+        let mut public_key = CompressedRistretto::new();
+        public_key.set_data(
+            hex::decode(&src.public_key)
+                .map_err(|err| format!("Failed to decode public key hex: {}", err))?,
+        );
+        let mut e_fog_hint = EncryptedFogHint::new();
+        e_fog_hint.set_data(
+            hex::decode(&src.e_fog_hint)
+                .map_err(|err| format!("Failed to decode e_fog_hint hex: {}", err))?,
+        );
+
+        let mut txo = mc_api::external::TxOut::new();
+        txo.set_amount(amount);
+        txo.set_target_key(target_key);
+        txo.set_public_key(public_key);
+        txo.set_e_fog_hint(e_fog_hint);
+
+        Ok(txo)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct JsonRange {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct JsonTxOutMembershipElement {
+    pub range: JsonRange,
+    pub hash: String,
+}
+
+impl From<&TxOutMembershipElement> for JsonTxOutMembershipElement {
+    fn from(src: &TxOutMembershipElement) -> Self {
+        Self {
+            range: JsonRange {
+                from: src.get_range().get_from().to_string(),
+                to: src.get_range().get_to().to_string(),
+            },
+            hash: hex::encode(src.get_hash().get_data()),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct JsonTxOutMembershipProof {
+    pub index: String,
+    pub highest_index: String,
+    pub elements: Vec<JsonTxOutMembershipElement>,
+}
+
+impl From<&TxOutMembershipProof> for JsonTxOutMembershipProof {
+    fn from(src: &TxOutMembershipProof) -> Self {
+        Self {
+            index: src.get_index().to_string(),
+            highest_index: src.get_highest_index().to_string(),
+            elements: src
+                .get_elements()
+                .iter()
+                .map(JsonTxOutMembershipElement::from)
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<&JsonTxOutMembershipProof> for TxOutMembershipProof {
+    type Error = String;
+
+    fn try_from(src: &JsonTxOutMembershipProof) -> Result<TxOutMembershipProof, String> {
+        let mut elements: Vec<TxOutMembershipElement> = Vec::new();
+        for element in &src.elements {
+            let mut range = mc_api::external::Range::new();
+            range.set_from(
+                element
+                    .range
+                    .from
+                    .parse::<u64>()
+                    .map_err(|err| format!("Failed to parse u64 from range.from: {}", err))?,
+            );
+            range.set_to(
+                element
+                    .range
+                    .to
+                    .parse::<u64>()
+                    .map_err(|err| format!("Failed to parse u64 from range.to: {}", err))?,
+            );
+
+            let mut hash = TxOutMembershipHash::new();
+            hash.set_data(
+                hex::decode(&element.hash)
+                    .map_err(|err| format!("Could not decode elem hash: {}", err))?,
+            );
+
+            let mut elem = TxOutMembershipElement::new();
+            elem.set_range(range);
+            elem.set_hash(hash);
+            elements.push(elem);
+        }
+
+        let mut proof = TxOutMembershipProof::new();
+        proof.set_index(
+            src.index
+                .parse::<u64>()
+                .map_err(|err| format!("Failed to parse u64 from index: {}", err))?,
+        );
+        proof.set_highest_index(
+            src.highest_index
+                .parse::<u64>()
+                .map_err(|err| format!("Failed to parse u64 from highest_index: {}", err))?,
+        );
+        proof.set_elements(RepeatedField::from_vec(elements));
+
+        Ok(proof)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct JsonTxIn {
+    pub ring: Vec<JsonTxOut>,
+    pub proofs: Vec<JsonTxOutMembershipProof>,
+}
+
+impl From<&TxIn> for JsonTxIn {
+    fn from(src: &TxIn) -> Self {
+        Self {
+            ring: src.get_ring().iter().map(JsonTxOut::from).collect(),
+            proofs: src
+                .get_proofs()
+                .iter()
+                .map(JsonTxOutMembershipProof::from)
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<&JsonTxIn> for TxIn {
+    type Error = String;
+
+    fn try_from(src: &JsonTxIn) -> Result<TxIn, String> {
+        let mut outputs: Vec<mc_api::external::TxOut> = Vec::new();
+        for output in &src.ring {
+            let p_output = mc_api::external::TxOut::try_from(output)
+                .map_err(|err| format!("Could not get TxOut: {}", err))?;
+            outputs.push(p_output);
+        }
+
+        let mut proofs: Vec<TxOutMembershipProof> = Vec::new();
+        for proof in &src.proofs {
+            let p_proof = TxOutMembershipProof::try_from(proof)
+                .map_err(|err| format!("Could not get proof: {}", err))?;
+            proofs.push(p_proof);
+        }
+
+        let mut txin = TxIn::new();
+        txin.set_ring(RepeatedField::from_vec(outputs));
+        txin.set_proofs(RepeatedField::from_vec(proofs));
+
+        Ok(txin)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct JsonTxPrefix {
+    pub inputs: Vec<JsonTxIn>,
+    pub outputs: Vec<JsonTxOut>,
+    pub fee: String,
+    tombstone_block: String,
+}
+
+impl From<&TxPrefix> for JsonTxPrefix {
+    fn from(src: &TxPrefix) -> Self {
+        Self {
+            inputs: src.get_inputs().iter().map(JsonTxIn::from).collect(),
+            outputs: src.get_outputs().iter().map(JsonTxOut::from).collect(),
+            fee: src.get_fee().to_string(),
+            tombstone_block: src.get_tombstone_block().to_string(),
+        }
+    }
+}
+
+impl TryFrom<&JsonTxPrefix> for TxPrefix {
+    type Error = String;
+
+    fn try_from(src: &JsonTxPrefix) -> Result<TxPrefix, String> {
+        let mut inputs: Vec<TxIn> = Vec::new();
+        for input in &src.inputs {
+            let p_input =
+                TxIn::try_from(input).map_err(|err| format!("Could not get TxIn: {}", err))?;
+            inputs.push(p_input);
+        }
+
+        let mut outputs: Vec<mc_api::external::TxOut> = Vec::new();
+        for output in &src.outputs {
+            let p_output = mc_api::external::TxOut::try_from(output)
+                .map_err(|err| format!("Could not get TxOut: {}", err))?;
+            outputs.push(p_output);
+        }
+
+        let mut prefix = TxPrefix::new();
+        prefix.set_inputs(RepeatedField::from_vec(inputs));
+        prefix.set_outputs(RepeatedField::from_vec(outputs));
+        prefix.set_fee(
+            src.fee
+                .parse::<u64>()
+                .map_err(|err| format!("Failed to parse u64 from fee: {}", err))?,
+        );
+        prefix.set_tombstone_block(
+            src.tombstone_block
+                .parse::<u64>()
+                .map_err(|err| format!("Failed to parse u64 from tombstone_block: {}", err))?,
+        );
+
+        Ok(prefix)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct JsonRingMLSAG {
+    pub c_zero: String,
+    pub responses: Vec<String>,
+    pub key_image: String,
+}
+
+impl From<&RingMLSAG> for JsonRingMLSAG {
+    fn from(src: &RingMLSAG) -> Self {
+        Self {
+            c_zero: hex::encode(src.get_c_zero().get_data()),
+            responses: src
+                .get_responses()
+                .iter()
+                .map(|x| hex::encode(x.get_data()))
+                .collect(),
+            key_image: hex::encode(src.get_key_image().get_data()),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct JsonSignatureRctBulletproofs {
+    pub ring_signatures: Vec<JsonRingMLSAG>,
+    pub pseudo_output_commitments: Vec<String>,
+    range_proofs: Vec<u8>,
+}
+
+impl From<&SignatureRctBulletproofs> for JsonSignatureRctBulletproofs {
+    fn from(src: &SignatureRctBulletproofs) -> Self {
+        Self {
+            ring_signatures: src
+                .get_ring_signatures()
+                .iter()
+                .map(JsonRingMLSAG::from)
+                .collect(),
+            pseudo_output_commitments: src
+                .get_pseudo_output_commitments()
+                .iter()
+                .map(|x| hex::encode(x.get_data()))
+                .collect(),
+            range_proofs: src.get_range_proofs().to_vec(),
+        }
+    }
+}
+
+impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
+    type Error = String;
+
+    fn try_from(src: &JsonSignatureRctBulletproofs) -> Result<SignatureRctBulletproofs, String> {
+        let mut ring_sigs: Vec<RingMLSAG> = Vec::new();
+        for sig in &src.ring_signatures {
+            let mut c_zero = mc_api::external::CurveScalar::new();
+            c_zero.set_data(
+                hex::decode(&sig.c_zero)
+                    .map_err(|err| format!("Could not decode from hex: {}", err))?,
+            );
+
+            let mut responses: Vec<mc_api::external::CurveScalar> = Vec::new();
+            for resp in &sig.responses {
+                let mut response = mc_api::external::CurveScalar::new();
+                response.set_data(
+                    hex::decode(resp)
+                        .map_err(|err| format!("Could not decode from hex: {}", err))?,
+                );
+                responses.push(response);
+            }
+
+            let mut key_image = KeyImage::new();
+            key_image.set_data(
+                hex::decode(&sig.key_image)
+                    .map_err(|err| format!("Could not decode from hex: {}", err))?,
+            );
+
+            let mut ring_sig = RingMLSAG::new();
+            ring_sig.set_c_zero(c_zero);
+            ring_sig.set_responses(RepeatedField::from_vec(responses));
+            ring_sig.set_key_image(key_image);
+
+            ring_sigs.push(ring_sig);
+        }
+
+        let mut commitments: Vec<CompressedRistretto> = Vec::new();
+        for comm in &src.pseudo_output_commitments {
+            let mut compressed = CompressedRistretto::new();
+            compressed.set_data(
+                hex::decode(&comm).map_err(|err| format!("Could not decode from hex: {}", err))?,
+            );
+            commitments.push(compressed);
+        }
+
+        let mut signature = SignatureRctBulletproofs::new();
+        signature.set_ring_signatures(RepeatedField::from_vec(ring_sigs));
+        signature.set_pseudo_output_commitments(RepeatedField::from_vec(commitments));
+        signature.set_range_proofs(src.range_proofs.clone());
+
+        Ok(signature)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct JsonTx {
+    pub prefix: JsonTxPrefix,
+    pub signature: JsonSignatureRctBulletproofs,
+}
+
+impl From<&Tx> for JsonTx {
+    fn from(src: &Tx) -> Self {
+        Self {
+            prefix: src.get_prefix().into(),
+            signature: src.get_signature().into(),
+        }
+    }
+}
+
+impl TryFrom<&JsonTx> for Tx {
+    type Error = String;
+
+    fn try_from(src: &JsonTx) -> Result<Tx, String> {
+        let mut tx = Tx::new();
+
+        tx.set_prefix(
+            TxPrefix::try_from(&src.prefix)
+                .map_err(|err| format!("Could not convert TxPrefix: {}", err))?,
+        );
+        tx.set_signature(
+            SignatureRctBulletproofs::try_from(&src.signature)
+                .map_err(|err| format!("Could not convert signature: {}", err))?,
+        );
+
+        Ok(tx)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct JsonTxProposal {
+    pub input_list: Vec<JsonUnspentTxOut>,
+    pub outlay_list: Vec<JsonOutlay>,
+    pub tx: JsonTx,
+    pub fee: u64,
+    pub outlay_index_to_tx_out_index: Vec<(u64, u64)>,
+    pub outlay_confirmation_numbers: Vec<Vec<u8>>,
+}
+
+impl From<&mc_mobilecoind_api::TxProposal> for JsonTxProposal {
+    fn from(src: &mc_mobilecoind_api::TxProposal) -> Self {
+        let outlay_map: Vec<(u64, u64)> = src
+            .get_outlay_index_to_tx_out_index()
+            .iter()
+            .map(|(key, val)| (*key, *val))
+            .collect();
+        Self {
+            input_list: src
+                .get_input_list()
+                .iter()
+                .map(JsonUnspentTxOut::from)
+                .collect(),
+            outlay_list: src.get_outlay_list().iter().map(JsonOutlay::from).collect(),
+            tx: src.get_tx().into(),
+            fee: src.get_fee(),
+            outlay_index_to_tx_out_index: outlay_map,
+            outlay_confirmation_numbers: src.get_outlay_confirmation_numbers().to_vec(),
+        }
+    }
+}
+
+// Helper conversion between json and protobuf
+impl TryFrom<&JsonTxProposal> for mc_mobilecoind_api::TxProposal {
+    type Error = String;
+
+    fn try_from(src: &JsonTxProposal) -> Result<mc_mobilecoind_api::TxProposal, String> {
+        let mut inputs: Vec<mc_mobilecoind_api::UnspentTxOut> = Vec::new();
+        for input in src.input_list.iter() {
+            let utxo = mc_mobilecoind_api::UnspentTxOut::try_from(input)
+                .map_err(|err| format!("Failed to convert input: {}", err))?;
+            inputs.push(utxo);
+        }
+
+        let mut outlays: Vec<mc_mobilecoind_api::Outlay> = Vec::new();
+        for outlay in src.outlay_list.iter() {
+            let out = mc_mobilecoind_api::Outlay::try_from(outlay)
+                .map_err(|err| format!("Failed to convert outlay: {}", err))?;
+            outlays.push(out);
+        }
+
+        // Reconstruct the public address as a protobuf
+        let mut proposal = mc_mobilecoind_api::TxProposal::new();
+        proposal.set_input_list(RepeatedField::from_vec(inputs));
+        proposal.set_outlay_list(RepeatedField::from_vec(outlays));
+        proposal
+            .set_tx(Tx::try_from(&src.tx).map_err(|err| format!("Could not convert tx: {}", err))?);
+        proposal.set_fee(src.fee);
+        proposal.set_outlay_index_to_tx_out_index(HashMap::from_iter(
+            src.outlay_index_to_tx_out_index.clone(),
+        ));
+        proposal.set_outlay_confirmation_numbers(RepeatedField::from_vec(
+            src.outlay_confirmation_numbers.clone(),
+        ));
+
+        Ok(proposal)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct JsonCreateTxProposalRequest {
+    pub input_list: Vec<JsonUnspentTxOut>,
+    pub transfer: JsonReadRequestCodeResponse,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct JsonCreateTxProposalResponse {
+    pub tx_proposal: JsonTxProposal,
+}
+
+impl From<&mc_mobilecoind_api::GenerateTxResponse> for JsonCreateTxProposalResponse {
+    fn from(src: &mc_mobilecoind_api::GenerateTxResponse) -> Self {
+        Self {
+            tx_proposal: src.get_tx_proposal().into(),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct JsonTxProposalRequest {
+    pub tx_proposal: JsonTxProposal,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct JsonSubmitTxResponse {
+    pub sender_tx_receipt: JsonSenderTxReceipt,
+    pub receiver_tx_receipt_list: Vec<JsonReceiverTxReceipt>,
+}
+
+impl From<&mc_mobilecoind_api::SubmitTxResponse> for JsonSubmitTxResponse {
+    fn from(src: &mc_mobilecoind_api::SubmitTxResponse) -> Self {
+        Self {
+            sender_tx_receipt: src.get_sender_tx_receipt().into(),
+            receiver_tx_receipt_list: src
+                .get_receiver_tx_receipt_list()
+                .iter()
+                .map(JsonReceiverTxReceipt::from)
+                .collect(),
+        }
+    }
+}
+
 #[derive(Serialize, Default)]
 pub struct JsonStatusResponse {
     pub status: String,
@@ -425,5 +1061,161 @@ impl From<&mc_mobilecoind_api::GetProcessedBlockResponse> for JsonProcessedBlock
                 .map(JsonProcessedTxOut::from)
                 .collect(),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use mc_crypto_keys::RistrettoPublic;
+    use mc_ledger_db::Ledger;
+    use mc_transaction_core::{amount::Amount, encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN};
+    use mc_transaction_core_test_utils::{
+        create_ledger, create_transaction, initialize_ledger, AccountKey,
+    };
+    use mc_util_from_random::FromRandom;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    /// Test conversion of TxProposal
+    #[test]
+    fn test_tx_proposal_conversion() {
+        // First, go from rust -> proto
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+        let tx = {
+            let mut ledger = create_ledger();
+            let sender = AccountKey::random(&mut rng);
+            let recipient = AccountKey::random(&mut rng);
+            initialize_ledger(&mut ledger, 1, &sender, &mut rng);
+
+            let block_contents = ledger.get_block_contents(0).unwrap();
+            let tx_out = block_contents.outputs[0].clone();
+
+            create_transaction(
+                &mut ledger,
+                &tx_out,
+                &sender,
+                &recipient.default_subaddress(),
+                10,
+                &mut rng,
+            )
+        };
+
+        let utxo = {
+            let tx_out = mc_transaction_core::tx::TxOut {
+                amount: Amount::new(1u64 << 13, &RistrettoPublic::from_random(&mut rng)).unwrap(),
+                target_key: RistrettoPublic::from_random(&mut rng).into(),
+                public_key: RistrettoPublic::from_random(&mut rng).into(),
+                e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
+            };
+
+            let subaddress_index = 123;
+            let key_image = mc_transaction_core::ring_signature::KeyImage::from(456);
+            let value = 789;
+            let attempted_spend_height = 1000;
+            let attempted_spend_tombstone = 1234;
+
+            // make proto UnspentTxOut
+            let mut unspent = mc_mobilecoind_api::UnspentTxOut::new();
+            unspent.set_tx_out(mc_api::external::TxOut::from(&tx_out));
+            unspent.set_subaddress_index(subaddress_index);
+            unspent.set_key_image(mc_api::external::KeyImage::from(&key_image));
+            unspent.set_value(value);
+            unspent.set_attempted_spend_height(attempted_spend_height);
+            unspent.set_attempted_spend_tombstone(attempted_spend_tombstone);
+            unspent
+        };
+
+        // Make proto outlay
+        let mut outlay = mc_mobilecoind_api::Outlay::new();
+        let public_addr = AccountKey::random(&mut rng).default_subaddress();
+        outlay.set_receiver(mc_api::external::PublicAddress::from(&public_addr));
+        outlay.set_value(1234);
+
+        let outlay_index_to_tx_out_index = HashMap::from_iter(vec![(0, 0)]);
+        let outlay_confirmation_numbers =
+            vec![mc_transaction_core::tx::TxOutConfirmationNumber::from(
+                [0u8; 32],
+            )];
+
+        // Make proto TxProposal
+        let mut proto_proposal = mc_mobilecoind_api::TxProposal::new();
+        proto_proposal.set_input_list(RepeatedField::from_vec(vec![utxo]));
+        proto_proposal.set_outlay_list(RepeatedField::from_vec(vec![outlay]));
+        proto_proposal.set_tx(mc_api::external::Tx::from(&tx));
+        proto_proposal.set_outlay_index_to_tx_out_index(outlay_index_to_tx_out_index);
+        proto_proposal.set_outlay_confirmation_numbers(RepeatedField::from_vec(
+            outlay_confirmation_numbers
+                .iter()
+                .map(|x| x.to_vec())
+                .collect(),
+        ));
+
+        // Proto -> Json
+        let json_proposal = JsonTxProposal::from(&proto_proposal);
+
+        // Json -> Proto
+        let proto2 = mc_mobilecoind_api::TxProposal::try_from(&json_proposal).unwrap();
+
+        // Assert each field, then the whole thing
+        assert_eq!(proto_proposal.input_list, proto2.input_list);
+        assert_eq!(proto_proposal.outlay_list, proto2.outlay_list);
+
+        // The tx is complicated, so check each field of the tx
+        assert_eq!(proto_proposal.get_tx().prefix, proto2.get_tx().prefix);
+        assert_eq!(
+            proto_proposal
+                .get_tx()
+                .get_signature()
+                .get_ring_signatures()[0]
+                .c_zero,
+            proto2.get_tx().get_signature().get_ring_signatures()[0].c_zero
+        );
+        assert_eq!(
+            proto_proposal
+                .get_tx()
+                .get_signature()
+                .get_ring_signatures()[0]
+                .responses,
+            proto2.get_tx().get_signature().get_ring_signatures()[0].responses
+        );
+        assert_eq!(
+            proto_proposal
+                .get_tx()
+                .get_signature()
+                .get_ring_signatures()[0]
+                .key_image,
+            proto2.get_tx().get_signature().get_ring_signatures()[0].key_image
+        );
+        assert_eq!(
+            proto_proposal.get_tx().get_signature().ring_signatures,
+            proto2.get_tx().get_signature().ring_signatures
+        );
+        assert_eq!(
+            proto_proposal
+                .get_tx()
+                .get_signature()
+                .pseudo_output_commitments,
+            proto2.get_tx().get_signature().pseudo_output_commitments
+        );
+        assert_eq!(
+            proto_proposal.get_tx().get_signature().range_proofs,
+            proto2.get_tx().get_signature().range_proofs
+        );
+
+        assert_eq!(proto_proposal.get_tx().signature, proto2.get_tx().signature);
+        assert_eq!(proto_proposal.tx, proto2.tx);
+
+        // Check the rest of the fields
+        assert_eq!(proto_proposal.fee, proto2.fee);
+        assert_eq!(
+            proto_proposal.outlay_index_to_tx_out_index,
+            proto2.outlay_index_to_tx_out_index
+        );
+        assert_eq!(
+            proto_proposal.outlay_confirmation_numbers,
+            proto2.outlay_confirmation_numbers
+        );
+        assert_eq!(proto_proposal, proto2);
     }
 }

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -44,8 +44,8 @@ impl From<&mc_mobilecoind_api::GetAccountKeyResponse> for JsonAccountKeyResponse
 #[derive(Deserialize, Default)]
 pub struct JsonMonitorRequest {
     pub account_key: JsonAccountKeyResponse,
-    pub first_subaddress: String,
-    pub num_subaddresses: String,
+    pub first_subaddress: u64,
+    pub num_subaddresses: u64,
 }
 
 #[derive(Serialize, Default)]

--- a/mobilecoind/README.md
+++ b/mobilecoind/README.md
@@ -99,8 +99,9 @@ Offline transactions are a way of constructing a transaction on a machine that i
 The steps for constructing and submitting an offline transaction are:
 
 1. Copy a recent copy of the ledger database into the airgapped machine. The copied ledger should include TxOuts that are spendable by the user.
-1. Run `mobilecoind` on the airgapped machine: `MC_LOG=trace CONSENSUS_ENCLAVE_CSS=$(pwd)/consensus-enclave.css SGX_MODE=SW IAS_MODE=DEV cargo run -p mc-mobilecoind --release -- --offline --listen-uri insecure-mobilecoind://127.0.0.1:4444/ --mobilecoind-db /tmp/wallet-db`. Note that a CSS file is still needed since its impossible to build mobilecoind without one, unless you are able to compile the enclave.
-1. Connect to this `mobilecoind`, add a monitor with your keys, let it scan the ledger, and construct a transaction using the `GenerateTx` API call.
-1. `GenerateTx` will return a `TxProposal` message, which you can then protobuf-encode into a blob of bytes.
-1. Copy this blob of bytes into a machine that has internet access and `mobilecoind` running.
-1. Decode the blob of bytes back into a `TxProposaland` submit it using the `SubmitTx` API call. Even if the `mobilecoind` instance you are submitting to has no monitors defined at all, this would still work.
+1. Copy the pre-built mobilecoind binary to the airgapped machine.
+1. Run `mobilecoind` on the airgapped machine: `MC_LOG=trace ./mobilecoind --release -- --offline --listen-uri insecure-mobilecoind://127.0.0.1:4444/ --mobilecoind-db /tmp/wallet-db`.
+1. Connect to this `mobilecoind`, add a monitor with your keys, let it scan the ledger, and construct a transaction using the `GenerateTx` API call, using one of the clients such as `mobilecoind-json`.
+1. `GenerateTx` will return a `TxProposal`, which you can then copy back to the internet-connected machine.
+1. Copy this `TxProposal` into a machine that has internet access and `mobilecoind` running.
+1. Decode the `TxProposal` and submit it using the `SubmitTx` API call. Even if the `mobilecoind` instance you are submitting to has no monitors defined at all, this would still work.


### PR DESCRIPTION
Soundtrack of this PR: [Buttercup](https://www.youtube.com/watch?v=e2qG5uwDCW4)

### Motivation

Currently the GetUnspentTxOutList, GenerateTx, and Submit endpoints are not exposed on mobilecoind-json.

### In this PR
* Adds GetUnspentTxOutList to mobilecoind-json (needed to get inputs for constructing offline transactions)
* Adds GenerateTx to mobilecoind-json (needed for offline transactions)
* Adds Submit to mobilecoind-json (needed for offline transactions)
* Adds necessary json conversions
* Updates READMEs to reflect offline usage and new endpoints

[MCC-1751](https://mobilecoin.atlassian.net/browse/MCC-1751)
