### PR TITLE
add Address Code to ProcessedTxOut [MCC-1755]

### DIFF
--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -203,15 +203,15 @@ enum ProcessedTxOutDirection {
 }
 
 
-// Structure used to report tx outs received in a given processed block.
+// Structure used to report processed information for TxOuts discovered in a given processed block.
 message ProcessedTxOut {
-    // The monitor id that received the transaction.
+    // The monitor id that owns the TxOut.
     bytes monitor_id = 1;
 
-    // The subaddress the transaction was sent to.
+    // The subaddress that owns the TxOut.
     uint64 subaddress_index = 2;
 
-    // The public key of the received TxOut.
+    // The public key of the TxOut.
     external.CompressedRistretto public_key = 3;
 
     // The key image of the TxOut.
@@ -220,8 +220,11 @@ message ProcessedTxOut {
     // The value of the TxOut.
     uint64 value = 5;
 
-    // Whether this ProcessedTxOut was received at this block or spent at this block.
+    // Whether the TxOut was received (deposit to subaddress) or spent (withdrawal from subaddress).
     ProcessedTxOutDirection direction = 6;
+    
+    // The b58-encoded Address Code for the subaddress that owns the TxOut.
+    string address_code = 7;
 }
 
 //*********************************

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1227,7 +1227,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                     .b58_encode()
                     .map_err(|err| {
                         rpc_internal_error("wrapper.b58_encode", err, &self.logger)
-                    });
+                    })?;
                 dst.set_address_code(encoded);
                 Ok(dst)
             })

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1231,7 +1231,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                 dst.set_address_code(encoded);
                 Ok(dst)
             })
-            .collect::<Result<Vec<_>, String>>()?;
+            .collect::<Result<Vec<_>, _>>()?;
 
         // Return response
         let mut response = mc_mobilecoind_api::GetProcessedBlockResponse::new();

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -355,21 +355,21 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         &mut self,
         request: mc_mobilecoind_api::ReadRequestCodeRequest,
     ) -> Result<mc_mobilecoind_api::ReadRequestCodeResponse, RpcStatus> {
-        let request_wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
+        let wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
             request.get_b58_code().to_string(),
         )
         .map_err(|err| rpc_internal_error("PrintableWrapper_b58_decode", err, &self.logger))?;
 
         // A request code could be a public address or a payment request
