### PR TITLE
add Address Codes to mobilecoind-json [MCC-1757]

### DIFF
--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -61,7 +61,7 @@ $ curl localhost:9090/monitors/a0cf8b79c9f8d74eb935ab4eeeb771f3809a408ad47246be4
 
 #### Generate a request code from a public address and optional other information
 ```
-$ curl localhost:9090/codes/request -d '{"public_address": {"view_public_key":"543b376e9d5b949dd8694f065d95a98a89e6f17a20c621621a808605d1904324","spend_public_key":"58dba855a885dd535dc5180af443abae67c790b860d5adadb4d6a2ecb71abd28","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""}, "amount": 10, "memo": "Please pay me"}'  -X POST -H 'Content-Type: application/json'
+$ curl localhost:9090/codes/request -d '{"receiver": {"view_public_key":"543b376e9d5b949dd8694f065d95a98a89e6f17a20c621621a808605d1904324","spend_public_key":"58dba855a885dd535dc5180af443abae67c790b860d5adadb4d6a2ecb71abd28","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""}, "amount": 10, "memo": "Please pay me"}'  -X POST -H 'Content-Type: application/json'
 
 {"request_code":"ufTwqVqF2rXmFVBZ1CWWS3ntdajVZGfZ5A2YZqAwhVnaVYrFpS9Z8iAg44CBGDeyjFDX8Hj4W7ZzArBn1xSp9wu8NriqQAogN8fUybKmoWgaz92kT4M7fbjRYKZmoY8"}
 ```

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -184,9 +184,8 @@ fn get_request_code(
     state: rocket::State<State>,
     request: Json<JsonGetRequestCodeRequest>,
 ) -> Result<Json<JsonGetRequestCodeResponse>, String> {
-    let receiver =
-        mc_mobilecoind_api::external::PublicAddress::try_from(&request.receiver)
-            .map_err(|err| format!("Failed to parse receiver's public address: {}", err))?;
+    let receiver = mc_mobilecoind_api::external::PublicAddress::try_from(&request.receiver)
+        .map_err(|err| format!("Failed to parse receiver's public address: {}", err))?;
 
     // Generate b58 code
     let mut req = mc_mobilecoind_api::GetRequestCodeRequest::new();
@@ -231,9 +230,8 @@ fn get_address_code(
     state: rocket::State<State>,
     request: Json<JsonGetAddressCodeRequest>,
 ) -> Result<Json<JsonGetAddressCodeResponse>, String> {
-    let receiver =
-        mc_mobilecoind_api::external::PublicAddress::try_from(&request.receiver)
-            .map_err(|err| format!("Failed to parse receiver's public address: {}", err))?;
+    let receiver = mc_mobilecoind_api::external::PublicAddress::try_from(&request.receiver)
+        .map_err(|err| format!("Failed to parse receiver's public address: {}", err))?;
 
     // Generate b58 code
     let mut req = mc_mobilecoind_api::GetAddressCodeRequest::new();

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -274,7 +274,7 @@ fn transfer(
     state: rocket::State<State>,
     monitor_hex: String,
     subaddress_index: u64,
-    transfer: Json<JsonReadRequestResponse>,
+    transfer: Json<JsonReadRequestCodeResponse>,
 ) -> Result<Json<JsonTransferResponse>, String> {
     let monitor_id =
         hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -104,21 +104,21 @@ impl From<&mc_mobilecoind_api::GetBalanceResponse> for JsonBalanceResponse {
 }
 
 #[derive(Deserialize)]
-pub struct JsonRequestCodeRequest {
-    pub public_address: JsonPublicAddress,
+pub struct JsonGetRequestCodeRequest {
+    pub receiver: JsonPublicAddress,
     pub value: Option<u64>,
     pub memo: Option<String>,
 }
 
 #[derive(Serialize, Default)]
-pub struct JsonRequestCodeResponse {
-    pub request_code: String,
+pub struct JsonGetRequestCodeResponse {
+    pub b58_code: String,
 }
 
-impl From<&mc_mobilecoind_api::GetRequestCodeResponse> for JsonRequestCodeResponse {
+impl From<&mc_mobilecoind_api::GetRequestCodeResponse> for JsonGetRequestCodeResponse {
     fn from(src: &mc_mobilecoind_api::GetRequestCodeResponse) -> Self {
         Self {
-            request_code: String::from(src.get_b58_code()),
+            b58_code: String::from(src.get_b58_code()),
         }
     }
 }
@@ -186,18 +186,49 @@ impl TryFrom<&JsonPublicAddress> for PublicAddress {
 }
 
 #[derive(Deserialize, Serialize, Default)]
-pub struct JsonReadRequestResponse {
+pub struct JsonReadRequestCodeResponse {
     pub receiver: JsonPublicAddress,
     pub value: String,
     pub memo: String,
 }
 
-impl From<&mc_mobilecoind_api::ReadRequestCodeResponse> for JsonReadRequestResponse {
+impl From<&mc_mobilecoind_api::ReadRequestCodeResponse> for JsonReadRequestCodeResponse {
     fn from(src: &mc_mobilecoind_api::ReadRequestCodeResponse) -> Self {
         Self {
             receiver: JsonPublicAddress::from(src.get_receiver()),
             value: src.get_value().to_string(),
             memo: src.get_memo().to_string(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct JsonGetAddressCodeRequest {
+    pub receiver: JsonPublicAddress,
+}
+
+#[derive(Serialize, Default)]
+pub struct JsonGetAddressCodeResponse {
+    pub b58_code: String,
+}
+
+impl From<&mc_mobilecoind_api::GetAddressCodeResponse> for JsonGetAddressCodeResponse {
+    fn from(src: &mc_mobilecoind_api::GetAddressCodeResponse) -> Self {
+        Self {
+            b58_code: String::from(src.get_b58_code()),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Default)]
+pub struct JsonReadAddressCodeResponse {
+    pub receiver: JsonPublicAddress,
+}
+
+impl From<&mc_mobilecoind_api::ReadAddressCodeResponse> for JsonReadAddressCodeResponse {
+    fn from(src: &mc_mobilecoind_api::ReadAddressCodeResponse) -> Self {
+        Self {
+            receiver: JsonPublicAddress::from(src.get_receiver()),
         }
     }
 }


### PR DESCRIPTION
### Motivation

We recently introduced an explicit concept for an Address Code to avoid confusion over the meaning of a Payment Request with zero value and no memo. This PR connects `mobilecoind-json` to the gRPC endpoints.


### In this PR
* adds two new API endpoints
* cleans up some names to better match mobilecoind protobuf

### Future Work
* update API semantics for codes to create/parse [MCC-1760](https://mobilecoin.atlassian.net/browse/MCC-1760)