### PR TITLE
Add bash function wrapper to log services and restart them if they die

### DIFF
--- a/ops/entrypoints/consensus_validator.sh
+++ b/ops/entrypoints/consensus_validator.sh
@@ -47,7 +47,7 @@ fi
 # If the ledgerdir is not already populated, copy the origin block.
 if [ ! -r "${NODE_LEDGER_DIR}/data.mdb" ]; then
     mkdir -p "${NODE_LEDGER_DIR}"
-    rsync -a --delete /var/lib/mobilecoin/origin_data/* ${NODE_LEDGER_DIR}/
+    rsync -a /var/lib/mobilecoin/origin_data/* ${NODE_LEDGER_DIR}/
 fi
 
 # Update the ledger to the current version if necessary
@@ -66,4 +66,4 @@ rm -rf /scp-debug-dump/${LOCAL_NODE_ID}
 
 launch /usr/bin/mc-admin-http-gateway --listen-host 0.0.0.0 --listen-port ${NODE_MANAGEMENT_PORT} --admin-uri insecure-mca://127.0.0.1:9091/
 
-exec env consensus-service $@
+exec consensus-service $@

--- a/ops/entrypoints/consensus_validator.sh
+++ b/ops/entrypoints/consensus_validator.sh
@@ -9,6 +9,24 @@
 # exit if anything fails.
 set -e
 
+function launch() {
+  app=$(basename $1)
+  (set +e; while true; do
+    echo "${@}"
+    if [ -z "${NODE_LOG_DIR}" ]; then
+       ${@}
+    else
+       ${@} >> ${NODE_LOG_DIR}/${app}.log 2>&1
+    fi
+    echo "${app} died; restarting after 10 seconds" >&2
+    sleep 10
+  done) &
+}
+
+if [ ! -z "${NODE_LOG_DIR}" ]; then
+  mkdir -p ${NODE_LOG_DIR}
+fi
+
 if [ -c /dev/isgx ]; then
   # Use a subshell to prevent environment leakage
   (
@@ -20,7 +38,7 @@ if [ -c /dev/isgx ]; then
     /bin/chown -R aesmd:aesmd /var/run/aesmd/
     /bin/chmod 0755 /var/run/aesmd/
     /bin/chown -R aesmd:aesmd /var/opt/aesmd/
-    ${AESM_PATH}/aesm_service &
+    launch ${AESM_PATH}/aesm_service --no-daemon
   )
 
   sleep 1
@@ -38,14 +56,14 @@ fi
 if [[ -z "${AWS_PATH}" ]] || [[ -z "${AWS_SECRET_ACCESS_KEY}" ]] || [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
   echo "Warning: Must provide AWS_PATH, AWS_SECRET_ACCESS_KEY, and AWS_ACCESS_KEY_ID to start ledger distribution";
 else
-  /usr/bin/ledger-distribution \
+  launch /usr/bin/ledger-distribution \
     --ledger-path "${NODE_LEDGER_DIR}" \
-    --dest "${AWS_PATH}" &
+    --dest "${AWS_PATH}"
 fi
 
 # Clean old dump directory - consensus writes a new dir, which is owned by root due to docker volume ownership
 rm -rf /scp-debug-dump/${LOCAL_NODE_ID}
 
-/usr/bin/mc-admin-http-gateway --listen-host 0.0.0.0 --listen-port ${NODE_MANAGEMENT_PORT} --admin-uri insecure-mca://127.0.0.1:9091/ &
+launch /usr/bin/mc-admin-http-gateway --listen-host 0.0.0.0 --listen-port ${NODE_MANAGEMENT_PORT} --admin-uri insecure-mca://127.0.0.1:9091/
 
 exec env consensus-service $@


### PR DESCRIPTION
Soundtrack of this PR: [https://www.youtube.com/watch?v=EgT_us6AsDg](I keep hitting repeat repeat repeat)

### Motivation

The entrypoint starts several backgrounded processes. All of their output goes to the same stdout/stderr. This makes it very difficult to distinguish which messages go with which component.

Also, if any of these processes die, they are not restarted.

### In this PR

This patch sends logs to `NODE_LOG_DIR` if it is set, and restarts any process that exits after 10 seconds.

Log rotation is left to the user; recommend specifying`copytruncate` if using `logrotate`.

### Future Work

* `aesm-service` in our evironment exits immediately with no stdout/stderr message, so it is not handled like the rest of the services. `&` is not needed.
* With `--no-daemon` it does the more expected thing - it stays in foreground and outputs stuff to stdout/stderr on startup.