-        if request_wrapper.has_payment_request() {
-            let payment_request = request_wrapper.get_payment_request();
+        if wrapper.has_payment_request() {
+            let payment_request = wrapper.get_payment_request();
             let mut response = mc_mobilecoind_api::ReadRequestCodeResponse::new();
             response.set_receiver(payment_request.get_public_address().clone());
             response.set_value(payment_request.get_value());
             response.set_memo(payment_request.get_memo().to_string());
             Ok(response)
-        } else if request_wrapper.has_public_address() {
-            let public_address = request_wrapper.get_public_address();
+        } else if wrapper.has_public_address() {
+            let public_address = wrapper.get_public_address();
             let mut response = mc_mobilecoind_api::ReadRequestCodeResponse::new();
             response.set_receiver(public_address.clone());
             response.set_value(0);
@@ -395,10 +395,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         payment_request.set_value(request.get_value());
         payment_request.set_memo(request.get_memo().to_string());
 
-        let mut request_wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
-        request_wrapper.set_payment_request(payment_request);
+        let mut wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
+        wrapper.set_payment_request(payment_request);
 
-        let encoded = request_wrapper
+        let encoded = wrapper
             .b58_encode()
             .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
 
@@ -411,18 +411,18 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         &mut self,
         request: mc_mobilecoind_api::ReadTransferCodeRequest,
     ) -> Result<mc_mobilecoind_api::ReadTransferCodeResponse, RpcStatus> {
-        let request_wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
+        let wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
             request.get_b58_code().to_string(),
         )
         .map_err(|err| rpc_internal_error("PrintableWrapper.b58_decode", err, &self.logger))?;
 
-        if !request_wrapper.has_transfer_payload() {
+        if !wrapper.has_transfer_payload() {
             return Err(RpcStatus::new(
                 RpcStatusCode::INVALID_ARGUMENT,
                 Some("has_transfer_payload".to_string()),
             ));
         }
-        let transfer_payload = request_wrapper.get_transfer_payload();
+        let transfer_payload = wrapper.get_transfer_payload();
 
         let tx_public_key = RistrettoPublic::try_from(transfer_payload.get_tx_public_key())
             .map_err(|err| rpc_internal_error("RistrettoPublic.try_from", err, &self.logger))?;
@@ -524,19 +524,19 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         &mut self,
         request: mc_mobilecoind_api::ReadAddressCodeRequest,
     ) -> Result<mc_mobilecoind_api::ReadAddressCodeResponse, RpcStatus> {
-        let request_wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
+        let wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
             request.get_b58_code().to_string(),
         )
         .map_err(|err| rpc_internal_error("PrintableWrapper_b58_decode", err, &self.logger))?;
 
         // An address code could be a public address or a payment request
-        if request_wrapper.has_payment_request() {
-            let payment_request = request_wrapper.get_payment_request();
+        if wrapper.has_payment_request() {
+            let payment_request = wrapper.get_payment_request();
             let mut response = mc_mobilecoind_api::ReadAddressCodeResponse::new();
             response.set_receiver(payment_request.get_public_address().clone());
             Ok(response)
-        } else if request_wrapper.has_public_address() {
-            let public_address = request_wrapper.get_public_address();
+        } else if wrapper.has_public_address() {
+            let public_address = wrapper.get_public_address();
             let mut response = mc_mobilecoind_api::ReadAddressCodeResponse::new();
             response.set_receiver(public_address.clone());
             Ok(response)
@@ -555,10 +555,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         let receiver = PublicAddress::try_from(request.get_receiver())
             .map_err(|err| rpc_internal_error("PublicAddress.try_from", err, &self.logger))?;
 
-        let mut request_wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
-        request_wrapper.set_public_address((&receiver).into());
+        let mut wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
+        wrapper.set_public_address((&receiver).into());
 
-        let encoded = request_wrapper
+        let encoded = wrapper
             .b58_encode()
             .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2254,10 +2254,7 @@ mod test {
             let response = client.get_address_code(&request).unwrap();
             let b58_code = response.get_b58_code();
 
-            assert_eq!(
-                tx_out.get_address_code(),
-                b58_code,
-            );
+            assert_eq!(tx_out.get_address_code(), b58_code);
         }
 
         // Add a block with a key images that spend the first two utxos and see that we get the

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1225,9 +1225,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                 wrapper.set_public_address((&subaddress).into());
                 let encoded = wrapper
                     .b58_encode()
-                    .map_err(|err| {
-                        rpc_internal_error("wrapper.b58_encode", err, &self.logger)
-                    })?;
+                    .map_err(|err| rpc_internal_error("wrapper.b58_encode", err, &self.logger))?;
                 dst.set_address_code(encoded);
                 Ok(dst)
             })

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1225,7 +1225,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                 wrapper.set_public_address((&subaddress).into());
                 let encoded = wrapper
                     .b58_encode()
-                    .unwrap_or("invalid address encoding".to_owned());
+                    .unwrap_or_else(|_| "invalid address encoding".to_owned());
                 dst.set_address_code(encoded);
                 dst
             })

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1225,11 +1225,13 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                 wrapper.set_public_address((&subaddress).into());
                 let encoded = wrapper
                     .b58_encode()
-                    .unwrap_or_else(|_| "invalid address encoding".to_owned());
+                    .map_err(|err| {
+                        rpc_internal_error("wrapper.b58_encode", err, &self.logger)
+                    })
                 dst.set_address_code(encoded);
-                dst
+                Ok(dst)
             })
