### PR TITLE
add remove_monitor to mobilecoind-json [MCC-1736]

### DIFF
--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -48,7 +48,7 @@ $ curl localhost:9090/monitors/a0cf8b79c9f8d74eb935ab4eeeb771f3809a408ad47246be4
 
 #### Remove an existing monitor
 ```
-$ curl localhost:9090/monitors/a0cf8b79c9f8d74eb935ab4eeeb771f3809a408ad47246be47cf40315be9876e
+$ curl -X DELETE localhost:9090/monitors/a0cf8b79c9f8d74eb935ab4eeeb771f3809a408ad47246be47cf40315be9876e
 
 ```
 

--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -46,6 +46,12 @@ $ curl localhost:9090/monitors/a0cf8b79c9f8d74eb935ab4eeeb771f3809a408ad47246be4
 {"first_subaddress":0,"num_subaddresses":10,"first_block":0,"next_block":2068}
 ```
 
+#### Remove an existing monitor
+```
+$ curl localhost:9090/monitors/a0cf8b79c9f8d74eb935ab4eeeb771f3809a408ad47246be47cf40315be9876e
+
+```
+
 #### Check the balance for a monitor and subaddress index
 ```
 $ curl localhost:9090/monitors/a0cf8b79c9f8d74eb935ab4eeeb771f3809a408ad47246be47cf40315be9876e/subaddresses/0/balance

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -114,7 +114,7 @@ fn remove_monitor(
     let mut req = mc_mobilecoind_api::RemoveMonitorRequest::new();
     req.set_monitor_id(monitor_id);
 
-    let resp = state
+    let _resp = state
         .mobilecoind_api_client
         .remove_monitor(&req)
         .map_err(|err| format!("Failed removing monitor: {}", err))?;

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -11,7 +11,7 @@ use mc_mobilecoind_api::{mobilecoind_api_grpc::MobilecoindApiClient, Mobilecoind
 use mc_mobilecoind_json::data_types::*;
 use mc_util_grpc::ConnectionUriGrpcioChannel;
 use protobuf::RepeatedField;
-use rocket::{get, post, routes};
+use rocket::{delete, get, post, routes};
 use rocket_contrib::json::Json;
 use std::{convert::TryFrom, sync::Arc};
 use structopt::StructOpt;
@@ -119,7 +119,7 @@ fn remove_monitor(
         .remove_monitor(&req)
         .map_err(|err| format!("Failed removing monitor: {}", err))?;
 
-    Ok()
+    Ok(())
 }
 
 /// Gets a list of existing monitors

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -104,10 +104,7 @@ fn add_monitor(
 
 /// Remove a monitor
 #[delete("/monitors/<monitor_hex>")]
-fn remove_monitor(
-    state: rocket::State<State>,
-    monitor_hex: String,
-) -> Result<(), String> {
+fn remove_monitor(state: rocket::State<State>, monitor_hex: String) -> Result<(), String> {
     let monitor_id =
         hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
 


### PR DESCRIPTION
### Motivation

Exposes the existing gRPC endpoint for removing a monitor in our JSON api.