-            .collect();
+            .collect::<Result<Vec<_>, String>>()?
 
         // Return response
         let mut response = mc_mobilecoind_api::GetProcessedBlockResponse::new();

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -790,7 +790,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         response.set_tx_proposal(tx_proposal);
         response.set_entropy(entropy);
         response.set_tx_public_key(proto_tx_public_key);
-        response.set_memo(request.get_memo().to_owned());
+        response.set_memo(request.get_memo().to_string());
         response.set_b58_code(b58_code);
         Ok(response)
     }
@@ -1225,7 +1225,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                 wrapper.set_public_address((&subaddress).into());
                 let encoded = wrapper
                     .b58_encode()
-                    .unwrap_or("invalid address encoding".to_owned())
+                    .unwrap_or("invalid address encoding".to_owned());
                 dst.set_address_code(encoded);
                 dst
             })
@@ -3200,7 +3200,7 @@ mod test {
 
             // Attempt to decode it.
             let mut request = mc_mobilecoind_api::ReadRequestCodeRequest::new();
-            request.set_b58_code(b58_code.to_owned());
+            request.set_b58_code(b58_code.to_string());
 
             let response = client.read_request_code(&request).unwrap();
 
@@ -3224,7 +3224,7 @@ mod test {
 
             // Attempt to decode it.
             let mut request = mc_mobilecoind_api::ReadRequestCodeRequest::new();
-            request.set_b58_code(b58_code.to_owned());
+            request.set_b58_code(b58_code.to_string());
 
             let response = client.read_request_code(&request).unwrap();
 
@@ -3249,7 +3249,7 @@ mod test {
 
             // Attempt to decode it.
             let mut request = mc_mobilecoind_api::ReadRequestCodeRequest::new();
-            request.set_b58_code(b58_code.to_owned());
+            request.set_b58_code(b58_code.to_string());
 
             let response = client.read_request_code(&request).unwrap();
 
@@ -3329,7 +3329,7 @@ mod test {
 
             // Decode
             let mut request = mc_mobilecoind_api::ReadTransferCodeRequest::new();
-            request.set_b58_code(b58_code.to_owned());
+            request.set_b58_code(b58_code.to_string());
 
             let response = client.read_transfer_code(&request).unwrap();
 
@@ -3392,7 +3392,7 @@ mod test {
 
             // Attempt to decode it.
             let mut request = mc_mobilecoind_api::ReadAddressCodeRequest::new();
-            request.set_b58_code(b58_code.to_owned());
+            request.set_b58_code(b58_code.to_string());
 
             let response = client.read_address_code(&request).unwrap();
 
@@ -3419,7 +3419,7 @@ mod test {
 
             // Attempt to decode it.
             let mut request = mc_mobilecoind_api::ReadAddressCodeRequest::new();
-            request.set_b58_code(b58_code.to_owned());
+            request.set_b58_code(b58_code.to_string());
 
             let response = client.read_address_code(&request).unwrap();
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1227,11 +1227,11 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
                     .b58_encode()
                     .map_err(|err| {
                         rpc_internal_error("wrapper.b58_encode", err, &self.logger)
-                    })
+                    });
                 dst.set_address_code(encoded);
                 Ok(dst)
             })
-            .collect::<Result<Vec<_>, String>>()?
+            .collect::<Result<Vec<_>, String>>()?;
 
         // Return response
         let mut response = mc_mobilecoind_api::GetProcessedBlockResponse::new();


### PR DESCRIPTION
# Motivation

Exchanges want to match incoming deposits to user accounts by associating each user's account with a unique subaddress. 

Subaddresses could be matched based on index or based on the unique PublicAddress that each index creates. Since it is not possible to calculate the PublicAddress for a subaddress index without private keys, we want to include this information in our decrypted "ProcessedTxOut" message. This allows an exchange to match incoming deposits based on an association between users and deposit Address Codes rather than a map to subaddress indices.

### In this PR
* add field to proto, connect in service and add test
