### PR TITLE
Make a constant time aes-gcm decrypt and use in cryptobox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,15 +16,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aead"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
-dependencies = [
- "generic-array 0.14.4",
-]
-
-[[package]]
 name = "aes"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,24 +29,12 @@ dependencies = [
 [[package]]
 name = "aes-gcm"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
+source = "git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa#d1a8517d3dd867ed9c5794002add67992a42f6aa"
 dependencies = [
- "aead 0.2.0",
+ "aead",
  "aes",
  "block-cipher",
  "ghash",
- "subtle 2.2.3",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.6.0"
-source = "git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa#d1a8517d3dd867ed9c5794002add67992a42f6aa"
-dependencies = [
- "aead 0.3.2",
- "block-cipher",
- "ghash 0.3.0",
  "subtle 2.2.3",
 ]
 
@@ -327,22 +306,8 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "block-buffer"
 version = "0.9.0"
-=======
-name = "block-cipher"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
-dependencies = [
- "generic-array 0.14.4",
-]
-
-[[package]]
-name = "block-cipher-trait"
-version = "0.6.2"
->>>>>>> integrate preliminary ct-aead code
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
@@ -1369,16 +1334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
-dependencies = [
- "typenum",
- "version_check 0.9.1",
-]
-
-[[package]]
 name = "genio"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,16 +1359,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
 dependencies = [
- "polyval 0.3.3",
-]
-
-[[package]]
-name = "ghash"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
-dependencies = [
- "polyval 0.4.0",
+ "polyval",
 ]
 
 [[package]]
@@ -2166,18 +2112,11 @@ dependencies = [
 name = "mc-attest-ake"
 version = "1.0.0"
 dependencies = [
-<<<<<<< HEAD
  "aead",
  "aes-gcm",
  "cargo-emit",
  "digest 0.9.0",
  "displaydoc",
-=======
- "aead 0.2.0",
- "aes-gcm 0.3.2",
- "digest",
- "failure",
->>>>>>> integrate preliminary ct-aead code
  "mc-attest-core",
  "mc-attest-net",
  "mc-common",
@@ -2198,7 +2137,7 @@ dependencies = [
 name = "mc-attest-api"
 version = "1.0.0"
 dependencies = [
- "aead 0.2.0",
+ "aead",
  "cargo-emit",
  "digest 0.9.0",
  "futures 0.3.5",
@@ -2342,7 +2281,7 @@ dependencies = [
 name = "mc-connection"
 version = "1.0.0"
 dependencies = [
- "aes-gcm 0.3.2",
+ "aes-gcm",
  "failure",
  "grpcio",
  "mc-attest-ake",
@@ -2621,15 +2560,9 @@ dependencies = [
 name = "mc-crypto-ake-enclave"
 version = "1.0.0"
 dependencies = [
-<<<<<<< HEAD
  "aead",
  "aes-gcm",
  "digest 0.9.0",
-=======
- "aead 0.2.0",
- "aes-gcm 0.3.2",
- "digest",
->>>>>>> integrate preliminary ct-aead code
  "failure",
  "mc-attest-ake",
  "mc-attest-core",
@@ -2652,8 +2585,8 @@ dependencies = [
 name = "mc-crypto-box"
 version = "1.0.0"
 dependencies = [
- "aead 0.2.0",
- "aes-gcm 0.3.2",
+ "aead",
+ "aes-gcm",
  "blake2",
  "digest 0.9.0",
  "failure",
@@ -2669,7 +2602,7 @@ dependencies = [
 name = "mc-crypto-ct-aead"
 version = "0.5.0"
 dependencies = [
- "aes-gcm 0.6.0",
+ "aes-gcm",
  "block-cipher",
  "subtle 2.2.3",
 ]
@@ -2759,7 +2692,7 @@ dependencies = [
 name = "mc-crypto-message-cipher"
 version = "1.0.0"
 dependencies = [
- "aes-gcm 0.3.2",
+ "aes-gcm",
  "failure",
  "generic-array 0.14.4",
  "mc-util-serial",
@@ -2773,15 +2706,9 @@ dependencies = [
 name = "mc-crypto-noise"
 version = "1.0.0"
 dependencies = [
-<<<<<<< HEAD
  "aead",
  "aes-gcm",
  "digest 0.9.0",
-=======
- "aead 0.2.0",
- "aes-gcm 0.3.2",
- "digest",
->>>>>>> integrate preliminary ct-aead code
  "failure",
  "generic-array 0.14.4",
  "hkdf",
@@ -4222,17 +4149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
 dependencies = [
  "cfg-if",
- "universal-hash 0.3.0",
-]
-
-[[package]]
-name = "polyval"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
-dependencies = [
- "cfg-if",
- "universal-hash 0.4.0",
+ "universal-hash",
 ]
 
 [[package]]
@@ -6196,16 +6113,6 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-
-[[package]]
-name = "universal-hash"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
-dependencies = [
- "generic-array 0.14.4",
- "subtle 2.2.3",
-]
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,6 +2602,7 @@ dependencies = [
 name = "mc-crypto-ct-aead"
 version = "0.5.0"
 dependencies = [
+ "aead",
  "aes-gcm",
  "block-cipher",
  "subtle 2.2.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6502,3 +6502,8 @@ dependencies = [
  "syn 1.0.18",
  "synstructure 0.12.3",
 ]
+
+[[patch.unused]]
+name = "aes-gcm"
+version = "0.6.0"
+source = "git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa#d1a8517d3dd867ed9c5794002add67992a42f6aa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "aes"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,10 +41,21 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
 dependencies = [
- "aead",
+ "aead 0.2.0",
  "aes",
  "block-cipher",
  "ghash",
+ "subtle 2.2.3",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.6.0"
+source = "git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa#d1a8517d3dd867ed9c5794002add67992a42f6aa"
+dependencies = [
+ "aead 0.3.2",
+ "block-cipher",
+ "ghash 0.3.0",
  "subtle 2.2.3",
 ]
 
@@ -307,8 +327,22 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "block-buffer"
 version = "0.9.0"
+=======
+name = "block-cipher"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-cipher-trait"
+version = "0.6.2"
+>>>>>>> integrate preliminary ct-aead code
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
@@ -1335,6 +1369,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check 0.9.1",
+]
+
+[[package]]
 name = "genio"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,7 +1404,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
 dependencies = [
- "polyval",
+ "polyval 0.3.3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
+dependencies = [
+ "polyval 0.4.0",
 ]
 
 [[package]]
@@ -2113,11 +2166,18 @@ dependencies = [
 name = "mc-attest-ake"
 version = "1.0.0"
 dependencies = [
+<<<<<<< HEAD
  "aead",
  "aes-gcm",
  "cargo-emit",
  "digest 0.9.0",
  "displaydoc",
+=======
+ "aead 0.2.0",
+ "aes-gcm 0.3.2",
+ "digest",
+ "failure",
+>>>>>>> integrate preliminary ct-aead code
  "mc-attest-core",
  "mc-attest-net",
  "mc-common",
@@ -2138,7 +2198,7 @@ dependencies = [
 name = "mc-attest-api"
 version = "1.0.0"
 dependencies = [
- "aead",
+ "aead 0.2.0",
  "cargo-emit",
  "digest 0.9.0",
  "futures 0.3.5",
@@ -2282,7 +2342,7 @@ dependencies = [
 name = "mc-connection"
 version = "1.0.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.3.2",
  "failure",
  "grpcio",
  "mc-attest-ake",
@@ -2561,9 +2621,15 @@ dependencies = [
 name = "mc-crypto-ake-enclave"
 version = "1.0.0"
 dependencies = [
+<<<<<<< HEAD
  "aead",
  "aes-gcm",
  "digest 0.9.0",
+=======
+ "aead 0.2.0",
+ "aes-gcm 0.3.2",
+ "digest",
+>>>>>>> integrate preliminary ct-aead code
  "failure",
  "mc-attest-ake",
  "mc-attest-core",
@@ -2586,16 +2652,26 @@ dependencies = [
 name = "mc-crypto-box"
 version = "1.0.0"
 dependencies = [
- "aead",
- "aes-gcm",
+ "aead 0.2.0",
+ "aes-gcm 0.3.2",
  "blake2",
  "digest 0.9.0",
  "failure",
  "hkdf",
+ "mc-crypto-ct-aead",
  "mc-crypto-keys",
  "mc-util-from-random",
  "mc-util-test-helper",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "mc-crypto-ct-aead"
+version = "0.5.0"
+dependencies = [
+ "aes-gcm 0.6.0",
+ "block-cipher",
+ "subtle 2.2.3",
 ]
 
 [[package]]
@@ -2683,7 +2759,7 @@ dependencies = [
 name = "mc-crypto-message-cipher"
 version = "1.0.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.3.2",
  "failure",
  "generic-array 0.14.4",
  "mc-util-serial",
@@ -2697,9 +2773,15 @@ dependencies = [
 name = "mc-crypto-noise"
 version = "1.0.0"
 dependencies = [
+<<<<<<< HEAD
  "aead",
  "aes-gcm",
  "digest 0.9.0",
+=======
+ "aead 0.2.0",
+ "aes-gcm 0.3.2",
+ "digest",
+>>>>>>> integrate preliminary ct-aead code
  "failure",
  "generic-array 0.14.4",
  "hkdf",
@@ -4140,7 +4222,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
 dependencies = [
  "cfg-if",
- "universal-hash",
+ "universal-hash 0.3.0",
+]
+
+[[package]]
+name = "polyval"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
+dependencies = [
+ "cfg-if",
+ "universal-hash 0.4.0",
 ]
 
 [[package]]
@@ -6116,6 +6208,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.2.3",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6502,8 +6604,3 @@ dependencies = [
  "syn 1.0.18",
  "synstructure 0.12.3",
 ]
-
-[[patch.unused]]
-name = "aes-gcm"
-version = "0.6.0"
-source = "git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa#d1a8517d3dd867ed9c5794002add67992a42f6aa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,3 +136,7 @@ bulletproofs = { git = "https://github.com/eranrund/bulletproofs", rev = "e8e8ef
 
 # Patched to disable the cpuid instruction because that is incompatible with our sgx builds.
 cpuid-bool = { git = "https://github.com/eranrund/RustCrypto-utils", rev = "74f8e04e9d18d93fc6d05c72756c236dc88daa19" }
+
+# We need to patch aes-gcm so we can make some fields/functions/structs pub in order to have a constant time decrypt
+aes-gcm = { git = "https://github.com/xoloki/AEADs", rev = "d1a8517d3dd867ed9c5794002add67992a42f6aa" }
+

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -816,6 +816,7 @@ dependencies = [
 name = "mc-crypto-ct-aead"
 version = "0.5.0"
 dependencies = [
+ "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 [[package]]
 name = "aes-gcm"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa#d1a8517d3dd867ed9c5794002add67992a42f6aa"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -777,7 +777,7 @@ name = "mc-crypto-ake-enclave"
 version = "1.0.0"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-attest-ake 1.0.0",
@@ -802,7 +802,7 @@ name = "mc-crypto-box"
 version = "1.0.0"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -816,7 +816,7 @@ dependencies = [
 name = "mc-crypto-ct-aead"
 version = "0.5.0"
 dependencies = [
- "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -881,7 +881,7 @@ dependencies = [
 name = "mc-crypto-message-cipher"
 version = "1.0.0"
 dependencies = [
- "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-util-serial 1.0.0",
@@ -895,7 +895,7 @@ name = "mc-crypto-noise"
 version = "1.0.0"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1706,7 +1706,7 @@ dependencies = [
 [metadata]
 "checksum aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 "checksum aes 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
-"checksum aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
+"checksum aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)" = "<none>"
 "checksum aes-soft 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
 "checksum aesni 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
 "checksum aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -9,14 +9,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aead"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "aes"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,17 +25,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ghash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ghash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -433,14 +414,6 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ghash"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "polyval 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1275,15 +1248,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polyval"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "universal-hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,15 +1577,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "universal-hash"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "universal-hash"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -86,7 +86,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -250,7 +250,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -412,7 +412,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -448,7 +448,7 @@ name = "hermit-abi"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.74"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1405,7 +1405,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpuid-bool 0.1.2 (git+https://github.com/eranrund/RustCrypto-utils?rev=74f8e04e9d18d93fc6d05c72756c236dc88daa19)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2-asm 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1522,7 +1522,7 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1617,7 +1617,7 @@ name = "which"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1745,7 +1745,7 @@ dependencies = [
 "checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
+"checksum libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)" = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -570,20 +570,20 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-crypto-digestible 0.6.0",
- "mc-crypto-hashes 0.6.0",
- "mc-crypto-keys 0.6.0",
- "mc-crypto-sig 0.6.0",
- "mc-util-from-random 0.6.0",
- "mc-util-repr-bytes 0.6.0",
- "mc-util-serial 0.6.0",
+ "mc-crypto-digestible 1.0.0",
+ "mc-crypto-hashes 1.0.0",
+ "mc-crypto-keys 1.0.0",
+ "mc-crypto-sig 1.0.0",
+ "mc-util-from-random 1.0.0",
+ "mc-util-repr-bytes 1.0.0",
+ "mc-util-serial 1.0.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -591,18 +591,18 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-attest-core 0.6.0",
- "mc-common 0.6.0",
- "mc-crypto-keys 0.6.0",
- "mc-crypto-noise 0.6.0",
- "mc-util-build-script 0.6.0",
- "mc-util-build-sgx 0.6.0",
+ "mc-attest-core 1.0.0",
+ "mc-common 1.0.0",
+ "mc-crypto-keys 1.0.0",
+ "mc-crypto-noise 1.0.0",
+ "mc-util-build-script 1.0.0",
+ "mc-util-build-sgx 1.0.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -623,12 +623,12 @@ dependencies = [
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
  "mbedtls-sys-auto 2.18.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
- "mc-common 0.6.0",
- "mc-crypto-rand 0.6.0",
- "mc-sgx-build 0.6.0",
- "mc-sgx-css 0.6.0",
- "mc-sgx-types 0.6.0",
- "mc-util-encodings 0.6.0",
+ "mc-common 1.0.0",
+ "mc-crypto-rand 1.0.0",
+ "mc-sgx-build 1.0.0",
+ "mc-sgx-css 1.0.0",
+ "mc-sgx-types 1.0.0",
+ "mc-util-encodings 1.0.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rjson 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -639,31 +639,31 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-attest-ake 0.6.0",
- "mc-attest-core 0.6.0",
- "mc-crypto-noise 0.6.0",
- "mc-sgx-compat 0.6.0",
+ "mc-attest-ake 1.0.0",
+ "mc-attest-core 1.0.0",
+ "mc-crypto-noise 1.0.0",
+ "mc-sgx-compat 1.0.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-attest-trusted"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-attest-core 0.6.0",
- "mc-common 0.6.0",
- "mc-sgx-compat 0.6.0",
- "mc-sgx-types 0.6.0",
+ "mc-attest-core 1.0.0",
+ "mc-common 1.0.0",
+ "mc-sgx-compat 1.0.0",
+ "mc-sgx-types 1.0.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
 ]
 
 [[package]]
 name = "mc-common"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -671,10 +671,10 @@ dependencies = [
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-crypto-digestible 0.6.0",
- "mc-crypto-keys 0.6.0",
- "mc-crypto-rand 0.6.0",
- "mc-util-serial 0.6.0",
+ "mc-crypto-digestible 1.0.0",
+ "mc-crypto-keys 1.0.0",
+ "mc-crypto-rand 1.0.0",
+ "mc-util-serial 1.0.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -684,58 +684,58 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-attest-ake 0.6.0",
- "mc-attest-core 0.6.0",
- "mc-attest-enclave-api 0.6.0",
- "mc-common 0.6.0",
- "mc-crypto-keys 0.6.0",
- "mc-crypto-message-cipher 0.6.0",
- "mc-crypto-noise 0.6.0",
- "mc-sgx-compat 0.6.0",
- "mc-sgx-report-cache-api 0.6.0",
- "mc-transaction-core 0.6.0",
- "mc-util-serial 0.6.0",
+ "mc-attest-ake 1.0.0",
+ "mc-attest-core 1.0.0",
+ "mc-attest-enclave-api 1.0.0",
+ "mc-common 1.0.0",
+ "mc-crypto-keys 1.0.0",
+ "mc-crypto-message-cipher 1.0.0",
+ "mc-crypto-noise 1.0.0",
+ "mc-sgx-compat 1.0.0",
+ "mc-sgx-report-cache-api 1.0.0",
+ "mc-transaction-core 1.0.0",
+ "mc-util-serial 1.0.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-util-build-script 0.6.0",
+ "mc-util-build-script 1.0.0",
 ]
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
- "mc-account-keys 0.6.0",
- "mc-attest-core 0.6.0",
- "mc-attest-enclave-api 0.6.0",
- "mc-attest-trusted 0.6.0",
- "mc-common 0.6.0",
- "mc-consensus-enclave-api 0.6.0",
- "mc-crypto-ake-enclave 0.6.0",
- "mc-crypto-digestible 0.6.0",
- "mc-crypto-hashes 0.6.0",
- "mc-crypto-keys 0.6.0",
- "mc-crypto-message-cipher 0.6.0",
- "mc-crypto-rand 0.6.0",
- "mc-sgx-compat 0.6.0",
- "mc-sgx-report-cache-api 0.6.0",
- "mc-sgx-slog 0.6.0",
- "mc-transaction-core 0.6.0",
- "mc-util-build-script 0.6.0",
- "mc-util-from-random 0.6.0",
- "mc-util-serial 0.6.0",
+ "mc-account-keys 1.0.0",
+ "mc-attest-core 1.0.0",
+ "mc-attest-enclave-api 1.0.0",
+ "mc-attest-trusted 1.0.0",
+ "mc-common 1.0.0",
+ "mc-consensus-enclave-api 1.0.0",
+ "mc-crypto-ake-enclave 1.0.0",
+ "mc-crypto-digestible 1.0.0",
+ "mc-crypto-hashes 1.0.0",
+ "mc-crypto-keys 1.0.0",
+ "mc-crypto-message-cipher 1.0.0",
+ "mc-crypto-rand 1.0.0",
+ "mc-sgx-compat 1.0.0",
+ "mc-sgx-report-cache-api 1.0.0",
+ "mc-sgx-slog 1.0.0",
+ "mc-transaction-core 1.0.0",
+ "mc-util-build-script 1.0.0",
+ "mc-util-from-random 1.0.0",
+ "mc-util-serial 1.0.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -743,55 +743,55 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
- "mc-attest-core 0.6.0",
- "mc-attest-trusted 0.6.0",
- "mc-common 0.6.0",
- "mc-consensus-enclave-api 0.6.0",
- "mc-consensus-enclave-edl 0.6.0",
- "mc-consensus-enclave-impl 0.6.0",
- "mc-crypto-keys 0.6.0",
- "mc-enclave-boundary 0.6.0",
- "mc-sgx-backtrace-edl 0.6.0",
- "mc-sgx-compat 0.6.0",
- "mc-sgx-debug-edl 0.6.0",
- "mc-sgx-enclave-id 0.6.0",
- "mc-sgx-panic-edl 0.6.0",
- "mc-sgx-report-cache-api 0.6.0",
- "mc-sgx-slog 0.6.0",
- "mc-sgx-slog-edl 0.6.0",
- "mc-sgx-types 0.6.0",
- "mc-util-build-script 0.6.0",
- "mc-util-build-sgx 0.6.0",
- "mc-util-serial 0.6.0",
+ "mc-attest-core 1.0.0",
+ "mc-attest-trusted 1.0.0",
+ "mc-common 1.0.0",
+ "mc-consensus-enclave-api 1.0.0",
+ "mc-consensus-enclave-edl 1.0.0",
+ "mc-consensus-enclave-impl 1.0.0",
+ "mc-crypto-keys 1.0.0",
+ "mc-enclave-boundary 1.0.0",
+ "mc-sgx-backtrace-edl 1.0.0",
+ "mc-sgx-compat 1.0.0",
+ "mc-sgx-debug-edl 1.0.0",
+ "mc-sgx-enclave-id 1.0.0",
+ "mc-sgx-panic-edl 1.0.0",
+ "mc-sgx-report-cache-api 1.0.0",
+ "mc-sgx-slog 1.0.0",
+ "mc-sgx-slog-edl 1.0.0",
+ "mc-sgx-types 1.0.0",
+ "mc-util-build-script 1.0.0",
+ "mc-util-build-sgx 1.0.0",
+ "mc-util-serial 1.0.0",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-attest-ake 0.6.0",
- "mc-attest-core 0.6.0",
- "mc-attest-enclave-api 0.6.0",
- "mc-attest-trusted 0.6.0",
- "mc-common 0.6.0",
- "mc-crypto-keys 0.6.0",
- "mc-crypto-noise 0.6.0",
- "mc-crypto-rand 0.6.0",
- "mc-sgx-build 0.6.0",
- "mc-sgx-compat 0.6.0",
- "mc-util-from-random 0.6.0",
- "mc-util-serial 0.6.0",
+ "mc-attest-ake 1.0.0",
+ "mc-attest-core 1.0.0",
+ "mc-attest-enclave-api 1.0.0",
+ "mc-attest-trusted 1.0.0",
+ "mc-common 1.0.0",
+ "mc-crypto-keys 1.0.0",
+ "mc-crypto-noise 1.0.0",
+ "mc-crypto-rand 1.0.0",
+ "mc-sgx-build 1.0.0",
+ "mc-sgx-compat 1.0.0",
+ "mc-util-from-random 1.0.0",
+ "mc-util-serial 1.0.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -808,7 +808,7 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-ct-aead 0.5.0",
- "mc-crypto-keys 0.6.0",
+ "mc-crypto-keys 1.0.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -823,19 +823,20 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-crypto-digestible-derive 0.6.0",
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mc-crypto-digestible-derive 1.0.0",
+ "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -844,15 +845,16 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mc-crypto-digestible 1.0.0",
 ]
 
 [[package]]
 name = "mc-crypto-keys"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -862,10 +864,10 @@ dependencies = [
  "ed25519-dalek 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-crypto-digestible 0.6.0",
- "mc-util-from-random 0.6.0",
- "mc-util-repr-bytes 0.6.0",
- "mc-util-serial 0.6.0",
+ "mc-crypto-digestible 1.0.0",
+ "mc-util-from-random 1.0.0",
+ "mc-util-repr-bytes 1.0.0",
+ "mc-util-serial 1.0.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -877,12 +879,12 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-util-serial 0.6.0",
+ "mc-util-serial 1.0.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -890,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -898,9 +900,9 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-crypto-keys 0.6.0",
- "mc-util-from-random 0.6.0",
- "mc-util-repr-bytes 0.6.0",
+ "mc-crypto-keys 1.0.0",
+ "mc-util-from-random 1.0.0",
+ "mc-util-repr-bytes 1.0.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -911,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -922,10 +924,10 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-sig"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
- "mc-crypto-hashes 0.6.0",
- "mc-crypto-keys 0.6.0",
+ "mc-crypto-hashes 1.0.0",
+ "mc-crypto-keys 1.0.0",
  "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -934,29 +936,29 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
- "mc-common 0.6.0",
- "mc-crypto-rand 0.6.0",
- "mc-sgx-compat 0.6.0",
- "mc-sgx-types 0.6.0",
+ "mc-common 1.0.0",
+ "mc-crypto-rand 1.0.0",
+ "mc-sgx-compat 1.0.0",
+ "mc-sgx-types 1.0.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "0.6.0"
+version = "1.0.0"
 
 [[package]]
 name = "mc-sgx-backtrace-edl"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-sgx-build"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -966,20 +968,20 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-sgx-alloc 0.6.0",
- "mc-sgx-debug 0.6.0",
- "mc-sgx-panic 0.6.0",
- "mc-sgx-service 0.6.0",
- "mc-sgx-sync 0.6.0",
- "mc-sgx-types 0.6.0",
+ "mc-sgx-alloc 1.0.0",
+ "mc-sgx-debug 1.0.0",
+ "mc-sgx-panic 1.0.0",
+ "mc-sgx-service 1.0.0",
+ "mc-sgx-sync 1.0.0",
+ "mc-sgx-types 1.0.0",
 ]
 
 [[package]]
 name = "mc-sgx-css"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -987,92 +989,92 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "0.6.0"
+version = "1.0.0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
- "mc-sgx-types 0.6.0",
+ "mc-sgx-types 1.0.0",
 ]
 
 [[package]]
 name = "mc-sgx-libc-types"
-version = "0.6.0"
+version = "1.0.0"
 
 [[package]]
 name = "mc-sgx-panic"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
- "mc-sgx-libc-types 0.6.0",
+ "mc-sgx-libc-types 1.0.0",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-attest-core 0.6.0",
- "mc-attest-enclave-api 0.6.0",
- "mc-util-serial 0.6.0",
+ "mc-attest-core 1.0.0",
+ "mc-attest-enclave-api 1.0.0",
+ "mc-util-serial 1.0.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-sgx-service"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
- "mc-sgx-build 0.6.0",
- "mc-sgx-types 0.6.0",
+ "mc-sgx-build 1.0.0",
+ "mc-sgx-types 1.0.0",
 ]
 
 [[package]]
 name = "mc-sgx-slog"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-common 0.6.0",
- "mc-sgx-build 0.6.0",
+ "mc-common 1.0.0",
+ "mc-sgx-build 1.0.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
 ]
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
- "mc-sgx-libc-types 0.6.0",
- "mc-sgx-panic 0.6.0",
- "mc-sgx-types 0.6.0",
+ "mc-sgx-libc-types 1.0.0",
+ "mc-sgx-panic 1.0.0",
+ "mc-sgx-types 1.0.0",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "0.6.0"
+version = "1.0.0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bulletproofs 2.0.0 (git+https://github.com/eranrund/bulletproofs?rev=e8e8ef45ecc6d31f1a9525140edc977351d0f780)",
@@ -1084,16 +1086,16 @@ dependencies = [
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-account-keys 0.6.0",
- "mc-common 0.6.0",
- "mc-crypto-box 0.6.0",
- "mc-crypto-digestible 0.6.0",
- "mc-crypto-hashes 0.6.0",
- "mc-crypto-keys 0.6.0",
- "mc-crypto-rand 0.6.0",
- "mc-util-from-random 0.6.0",
- "mc-util-repr-bytes 0.6.0",
- "mc-util-serial 0.6.0",
+ "mc-account-keys 1.0.0",
+ "mc-common 1.0.0",
+ "mc-crypto-box 1.0.0",
+ "mc-crypto-digestible 1.0.0",
+ "mc-crypto-hashes 1.0.0",
+ "mc-crypto-keys 1.0.0",
+ "mc-crypto-rand 1.0.0",
+ "mc-util-from-random 1.0.0",
+ "mc-util-repr-bytes 1.0.0",
+ "mc-util-serial 1.0.0",
  "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1105,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1116,38 +1118,38 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-util-build-script 0.6.0",
+ "mc-util-build-script 1.0.0",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-util-encodings"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-util-repr-bytes 0.6.0",
+ "mc-util-repr-bytes 1.0.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-util-from-random"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
@@ -1156,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -714,8 +714,10 @@ dependencies = [
 name = "mc-consensus-enclave-impl"
 version = "1.0.0"
 dependencies = [
+ "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
  "mc-account-keys 1.0.0",
  "mc-attest-core 1.0.0",
@@ -756,9 +758,7 @@ dependencies = [
  "mc-consensus-enclave-impl 1.0.0",
  "mc-crypto-keys 1.0.0",
  "mc-enclave-boundary 1.0.0",
- "mc-sgx-backtrace-edl 1.0.0",
  "mc-sgx-compat 1.0.0",
- "mc-sgx-debug-edl 1.0.0",
  "mc-sgx-enclave-id 1.0.0",
  "mc-sgx-panic-edl 1.0.0",
  "mc-sgx-report-cache-api 1.0.0",
@@ -950,13 +950,6 @@ name = "mc-sgx-alloc"
 version = "1.0.0"
 
 [[package]]
-name = "mc-sgx-backtrace-edl"
-version = "1.0.0"
-dependencies = [
- "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "mc-sgx-build"
 version = "1.0.0"
 dependencies = [
@@ -992,13 +985,6 @@ name = "mc-sgx-debug"
 version = "1.0.0"
 
 [[package]]
-name = "mc-sgx-debug-edl"
-version = "1.0.0"
-dependencies = [
- "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "mc-sgx-enclave-id"
 version = "1.0.0"
 dependencies = [
@@ -1006,15 +992,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "mc-sgx-libc-types"
-version = "1.0.0"
-
-[[package]]
 name = "mc-sgx-panic"
 version = "1.0.0"
-dependencies = [
- "mc-sgx-libc-types 1.0.0",
-]
 
 [[package]]
 name = "mc-sgx-panic-edl"
@@ -1063,7 +1042,6 @@ dependencies = [
 name = "mc-sgx-sync"
 version = "1.0.0"
 dependencies = [
- "mc-sgx-libc-types 1.0.0",
  "mc-sgx-panic 1.0.0",
  "mc-sgx-types 1.0.0",
 ]
@@ -1078,7 +1056,6 @@ version = "1.0.0"
 dependencies = [
  "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bulletproofs 2.0.0 (git+https://github.com/eranrund/bulletproofs?rev=e8e8ef45ecc6d31f1a9525140edc977351d0f780)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -9,6 +9,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "aes"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +33,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ghash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ghash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -86,7 +105,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -250,7 +269,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -371,15 +390,15 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.8"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure_derive"
-version = "0.1.8"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -412,8 +431,16 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ghash"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "polyval 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -448,7 +475,7 @@ name = "hermit-abi"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -520,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.76"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -570,20 +597,20 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-crypto-digestible 1.0.0",
- "mc-crypto-hashes 1.0.0",
- "mc-crypto-keys 1.0.0",
- "mc-crypto-sig 1.0.0",
- "mc-util-from-random 1.0.0",
- "mc-util-repr-bytes 1.0.0",
- "mc-util-serial 1.0.0",
+ "mc-crypto-digestible 0.6.0",
+ "mc-crypto-hashes 0.6.0",
+ "mc-crypto-keys 0.6.0",
+ "mc-crypto-sig 0.6.0",
+ "mc-util-from-random 0.6.0",
+ "mc-util-repr-bytes 0.6.0",
+ "mc-util-serial 0.6.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -591,18 +618,18 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-attest-core 1.0.0",
- "mc-common 1.0.0",
- "mc-crypto-keys 1.0.0",
- "mc-crypto-noise 1.0.0",
- "mc-util-build-script 1.0.0",
- "mc-util-build-sgx 1.0.0",
+ "mc-attest-core 0.6.0",
+ "mc-common 0.6.0",
+ "mc-crypto-keys 0.6.0",
+ "mc-crypto-noise 0.6.0",
+ "mc-util-build-script 0.6.0",
+ "mc-util-build-sgx 0.6.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -610,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -618,17 +645,17 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
  "mbedtls-sys-auto 2.18.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
- "mc-common 1.0.0",
- "mc-crypto-rand 1.0.0",
- "mc-sgx-build 1.0.0",
- "mc-sgx-css 1.0.0",
- "mc-sgx-types 1.0.0",
- "mc-util-encodings 1.0.0",
+ "mc-common 0.6.0",
+ "mc-crypto-rand 0.6.0",
+ "mc-sgx-build 0.6.0",
+ "mc-sgx-css 0.6.0",
+ "mc-sgx-types 0.6.0",
+ "mc-util-encodings 0.6.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rjson 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -639,42 +666,42 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-attest-ake 1.0.0",
- "mc-attest-core 1.0.0",
- "mc-crypto-noise 1.0.0",
- "mc-sgx-compat 1.0.0",
+ "mc-attest-ake 0.6.0",
+ "mc-attest-core 0.6.0",
+ "mc-crypto-noise 0.6.0",
+ "mc-sgx-compat 0.6.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
- "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-attest-core 1.0.0",
- "mc-common 1.0.0",
- "mc-sgx-compat 1.0.0",
- "mc-sgx-types 1.0.0",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mc-attest-core 0.6.0",
+ "mc-common 0.6.0",
+ "mc-sgx-compat 0.6.0",
+ "mc-sgx-types 0.6.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
 ]
 
 [[package]]
 name = "mc-common"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-crypto-digestible 1.0.0",
- "mc-crypto-keys 1.0.0",
- "mc-crypto-rand 1.0.0",
- "mc-util-serial 1.0.0",
+ "mc-crypto-digestible 0.6.0",
+ "mc-crypto-keys 0.6.0",
+ "mc-crypto-rand 0.6.0",
+ "mc-util-serial 0.6.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -684,60 +711,58 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-attest-ake 1.0.0",
- "mc-attest-core 1.0.0",
- "mc-attest-enclave-api 1.0.0",
- "mc-common 1.0.0",
- "mc-crypto-keys 1.0.0",
- "mc-crypto-message-cipher 1.0.0",
- "mc-crypto-noise 1.0.0",
- "mc-sgx-compat 1.0.0",
- "mc-sgx-report-cache-api 1.0.0",
- "mc-transaction-core 1.0.0",
- "mc-util-serial 1.0.0",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mc-attest-ake 0.6.0",
+ "mc-attest-core 0.6.0",
+ "mc-attest-enclave-api 0.6.0",
+ "mc-common 0.6.0",
+ "mc-crypto-keys 0.6.0",
+ "mc-crypto-message-cipher 0.6.0",
+ "mc-crypto-noise 0.6.0",
+ "mc-sgx-compat 0.6.0",
+ "mc-sgx-report-cache-api 0.6.0",
+ "mc-transaction-core 0.6.0",
+ "mc-util-serial 0.6.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-util-build-script 1.0.0",
+ "mc-util-build-script 0.6.0",
 ]
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
- "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
- "mc-account-keys 1.0.0",
- "mc-attest-core 1.0.0",
- "mc-attest-enclave-api 1.0.0",
- "mc-attest-trusted 1.0.0",
- "mc-common 1.0.0",
- "mc-consensus-enclave-api 1.0.0",
- "mc-crypto-ake-enclave 1.0.0",
- "mc-crypto-digestible 1.0.0",
- "mc-crypto-hashes 1.0.0",
- "mc-crypto-keys 1.0.0",
- "mc-crypto-message-cipher 1.0.0",
- "mc-crypto-rand 1.0.0",
- "mc-sgx-compat 1.0.0",
- "mc-sgx-report-cache-api 1.0.0",
- "mc-sgx-slog 1.0.0",
- "mc-transaction-core 1.0.0",
- "mc-util-build-script 1.0.0",
- "mc-util-from-random 1.0.0",
- "mc-util-serial 1.0.0",
+ "mc-account-keys 0.6.0",
+ "mc-attest-core 0.6.0",
+ "mc-attest-enclave-api 0.6.0",
+ "mc-attest-trusted 0.6.0",
+ "mc-common 0.6.0",
+ "mc-consensus-enclave-api 0.6.0",
+ "mc-crypto-ake-enclave 0.6.0",
+ "mc-crypto-digestible 0.6.0",
+ "mc-crypto-hashes 0.6.0",
+ "mc-crypto-keys 0.6.0",
+ "mc-crypto-message-cipher 0.6.0",
+ "mc-crypto-rand 0.6.0",
+ "mc-sgx-compat 0.6.0",
+ "mc-sgx-report-cache-api 0.6.0",
+ "mc-sgx-slog 0.6.0",
+ "mc-transaction-core 0.6.0",
+ "mc-util-build-script 0.6.0",
+ "mc-util-from-random 0.6.0",
+ "mc-util-serial 0.6.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -745,53 +770,55 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
- "mc-attest-core 1.0.0",
- "mc-attest-trusted 1.0.0",
- "mc-common 1.0.0",
- "mc-consensus-enclave-api 1.0.0",
- "mc-consensus-enclave-edl 1.0.0",
- "mc-consensus-enclave-impl 1.0.0",
- "mc-crypto-keys 1.0.0",
- "mc-enclave-boundary 1.0.0",
- "mc-sgx-compat 1.0.0",
- "mc-sgx-enclave-id 1.0.0",
- "mc-sgx-panic-edl 1.0.0",
- "mc-sgx-report-cache-api 1.0.0",
- "mc-sgx-slog 1.0.0",
- "mc-sgx-slog-edl 1.0.0",
- "mc-sgx-types 1.0.0",
- "mc-util-build-script 1.0.0",
- "mc-util-build-sgx 1.0.0",
- "mc-util-serial 1.0.0",
+ "mc-attest-core 0.6.0",
+ "mc-attest-trusted 0.6.0",
+ "mc-common 0.6.0",
+ "mc-consensus-enclave-api 0.6.0",
+ "mc-consensus-enclave-edl 0.6.0",
+ "mc-consensus-enclave-impl 0.6.0",
+ "mc-crypto-keys 0.6.0",
+ "mc-enclave-boundary 0.6.0",
+ "mc-sgx-backtrace-edl 0.6.0",
+ "mc-sgx-compat 0.6.0",
+ "mc-sgx-debug-edl 0.6.0",
+ "mc-sgx-enclave-id 0.6.0",
+ "mc-sgx-panic-edl 0.6.0",
+ "mc-sgx-report-cache-api 0.6.0",
+ "mc-sgx-slog 0.6.0",
+ "mc-sgx-slog-edl 0.6.0",
+ "mc-sgx-types 0.6.0",
+ "mc-util-build-script 0.6.0",
+ "mc-util-build-sgx 0.6.0",
+ "mc-util-serial 0.6.0",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-attest-ake 1.0.0",
- "mc-attest-core 1.0.0",
- "mc-attest-enclave-api 1.0.0",
- "mc-attest-trusted 1.0.0",
- "mc-common 1.0.0",
- "mc-crypto-keys 1.0.0",
- "mc-crypto-noise 1.0.0",
- "mc-crypto-rand 1.0.0",
- "mc-sgx-build 1.0.0",
- "mc-sgx-compat 1.0.0",
- "mc-util-from-random 1.0.0",
- "mc-util-serial 1.0.0",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mc-attest-ake 0.6.0",
+ "mc-attest-core 0.6.0",
+ "mc-attest-enclave-api 0.6.0",
+ "mc-attest-trusted 0.6.0",
+ "mc-common 0.6.0",
+ "mc-crypto-keys 0.6.0",
+ "mc-crypto-noise 0.6.0",
+ "mc-crypto-rand 0.6.0",
+ "mc-sgx-build 0.6.0",
+ "mc-sgx-compat 0.6.0",
+ "mc-util-from-random 0.6.0",
+ "mc-util-serial 0.6.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -799,34 +826,43 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-crypto-keys 1.0.0",
+ "mc-crypto-ct-aead 0.5.0",
+ "mc-crypto-keys 0.6.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "mc-crypto-ct-aead"
+version = "0.5.0"
+dependencies = [
+ "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mc-crypto-digestible"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-crypto-digestible-derive 1.0.0",
- "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mc-crypto-digestible-derive 0.6.0",
  "x25519-dalek 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -835,16 +871,15 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-crypto-digestible 1.0.0",
 ]
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -852,12 +887,12 @@ dependencies = [
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-crypto-digestible 1.0.0",
- "mc-util-from-random 1.0.0",
- "mc-util-repr-bytes 1.0.0",
- "mc-util-serial 1.0.0",
+ "mc-crypto-digestible 0.6.0",
+ "mc-util-from-random 0.6.0",
+ "mc-util-repr-bytes 0.6.0",
+ "mc-util-serial 0.6.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -869,12 +904,12 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-util-serial 1.0.0",
+ "mc-util-serial 0.6.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -882,17 +917,17 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-crypto-keys 1.0.0",
- "mc-util-from-random 1.0.0",
- "mc-util-repr-bytes 1.0.0",
+ "mc-crypto-keys 0.6.0",
+ "mc-util-from-random 0.6.0",
+ "mc-util-repr-bytes 0.6.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -903,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,10 +949,10 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-sig"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
- "mc-crypto-hashes 1.0.0",
- "mc-crypto-keys 1.0.0",
+ "mc-crypto-hashes 0.6.0",
+ "mc-crypto-keys 0.6.0",
  "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -926,22 +961,29 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
- "mc-common 1.0.0",
- "mc-crypto-rand 1.0.0",
- "mc-sgx-compat 1.0.0",
- "mc-sgx-types 1.0.0",
+ "mc-common 0.6.0",
+ "mc-crypto-rand 0.6.0",
+ "mc-sgx-compat 0.6.0",
+ "mc-sgx-types 0.6.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.0.0"
+version = "0.6.0"
+
+[[package]]
+name = "mc-sgx-backtrace-edl"
+version = "0.6.0"
+dependencies = [
+ "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -951,20 +993,20 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-sgx-alloc 1.0.0",
- "mc-sgx-debug 1.0.0",
- "mc-sgx-panic 1.0.0",
- "mc-sgx-service 1.0.0",
- "mc-sgx-sync 1.0.0",
- "mc-sgx-types 1.0.0",
+ "mc-sgx-alloc 0.6.0",
+ "mc-sgx-debug 0.6.0",
+ "mc-sgx-panic 0.6.0",
+ "mc-sgx-service 0.6.0",
+ "mc-sgx-sync 0.6.0",
+ "mc-sgx-types 0.6.0",
 ]
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -972,97 +1014,113 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.0.0"
+version = "0.6.0"
 
 [[package]]
-name = "mc-sgx-enclave-id"
-version = "1.0.0"
+name = "mc-sgx-debug-edl"
+version = "0.6.0"
 dependencies = [
- "mc-sgx-types 1.0.0",
+ "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "mc-sgx-enclave-id"
+version = "0.6.0"
+dependencies = [
+ "mc-sgx-types 0.6.0",
+]
+
+[[package]]
+name = "mc-sgx-libc-types"
+version = "0.6.0"
+
+[[package]]
 name = "mc-sgx-panic"
-version = "1.0.0"
+version = "0.6.0"
+dependencies = [
+ "mc-sgx-libc-types 0.6.0",
+]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-attest-core 1.0.0",
- "mc-attest-enclave-api 1.0.0",
- "mc-util-serial 1.0.0",
+ "mc-attest-core 0.6.0",
+ "mc-attest-enclave-api 0.6.0",
+ "mc-util-serial 0.6.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
- "mc-sgx-build 1.0.0",
- "mc-sgx-types 1.0.0",
+ "mc-sgx-build 0.6.0",
+ "mc-sgx-types 0.6.0",
 ]
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-common 1.0.0",
- "mc-sgx-build 1.0.0",
+ "mc-common 0.6.0",
+ "mc-sgx-build 0.6.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
 ]
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
- "mc-sgx-panic 1.0.0",
- "mc-sgx-types 1.0.0",
+ "mc-sgx-libc-types 0.6.0",
+ "mc-sgx-panic 0.6.0",
+ "mc-sgx-types 0.6.0",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.0.0"
+version = "0.6.0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bulletproofs 2.0.0 (git+https://github.com/eranrund/bulletproofs?rev=e8e8ef45ecc6d31f1a9525140edc977351d0f780)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-account-keys 1.0.0",
- "mc-common 1.0.0",
- "mc-crypto-box 1.0.0",
- "mc-crypto-digestible 1.0.0",
- "mc-crypto-hashes 1.0.0",
- "mc-crypto-keys 1.0.0",
- "mc-crypto-rand 1.0.0",
- "mc-util-from-random 1.0.0",
- "mc-util-repr-bytes 1.0.0",
- "mc-util-serial 1.0.0",
+ "mc-account-keys 0.6.0",
+ "mc-common 0.6.0",
+ "mc-crypto-box 0.6.0",
+ "mc-crypto-digestible 0.6.0",
+ "mc-crypto-hashes 0.6.0",
+ "mc-crypto-keys 0.6.0",
+ "mc-crypto-rand 0.6.0",
+ "mc-util-from-random 0.6.0",
+ "mc-util-repr-bytes 0.6.0",
+ "mc-util-serial 0.6.0",
  "merlin 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1074,10 +1132,10 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1085,38 +1143,38 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-util-build-script 1.0.0",
+ "mc-util-build-script 0.6.0",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "mc-util-repr-bytes 1.0.0",
+ "mc-util-repr-bytes 0.6.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
@@ -1125,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1206,6 +1264,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "polyval"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "universal-hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "polyval"
@@ -1394,7 +1461,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpuid-bool 0.1.2 (git+https://github.com/eranrund/RustCrypto-utils?rev=74f8e04e9d18d93fc6d05c72756c236dc88daa19)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2-asm 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1511,7 +1578,7 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1546,6 +1613,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "universal-hash"
@@ -1606,7 +1682,7 @@ name = "which"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1715,8 +1791,8 @@ dependencies = [
 "checksum ed25519-dalek 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53d2e93f837d749c16d118e7ddf7a4dfd0ac8f452cf51e46e9348824e5ef6851"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
-"checksum failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-"checksum failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
+"checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 "checksum genio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4e26859a808ffa83a83f20c7e3c9366afea91edae637a6ac203051885882dc8"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
@@ -1734,7 +1810,7 @@ dependencies = [
 "checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)" = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
+"checksum libc 0.2.74 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -371,15 +371,15 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure_derive"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -618,7 +618,7 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
@@ -653,7 +653,7 @@ dependencies = [
 name = "mc-attest-trusted"
 version = "1.0.0"
 dependencies = [
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-attest-core 1.0.0",
  "mc-common 1.0.0",
  "mc-sgx-compat 1.0.0",
@@ -667,7 +667,7 @@ version = "1.0.0"
 dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -687,7 +687,7 @@ name = "mc-consensus-enclave-api"
 version = "1.0.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-attest-ake 1.0.0",
  "mc-attest-core 1.0.0",
  "mc-attest-enclave-api 1.0.0",
@@ -779,7 +779,7 @@ dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-attest-ake 1.0.0",
  "mc-attest-core 1.0.0",
  "mc-attest-enclave-api 1.0.0",
@@ -805,7 +805,7 @@ dependencies = [
  "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-ct-aead 0.5.0",
  "mc-crypto-keys 1.0.0",
@@ -863,7 +863,7 @@ dependencies = [
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-digestible 1.0.0",
  "mc-util-from-random 1.0.0",
@@ -883,7 +883,7 @@ name = "mc-crypto-message-cipher"
 version = "1.0.0"
 dependencies = [
  "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-util-serial 1.0.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -898,7 +898,7 @@ dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-keys 1.0.0",
@@ -1060,7 +1060,7 @@ dependencies = [
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1088,7 +1088,7 @@ name = "mc-util-build-script"
 version = "1.0.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1726,8 +1726,8 @@ dependencies = [
 "checksum ed25519-dalek 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53d2e93f837d749c16d118e7ddf7a4dfd0ac8f452cf51e46e9348824e5ef6851"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
-"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
-"checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
+"checksum failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+"checksum failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 "checksum generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 "checksum genio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4e26859a808ffa83a83f20c7e3c9366afea91edae637a6ac203051885882dc8"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -79,4 +79,8 @@ bulletproofs = { git = "https://github.com/eranrund/bulletproofs", rev = "e8e8ef
 # Patched to disable the cpuid instruction because that is incompatible with our sgx builds.
 cpuid-bool = { git = "https://github.com/eranrund/RustCrypto-utils", rev = "74f8e04e9d18d93fc6d05c72756c236dc88daa19" }
 
+# We need to patch aes-gcm so we can make some fields/functions/structs pub in order to have a constant time decrypt
+aes-gcm = { git = "https://github.com/xoloki/AEADs", rev = "d1a8517d3dd867ed9c5794002add67992a42f6aa" }
+
+
 [workspace]

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -12,6 +12,7 @@ digest = { version = "0.9" }
 failure = { version = "0.1.8", default-features = false }
 hkdf = { version = "0.9.0", default-features = false }
 mc-crypto-keys = { path = "../keys", default-features = false }
+mc-crypto-ct-aead = { path = "../ct-aead" }
 rand_core = { version = "0.5", default-features = false }
 
 [dev_dependencies]

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -11,8 +11,8 @@ blake2 = { version = "0.9", default-features = false }
 digest = { version = "0.9" }
 failure = { version = "0.1.8", default-features = false }
 hkdf = { version = "0.9.0", default-features = false }
-mc-crypto-keys = { path = "../keys", default-features = false }
 mc-crypto-ct-aead = { path = "../ct-aead" }
+mc-crypto-keys = { path = "../keys", default-features = false }
 rand_core = { version = "0.5", default-features = false }
 
 [dev_dependencies]

--- a/crypto/box/src/hkdf_box.rs
+++ b/crypto/box/src/hkdf_box.rs
@@ -15,6 +15,7 @@ use core::{
 };
 use digest::{BlockInput, Digest, FixedOutput, Reset, Update};
 use hkdf::Hkdf;
+use mc_crypto_ct_aead::CtAeadDecrypt;
 use mc_crypto_keys::{Kex, ReprBytes};
 use rand_core::{CryptoRng, RngCore};
 
@@ -30,8 +31,13 @@ pub struct HkdfBox<KexAlgo, DigestAlgo, AeadAlgo>
 where
     KexAlgo: Kex,
     for<'privkey> <KexAlgo as Kex>::Public: From<&'privkey <KexAlgo as Kex>::EphemeralPrivate>,
+<<<<<<< HEAD
     DigestAlgo: Digest + Update + FixedOutput + Default + Clone + BlockInput + Reset,
     AeadAlgo: AeadInPlace + NewAead,
+=======
+    DigestAlgo: Digest + Input + FixedOutput + Default + Clone + BlockInput + Reset,
+    AeadAlgo: Aead + NewAead + CtAeadDecrypt,
+>>>>>>> integrate preliminary ct-aead code
 {
     _kex: PhantomData<fn() -> KexAlgo>,
     _digest: PhantomData<fn() -> DigestAlgo>,
@@ -42,8 +48,13 @@ impl<KexAlgo, DigestAlgo, AeadAlgo> CryptoBox<KexAlgo> for HkdfBox<KexAlgo, Dige
 where
     KexAlgo: Kex,
     for<'privkey> <KexAlgo as Kex>::Public: From<&'privkey <KexAlgo as Kex>::EphemeralPrivate>,
+<<<<<<< HEAD
     DigestAlgo: Digest + Update + FixedOutput + Default + Clone + BlockInput + Reset,
     AeadAlgo: AeadInPlace + NewAead,
+=======
+    DigestAlgo: Digest + Input + FixedOutput + Default + Clone + BlockInput + Reset,
+    AeadAlgo: Aead + NewAead + CtAeadDecrypt,
+>>>>>>> integrate preliminary ct-aead code
     // Note: I think all of these bounds should go away after RFC 2089 is implemented
     // https://github.com/rust-lang/rfcs/blob/master/text/2089-implied-bounds.md
     <<KexAlgo as Kex>::Public as ReprBytes>::Size:
@@ -111,11 +122,8 @@ where
         let mac_ref = <&GenericArray<u8, AeadAlgo::TagSize>>::from(
             &tag[<KexAlgo::Public as ReprBytes>::Size::USIZE..],
         );
-        let aead = AeadAlgo::new(&aes_key);
-        aead.decrypt_in_place_detached(&aes_nonce, &[], buffer, mac_ref)
-            .map_err(|_| Error::MacFailed)?;
-
-        Ok(())
+        let aead = AeadAlgo::new(aes_key);
+        Ok(aead.ct_decrypt_in_place_detached(&aes_nonce, &[], buffer, mac_ref))
     }
 }
 
@@ -123,8 +131,8 @@ impl<KexAlgo, DigestAlgo, AeadAlgo> HkdfBox<KexAlgo, DigestAlgo, AeadAlgo>
 where
     KexAlgo: Kex,
     for<'privkey> <KexAlgo as Kex>::Public: From<&'privkey <KexAlgo as Kex>::EphemeralPrivate>,
-    DigestAlgo: Digest + Update + FixedOutput + Default + Clone + BlockInput + Reset,
-    AeadAlgo: AeadInPlace + NewAead,
+    DigestAlgo: Digest + Input + FixedOutput + Default + Clone + BlockInput + Reset,
+    AeadAlgo: Aead + NewAead + CtAeadDecrypt,
     AeadAlgo::KeySize: Add<AeadAlgo::NonceSize>,
     Sum<AeadAlgo::KeySize, AeadAlgo::NonceSize>:
         ArrayLength<u8> + Sub<AeadAlgo::KeySize, Output = AeadAlgo::NonceSize>,
@@ -151,8 +159,8 @@ impl<KexAlgo, DigestAlgo, AeadAlgo> Default for HkdfBox<KexAlgo, DigestAlgo, Aea
 where
     KexAlgo: Kex,
     for<'privkey> <KexAlgo as Kex>::Public: From<&'privkey <KexAlgo as Kex>::EphemeralPrivate>,
-    DigestAlgo: Digest + Update + FixedOutput + Default + Clone + BlockInput + Reset,
-    AeadAlgo: AeadInPlace + NewAead,
+    DigestAlgo: Digest + Input + FixedOutput + Default + Clone + BlockInput + Reset,
+    AeadAlgo: Aead + NewAead + CtAeadDecrypt,
 {
     fn default() -> Self {
         Self {

--- a/crypto/box/src/hkdf_box.rs
+++ b/crypto/box/src/hkdf_box.rs
@@ -31,13 +31,8 @@ pub struct HkdfBox<KexAlgo, DigestAlgo, AeadAlgo>
 where
     KexAlgo: Kex,
     for<'privkey> <KexAlgo as Kex>::Public: From<&'privkey <KexAlgo as Kex>::EphemeralPrivate>,
-<<<<<<< HEAD
     DigestAlgo: Digest + Update + FixedOutput + Default + Clone + BlockInput + Reset,
-    AeadAlgo: AeadInPlace + NewAead,
-=======
-    DigestAlgo: Digest + Input + FixedOutput + Default + Clone + BlockInput + Reset,
-    AeadAlgo: Aead + NewAead + CtAeadDecrypt,
->>>>>>> integrate preliminary ct-aead code
+    AeadAlgo: AeadInPlace + NewAead + CtAeadDecrypt,
 {
     _kex: PhantomData<fn() -> KexAlgo>,
     _digest: PhantomData<fn() -> DigestAlgo>,
@@ -48,13 +43,7 @@ impl<KexAlgo, DigestAlgo, AeadAlgo> CryptoBox<KexAlgo> for HkdfBox<KexAlgo, Dige
 where
     KexAlgo: Kex,
     for<'privkey> <KexAlgo as Kex>::Public: From<&'privkey <KexAlgo as Kex>::EphemeralPrivate>,
-<<<<<<< HEAD
-    DigestAlgo: Digest + Update + FixedOutput + Default + Clone + BlockInput + Reset,
-    AeadAlgo: AeadInPlace + NewAead,
-=======
-    DigestAlgo: Digest + Input + FixedOutput + Default + Clone + BlockInput + Reset,
-    AeadAlgo: Aead + NewAead + CtAeadDecrypt,
->>>>>>> integrate preliminary ct-aead code
+    AeadAlgo: AeadInPlace + NewAead + CtAeadDecrypt,
     // Note: I think all of these bounds should go away after RFC 2089 is implemented
     // https://github.com/rust-lang/rfcs/blob/master/text/2089-implied-bounds.md
     <<KexAlgo as Kex>::Public as ReprBytes>::Size:
@@ -131,8 +120,8 @@ impl<KexAlgo, DigestAlgo, AeadAlgo> HkdfBox<KexAlgo, DigestAlgo, AeadAlgo>
 where
     KexAlgo: Kex,
     for<'privkey> <KexAlgo as Kex>::Public: From<&'privkey <KexAlgo as Kex>::EphemeralPrivate>,
-    DigestAlgo: Digest + Input + FixedOutput + Default + Clone + BlockInput + Reset,
-    AeadAlgo: Aead + NewAead + CtAeadDecrypt,
+    DigestAlgo: Digest + Update + FixedOutput + Default + Clone + BlockInput + Reset,
+    AeadAlgo: AeadInPlace + NewAead + CtAeadDecrypt,
     AeadAlgo::KeySize: Add<AeadAlgo::NonceSize>,
     Sum<AeadAlgo::KeySize, AeadAlgo::NonceSize>:
         ArrayLength<u8> + Sub<AeadAlgo::KeySize, Output = AeadAlgo::NonceSize>,
@@ -159,8 +148,8 @@ impl<KexAlgo, DigestAlgo, AeadAlgo> Default for HkdfBox<KexAlgo, DigestAlgo, Aea
 where
     KexAlgo: Kex,
     for<'privkey> <KexAlgo as Kex>::Public: From<&'privkey <KexAlgo as Kex>::EphemeralPrivate>,
-    DigestAlgo: Digest + Input + FixedOutput + Default + Clone + BlockInput + Reset,
-    AeadAlgo: Aead + NewAead + CtAeadDecrypt,
+    DigestAlgo: Digest + Update + FixedOutput + Default + Clone + BlockInput + Reset,
+    AeadAlgo: AeadInPlace + NewAead + CtAeadDecrypt,
 {
     fn default() -> Self {
         Self {

--- a/crypto/box/src/hkdf_box.rs
+++ b/crypto/box/src/hkdf_box.rs
@@ -56,9 +56,7 @@ where
         Rest = GenericArray<u8, AeadAlgo::TagSize>,
         Output = GenericArray<
             u8,
-            <<<KexAlgo as Kex>::Public as ReprBytes>::Size as Add<
-                AeadAlgo::TagSize,
-            >>::Output,
+            <<<KexAlgo as Kex>::Public as ReprBytes>::Size as Add<AeadAlgo::TagSize>>::Output,
         >,
     >,
     AeadAlgo::KeySize: Add<AeadAlgo::NonceSize>,
@@ -110,9 +108,8 @@ where
         // KDF
         let (aes_key, aes_nonce) = Self::kdf_step(&shared_secret);
 
-        let ct_aes_nonce = <GenericArray<u8, AeadAlgo::NonceSize>>::from_slice(
-            aes_nonce.as_slice(),
-        );
+        let ct_aes_nonce =
+            <GenericArray<u8, AeadAlgo::NonceSize>>::from_slice(aes_nonce.as_slice());
 
         // AES
         let mac_ref = <&GenericArray<u8, AeadAlgo::TagSize>>::from(
@@ -142,10 +139,7 @@ where
         GenericArray<u8, AeadAlgo::NonceSize>,
     ) {
         let kdf = Hkdf::<DigestAlgo>::new(Some(b"dei-salty-box"), dh_secret.as_ref());
-        let mut okm = GenericArray::<
-            u8,
-            Sum<AeadAlgo::KeySize, AeadAlgo::NonceSize>,
-        >::default();
+        let mut okm = GenericArray::<u8, Sum<AeadAlgo::KeySize, AeadAlgo::NonceSize>>::default();
         kdf.expand(b"aead-key-iv", okm.as_mut_slice())
             .expect("Digest output size is insufficient");
 

--- a/crypto/box/src/hkdf_box.rs
+++ b/crypto/box/src/hkdf_box.rs
@@ -110,8 +110,9 @@ where
         // KDF
         let (aes_key, aes_nonce) = Self::kdf_step(&shared_secret);
 
-        let ct_aes_nonce =
-            <GenericArray<u8, <AeadAlgo as CtAeadDecrypt>::NonceSize>>::from(aes_nonce);
+        let ct_aes_nonce = <GenericArray<u8, <AeadAlgo as CtAeadDecrypt>::NonceSize>>::from_slice(
+            aes_nonce.as_slice(),
+        );
 
         // AES
         let mac_ref = <&GenericArray<u8, <AeadAlgo as CtAeadDecrypt>::TagSize>>::from(

--- a/crypto/box/src/hkdf_box.rs
+++ b/crypto/box/src/hkdf_box.rs
@@ -48,24 +48,24 @@ where
     // Note: I think all of these bounds should go away after RFC 2089 is implemented
     // https://github.com/rust-lang/rfcs/blob/master/text/2089-implied-bounds.md
     <<KexAlgo as Kex>::Public as ReprBytes>::Size:
-        ArrayLength<u8> + Unsigned + Add<<AeadAlgo as AeadInPlace>::TagSize>,
-    Sum<<KexAlgo::Public as ReprBytes>::Size, <AeadAlgo as AeadInPlace>::TagSize>: ArrayLength<u8>,
+        ArrayLength<u8> + Unsigned + Add<AeadAlgo::TagSize>,
+    Sum<<KexAlgo::Public as ReprBytes>::Size, AeadAlgo::TagSize>: ArrayLength<u8>,
     GenericArray<u8, <<KexAlgo as Kex>::Public as ReprBytes>::Size>: Concat<
         u8,
-        <AeadAlgo as AeadInPlace>::TagSize,
-        Rest = GenericArray<u8, <AeadAlgo as AeadInPlace>::TagSize>,
+        AeadAlgo::TagSize,
+        Rest = GenericArray<u8, AeadAlgo::TagSize>,
         Output = GenericArray<
             u8,
             <<<KexAlgo as Kex>::Public as ReprBytes>::Size as Add<
-                <AeadAlgo as AeadInPlace>::TagSize,
+                AeadAlgo::TagSize,
             >>::Output,
         >,
     >,
-    AeadAlgo::KeySize: Add<<AeadAlgo as AeadInPlace>::NonceSize>,
-    Sum<AeadAlgo::KeySize, <AeadAlgo as AeadInPlace>::NonceSize>:
-        ArrayLength<u8> + Sub<AeadAlgo::KeySize, Output = <AeadAlgo as AeadInPlace>::NonceSize>,
+    AeadAlgo::KeySize: Add<AeadAlgo::NonceSize>,
+    Sum<AeadAlgo::KeySize, AeadAlgo::NonceSize>:
+        ArrayLength<u8> + Sub<AeadAlgo::KeySize, Output = AeadAlgo::NonceSize>,
 {
-    type FooterSize = Sum<<KexAlgo::Public as ReprBytes>::Size, <AeadAlgo as AeadInPlace>::TagSize>;
+    type FooterSize = Sum<<KexAlgo::Public as ReprBytes>::Size, AeadAlgo::TagSize>;
 
     fn encrypt_in_place_detached<T: RngCore + CryptoRng>(
         &self,
@@ -110,12 +110,12 @@ where
         // KDF
         let (aes_key, aes_nonce) = Self::kdf_step(&shared_secret);
 
-        let ct_aes_nonce = <GenericArray<u8, <AeadAlgo as CtAeadDecrypt>::NonceSize>>::from_slice(
+        let ct_aes_nonce = <GenericArray<u8, AeadAlgo::NonceSize>>::from_slice(
             aes_nonce.as_slice(),
         );
 
         // AES
-        let mac_ref = <&GenericArray<u8, <AeadAlgo as CtAeadDecrypt>::TagSize>>::from(
+        let mac_ref = <&GenericArray<u8, AeadAlgo::TagSize>>::from(
             &tag[<KexAlgo::Public as ReprBytes>::Size::USIZE..],
         );
         let aead = AeadAlgo::new(&aes_key);
@@ -129,9 +129,9 @@ where
     for<'privkey> <KexAlgo as Kex>::Public: From<&'privkey <KexAlgo as Kex>::EphemeralPrivate>,
     DigestAlgo: Digest + Update + FixedOutput + Default + Clone + BlockInput + Reset,
     AeadAlgo: AeadInPlace + NewAead + CtAeadDecrypt,
-    AeadAlgo::KeySize: Add<<AeadAlgo as AeadInPlace>::NonceSize>,
-    Sum<AeadAlgo::KeySize, <AeadAlgo as AeadInPlace>::NonceSize>:
-        ArrayLength<u8> + Sub<AeadAlgo::KeySize, Output = <AeadAlgo as AeadInPlace>::NonceSize>,
+    AeadAlgo::KeySize: Add<AeadAlgo::NonceSize>,
+    Sum<AeadAlgo::KeySize, AeadAlgo::NonceSize>:
+        ArrayLength<u8> + Sub<AeadAlgo::KeySize, Output = AeadAlgo::NonceSize>,
 {
     /// KDF part, factored out to avoid duplication
     /// This part must produce the key and IV/nonce for Aead, from the IKM, using Hkdf.
@@ -139,12 +139,12 @@ where
         dh_secret: &KexAlgo::Secret,
     ) -> (
         GenericArray<u8, AeadAlgo::KeySize>,
-        GenericArray<u8, <AeadAlgo as AeadInPlace>::NonceSize>,
+        GenericArray<u8, AeadAlgo::NonceSize>,
     ) {
         let kdf = Hkdf::<DigestAlgo>::new(Some(b"dei-salty-box"), dh_secret.as_ref());
         let mut okm = GenericArray::<
             u8,
-            Sum<AeadAlgo::KeySize, <AeadAlgo as AeadInPlace>::NonceSize>,
+            Sum<AeadAlgo::KeySize, AeadAlgo::NonceSize>,
         >::default();
         kdf.expand(b"aead-key-iv", okm.as_mut_slice())
             .expect("Digest output size is insufficient");

--- a/crypto/box/src/hkdf_box.rs
+++ b/crypto/box/src/hkdf_box.rs
@@ -108,15 +108,12 @@ where
         // KDF
         let (aes_key, aes_nonce) = Self::kdf_step(&shared_secret);
 
-        let ct_aes_nonce =
-            <GenericArray<u8, AeadAlgo::NonceSize>>::from_slice(aes_nonce.as_slice());
-
         // AES
         let mac_ref = <&GenericArray<u8, AeadAlgo::TagSize>>::from(
             &tag[<KexAlgo::Public as ReprBytes>::Size::USIZE..],
         );
         let aead = AeadAlgo::new(&aes_key);
-        Ok(aead.ct_decrypt_in_place_detached(&ct_aes_nonce, &[], buffer, mac_ref))
+        Ok(aead.ct_decrypt_in_place_detached(&aes_nonce, &[], buffer, mac_ref))
     }
 }
 

--- a/crypto/box/src/lib.rs
+++ b/crypto/box/src/lib.rs
@@ -51,9 +51,10 @@ mod test {
             for plaintext in &[&plaintext1[..], &plaintext2[..]] {
                 for _reps in 0..50 {
                     let ciphertext = algo.encrypt(&mut rng, &a_pub, plaintext).unwrap();
-                    let decrypted = algo.decrypt(&a, &ciphertext).expect("decryption failed!");
+                    let (success, decrypted) = algo.decrypt(&a, &ciphertext).expect("decryption failed!");
                     assert_eq!(plaintext.len(), decrypted.len());
                     assert_eq!(plaintext, &&decrypted[..]);
+                    assert_eq!(success, true);
                 }
             }
         });
@@ -97,10 +98,11 @@ mod test {
                     let ciphertext = algo
                         .encrypt_fixed_length(&mut rng, &a_pub, plaintext)
                         .unwrap();
-                    let decrypted = algo
+                    let (success, decrypted) = algo
                         .decrypt_fixed_length(&a, &ciphertext)
                         .expect("decryption failed!");
                     assert_eq!(plaintext, &decrypted);
+                    assert_eq!(success, true);
                 }
             }
         });

--- a/crypto/box/src/lib.rs
+++ b/crypto/box/src/lib.rs
@@ -51,7 +51,8 @@ mod test {
             for plaintext in &[&plaintext1[..], &plaintext2[..]] {
                 for _reps in 0..50 {
                     let ciphertext = algo.encrypt(&mut rng, &a_pub, plaintext).unwrap();
-                    let (success, decrypted) = algo.decrypt(&a, &ciphertext).expect("decryption failed!");
+                    let (success, decrypted) =
+                        algo.decrypt(&a, &ciphertext).expect("decryption failed!");
                     assert_eq!(plaintext.len(), decrypted.len());
                     assert_eq!(plaintext, &&decrypted[..]);
                     assert_eq!(success, true);

--- a/crypto/box/src/lib.rs
+++ b/crypto/box/src/lib.rs
@@ -77,8 +77,11 @@ mod test {
                 for _reps in 0..50 {
                     let ciphertext = algo.encrypt(&mut rng, &a_pub, plaintext).unwrap();
                     let decrypted = algo.decrypt(&not_a, &ciphertext);
-                    assert!(decrypted.is_err());
-                    assert_eq!(decrypted, Err(Error::MacFailed));
+                    if decrypted.is_err() {
+                        assert_eq!(decrypted, Err(Error::MacFailed));
+                    } else {
+                        assert_eq!(decrypted.unwrap().0, false);
+                    }
                 }
             }
         });

--- a/crypto/box/src/traits.rs
+++ b/crypto/box/src/traits.rs
@@ -52,16 +52,24 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
     ///
     /// Meant to mirror aead::decrypt_in_place_detached
     ///
+    /// NOTE: Meant to run in constant-time even if the mac-check fails.
+    ///
     /// Fails if:
     /// - Curvepoint cannot be decoded
     /// - MAC check fails
     /// - Anything is wrong with the footer (magic bytes? version code?)
+    ///
+    /// Returns:
+    /// - true if decryption succeeded, buffer contains plaintext
+    /// - false if mac check failed, buffer contains failed plaintext.
+    ///   Buffer SHOULD be zeroized to avoid attacks
+    /// - error if anything else is wrong
     fn decrypt_in_place_detached(
         &self,
         key: &KexAlgo::Private,
         footer: &GenericArray<u8, Self::FooterSize>,
         buffer: &mut [u8],
-    ) -> Result<(), Error>;
+    ) -> Result<bool, Error>;
 
     // Provided functions
     // These functions consume and produce "cryptograms" where the footer bytes
@@ -82,13 +90,14 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
         Ok(result)
     }
 
-    /// Decrypt a slice pointing to the cryptogram, returning a Vec<u8> plaintext.
+    /// Decrypt a slice pointing to the cryptogram, returning a status and a Vec<u8> plaintext.
+    /// If status is false then mac check failed and plaintext should be discarded.
     ///
     /// Meant to mirror aead::decrypt
-    fn decrypt(&self, key: &KexAlgo::Private, cryptogram: &[u8]) -> Result<Vec<u8>, Error> {
+    fn decrypt(&self, key: &KexAlgo::Private, cryptogram: &[u8]) -> Result<(bool, Vec<u8>), Error> {
         let mut result = cryptogram.to_vec();
-        self.decrypt_in_place(key, &mut result)?;
-        Ok(result)
+        let status = self.decrypt_in_place(key, &mut result)?;
+        Ok((status, result))
     }
 
     /// Encrypt a buffer, extending the buffer to place the footer at the end.
@@ -115,6 +124,12 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
     /// - The buffer is too short to be interpretted
     /// - The curvepoint cannot be deserialized
     /// - The mac check fails
+    ///
+    /// Returns:
+    /// - true if decryption succeeded, buffer contains plaintext
+    /// - false if mac check failed, buffer contains failed plaintext.
+    ///   Buffer SHOULD be zeroized to avoid attacks
+    /// - error if anything else is wrong
     fn decrypt_in_place(
         &self,
         key: &KexAlgo::Private,
@@ -127,9 +142,10 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
         let footer_pos = cryptogram.len() - Self::FooterSize::USIZE;
         let (ciphertext, footer) = cryptogram.as_mut().split_at_mut(footer_pos);
         // Note: this is modifying the cryptogram via the mutable slice ciphertext
-        self.decrypt_in_place_detached(key, GenericArray::from_slice(footer), ciphertext)?;
+        let status =
+            self.decrypt_in_place_detached(key, GenericArray::from_slice(footer), ciphertext)?;
         cryptogram.truncate(footer_pos);
-        Ok(())
+        Ok(status)
     }
 
     /// Encrypt a fixed-length buffer, producing a fixed-length buffer containing
@@ -156,14 +172,17 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
     /// the plaintext in a fixed-length buffer.
     ///
     /// A non-allocating counterpart to decrypt
+    ///
+    /// Returns:
+    /// - true if decryption succeeded, buffer contains plaintext
+    /// - false if mac check failed, buffer contains failed plaintext.
+    ///   Buffer SHOULD be zeroized to avoid attacks
+    /// - error if anything else is wrong
     fn decrypt_fixed_length<L>(
         &self,
         key: &KexAlgo::Private,
         cryptogram: &GenericArray<u8, L>,
-    ) -> Result<GenericArray<u8, Diff<L, Self::FooterSize>>, Error>
-    // generic_array/typenum can be really annoying...
-    // we have to convince it that not only is L - FooterSize a number,
-    // and an array length, but also that L - (L - FooterSize) is FooterSize
+    ) -> Result<(bool, GenericArray<u8, Diff<L, Self::FooterSize>>), Error>
     where
         L: ArrayLength<u8>
             + Sub<Self::FooterSize>
@@ -172,7 +191,7 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
     {
         let (mut ciphertext, footer) =
             Split::<u8, Diff<L, Self::FooterSize>>::split(cryptogram.clone());
-        self.decrypt_in_place_detached(key, &footer, ciphertext.as_mut_slice())?;
-        Ok(ciphertext)
+        let status = self.decrypt_in_place_detached(key, &footer, ciphertext.as_mut_slice())?;
+        Ok((status, ciphertext))
     }
 }

--- a/crypto/box/src/traits.rs
+++ b/crypto/box/src/traits.rs
@@ -84,7 +84,7 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
     }
 
     /// Decrypt a slice pointing to the cryptogram, returning a status and a Vec<u8> plaintext.
-    /// If status is false then mac check failed and plaintext should be discarded.
+    /// If status is false then mac check failed and plaintext should be zeroed.
     ///
     /// Meant to mirror aead::decrypt
     fn decrypt(&self, key: &KexAlgo::Private, cryptogram: &[u8]) -> Result<(bool, Vec<u8>), Error> {

--- a/crypto/box/src/traits.rs
+++ b/crypto/box/src/traits.rs
@@ -134,7 +134,7 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
         &self,
         key: &KexAlgo::Private,
         cryptogram: &mut impl aead::Buffer,
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         // Extract the footer from end of ciphertext, doing bounds checks
         if cryptogram.len() < Self::FooterSize::USIZE {
             return Err(Error::TooShort(cryptogram.len(), Self::FooterSize::USIZE));

--- a/crypto/box/src/traits.rs
+++ b/crypto/box/src/traits.rs
@@ -54,16 +54,9 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
     ///
     /// NOTE: Meant to run in constant-time even if the mac-check fails.
     ///
-    /// Fails if:
-    /// - Curvepoint cannot be decoded
-    /// - MAC check fails
-    /// - Anything is wrong with the footer (magic bytes? version code?)
-    ///
-    /// Returns:
-    /// - true if decryption succeeded, buffer contains plaintext
-    /// - false if mac check failed, buffer contains failed plaintext.
-    ///   Buffer SHOULD be zeroized to avoid attacks
-    /// - error if anything else is wrong
+    /// Returns
+    /// `Ok(true)` if decryption succeeds. `buffer` contains the plaintext and SHOULD be zeroized after use.
+    /// `Ok(false) if MAC check fails. `buffer` contains failed plaintext and SHOULD be zeroized after use.
     fn decrypt_in_place_detached(
         &self,
         key: &KexAlgo::Private,

--- a/crypto/box/src/versioned.rs
+++ b/crypto/box/src/versioned.rs
@@ -208,12 +208,17 @@ mod test {
 
             let not_a = RistrettoPrivate::from_random(&mut rng);
 
+            assert_eq!(a.to_bytes(), not_a.to_bytes());
+
             for plaintext in &[&plaintext1[..], &plaintext2[..]] {
                 for _reps in 0..50 {
                     let ciphertext = algo.encrypt(&mut rng, &a_pub, plaintext).unwrap();
                     let decrypted = algo.decrypt(&not_a, &ciphertext);
-                    assert!(decrypted.is_err());
-                    assert_eq!(decrypted, Err(Error::MacFailed));
+                    if decrypted.is_err() {
+                        assert_eq!(decrypted, Err(Error::MacFailed));
+                    } else {
+                        assert_eq!(decrypted.unwrap().0, false);
+                    }
                 }
             }
         });

--- a/crypto/box/src/versioned.rs
+++ b/crypto/box/src/versioned.rs
@@ -208,8 +208,6 @@ mod test {
 
             let not_a = RistrettoPrivate::from_random(&mut rng);
 
-            assert_eq!(a.to_bytes(), not_a.to_bytes());
-
             for plaintext in &[&plaintext1[..], &plaintext2[..]] {
                 for _reps in 0..50 {
                     let ciphertext = algo.encrypt(&mut rng, &a_pub, plaintext).unwrap();

--- a/crypto/box/src/versioned.rs
+++ b/crypto/box/src/versioned.rs
@@ -141,7 +141,7 @@ impl CryptoBox<Ristretto> for VersionedCryptoBox {
         key: &<Ristretto as Kex>::Private,
         footer: &GenericArray<u8, Self::FooterSize>,
         buffer: &mut [u8],
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         // Note: When generic_array is upreved, this can be tidier using this:
         // https://docs.rs/generic-array/0.14.1/src/generic_array/sequence.rs.html#302-320
         // For now we have to split as a slice, then convert back to Generic Array.

--- a/crypto/box/src/versioned.rs
+++ b/crypto/box/src/versioned.rs
@@ -186,9 +186,11 @@ mod test {
             for plaintext in &[&plaintext1[..], &plaintext2[..]] {
                 for _reps in 0..50 {
                     let ciphertext = algo.encrypt(&mut rng, &a_pub, plaintext).unwrap();
-                    let decrypted = algo.decrypt(&a, &ciphertext).expect("decryption failed!");
+                    let (success, decrypted) =
+                        algo.decrypt(&a, &ciphertext).expect("decryption failed!");
                     assert_eq!(plaintext.len(), decrypted.len());
                     assert_eq!(plaintext, &&decrypted[..]);
+                    assert_eq!(success, true);
                 }
             }
         });

--- a/crypto/ct-aead/Cargo.toml
+++ b/crypto/ct-aead/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mc-crypto-ct-aead"
+version = "0.5.0"
+authors = ["MobileCoin"]
+edition = "2018"
+
+[dependencies]
+aes-gcm = { version = "0.6", default-features = false }
+block-cipher = "0.7"
+subtle = { version = "2", default-features = false }

--- a/crypto/ct-aead/Cargo.toml
+++ b/crypto/ct-aead/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["MobileCoin"]
 edition = "2018"
 
 [dependencies]
+aead = "0.3"
 aes-gcm = { version = "0.6", default-features = false }
 block-cipher = "0.7"
 subtle = { version = "2", default-features = false }

--- a/crypto/ct-aead/README.md
+++ b/crypto/ct-aead/README.md
@@ -1,0 +1,10 @@
+ct-aead
+========
+
+This crate contains a trait extending the suite of Aead traits offered by
+https://github.com/RustCrypto/traits
+
+This is needed to offer a decrypt interface with an additional constant-time property:
+Timings, code paths, and data paths are the same whether or not the mac check succeeds.
+
+It also implements this trait on the AesGcm AEAD's from the aes-gcm crate.

--- a/crypto/ct-aead/src/aes_impl.rs
+++ b/crypto/ct-aead/src/aes_impl.rs
@@ -1,0 +1,41 @@
+use crate::CtAeadDecrypt;
+
+use aes_gcm::{AesGcm, Tag, A_MAX, C_MAX};
+use block_cipher::{
+    consts::{U0, U16},
+    generic_array::{ArrayLength, GenericArray},
+    Block, BlockCipher,
+};
+
+impl<Aes, NonceSize> CtAeadDecrypt for AesGcm<Aes, NonceSize>
+where
+    Aes: BlockCipher<BlockSize = U16>,
+    Aes::ParBlocks: ArrayLength<Block<Aes>>,
+    NonceSize: ArrayLength<u8>,
+{
+    type NonceSize = NonceSize;
+    type TagSize = U16;
+    type CiphertextOverhead = U0;
+
+    fn ct_decrypt_in_place_detached(
+        &self,
+        nonce: &GenericArray<u8, NonceSize>,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+        tag: &Tag,
+    ) -> bool {
+        if buffer.len() as u64 > C_MAX || associated_data.len() as u64 > A_MAX {
+            return false;
+        }
+
+        // TODO(tarcieri): interleave encryption with GHASH
+        // See: <https://github.com/RustCrypto/AEADs/issues/74>
+        let mut expected_tag = self.compute_tag(associated_data, buffer);
+        let mut ctr = self.init_ctr(nonce);
+        ctr.apply_keystream(&self.cipher, expected_tag.as_mut_slice());
+        ctr.apply_keystream(&self.cipher, buffer);
+
+        use subtle::ConstantTimeEq;
+        bool::from(expected_tag.ct_eq(&tag))
+    }
+}

--- a/crypto/ct-aead/src/aes_impl.rs
+++ b/crypto/ct-aead/src/aes_impl.rs
@@ -17,6 +17,8 @@ where
     type TagSize = U16;
     type CiphertextOverhead = U0;
 
+    /// A constant time version of the original
+    /// https://docs.rs/aes-gcm/0.6.0/src/aes_gcm/lib.rs.html#251
     fn ct_decrypt_in_place_detached(
         &self,
         nonce: &GenericArray<u8, NonceSize>,

--- a/crypto/ct-aead/src/aes_impl.rs
+++ b/crypto/ct-aead/src/aes_impl.rs
@@ -2,7 +2,7 @@ use crate::CtAeadDecrypt;
 
 use aes_gcm::{AesGcm, Tag, A_MAX, C_MAX};
 use block_cipher::{
-    consts::{U0, U16},
+    consts::U16,
     generic_array::{ArrayLength, GenericArray},
     Block, BlockCipher,
 };
@@ -13,10 +13,6 @@ where
     Aes::ParBlocks: ArrayLength<Block<Aes>>,
     NonceSize: ArrayLength<u8>,
 {
-    type NonceSize = NonceSize;
-    type TagSize = U16;
-    type CiphertextOverhead = U0;
-
     /// A constant time version of the original
     /// https://docs.rs/aes-gcm/0.6.0/src/aes_gcm/lib.rs.html#251
     fn ct_decrypt_in_place_detached(

--- a/crypto/ct-aead/src/lib.rs
+++ b/crypto/ct-aead/src/lib.rs
@@ -1,0 +1,13 @@
+//! Definition of CtAeadDecrypt trait and an implementation for AesGcm object.
+
+#![no_std]
+
+extern crate alloc;
+
+// Re-export the versions of traits and objects from our dependencies
+pub use aes_gcm;
+
+mod aes_impl;
+
+mod traits;
+pub use traits::CtAeadDecrypt;

--- a/crypto/ct-aead/src/traits.rs
+++ b/crypto/ct-aead/src/traits.rs
@@ -1,0 +1,27 @@
+use block_cipher::generic_array::{ArrayLength, GenericArray};
+
+/// API for Aead in-place decryption which is constant-time with respect to
+/// the mac check failing
+pub trait CtAeadDecrypt {
+    type NonceSize: ArrayLength<u8>;
+    type TagSize: ArrayLength<u8>;
+    type CiphertextOverhead: ArrayLength<u8>;
+
+    /// Decrypt a buffer using given aead nonce, validating associated data
+    /// under the mac (tag).
+    ///
+    /// This API promises to be branchless and constant time, particularly,
+    /// not branching on whether or not the mac check succeeded.
+    ///
+    /// Returns:
+    /// true: The mac check succeeded and the buffer contains the plaintext
+    /// false: The mac check failed, and the buffer contains failed decryption.
+    ///        The caller should zeroize buffer before it is discarded.
+    fn ct_decrypt_in_place_detached(
+        &self,
+        nonce: &GenericArray<u8, Self::NonceSize>,
+        associated_data: &[u8],
+        buffer: &mut [u8],
+        tag: &GenericArray<u8, Self::TagSize>,
+    ) -> bool;
+}

--- a/crypto/ct-aead/src/traits.rs
+++ b/crypto/ct-aead/src/traits.rs
@@ -1,12 +1,9 @@
-use block_cipher::generic_array::{ArrayLength, GenericArray};
+use aead::AeadInPlace;
+use block_cipher::generic_array::GenericArray;
 
 /// API for Aead in-place decryption which is constant-time with respect to
 /// the mac check failing
-pub trait CtAeadDecrypt {
-    type NonceSize: ArrayLength<u8>;
-    type TagSize: ArrayLength<u8>;
-    type CiphertextOverhead: ArrayLength<u8>;
-
+pub trait CtAeadDecrypt: AeadInPlace {
     /// Decrypt a buffer using given aead nonce, validating associated data
     /// under the mac (tag).
     ///

--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -112,7 +112,7 @@ impl FogHint {
         let (result, plaintext) = VersionedCryptoBox::default()
             .decrypt_fixed_length(ingest_server_private_key, ciphertext.as_ref())?;
 
-        if result == false {
+        if !result {
             return Err(CryptoBoxError::MacFailed);
         }
 

--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -207,7 +207,7 @@ mod testing {
             let not_z = RistrettoPrivate::from_random(&mut rng);
 
             let result = FogHint::decrypt(&not_z, &ciphertext);
-            assert_eq!(Err(CryptoBoxError::MacFailed), result);
+            assert_eq!(Err(CryptoBoxError::WrongMagicBytes), result);
         });
     }
 }

--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -109,7 +109,7 @@ impl FogHint {
         ingest_server_private_key: &RistrettoPrivate,
         ciphertext: &EncryptedFogHint,
     ) -> Result<Self, CryptoBoxError> {
-        let plaintext = VersionedCryptoBox::default()
+        let (_result, plaintext) = VersionedCryptoBox::default()
             .decrypt_fixed_length(ingest_server_private_key, ciphertext.as_ref())?;
         // Check magic numbers
         for byte in &plaintext[RISTRETTO_PUBLIC_LEN..] {
@@ -149,7 +149,7 @@ impl FogHint {
         let (plaintext, mut success) = match VersionedCryptoBox::default()
             .decrypt_fixed_length(ingest_server_private_key, ciphertext.as_ref())
         {
-            Ok(real_plaintext) => (real_plaintext, true),
+            Ok((result, real_plaintext)) => (real_plaintext, result),
             Err(_) => (default_plaintext, false),
         };
 

--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -175,7 +175,10 @@ impl FogHint {
                 output.view_pubkey = key;
                 Choice::from(success as u8)
             }
-            Err(_) => Choice::from(0),
+            Err(_) => {
+                output.view_pubkey = CompressedRistrettoPublic::from(default_pubkey);
+                Choice::from(0)
+            }
         }
     }
 }

--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -155,8 +155,8 @@ impl FogHint {
         let (real_plaintext, mut success) = match VersionedCryptoBox::default()
             .decrypt_fixed_length(ingest_server_private_key, ciphertext.as_ref())
         {
-            Ok((result, real_plaintext)) => (Plaintext(real_plaintext.clone()), result),
-            Err(_) => (plaintext.clone(), false),
+            Ok((result, real_plaintext)) => (Plaintext(real_plaintext), result),
+            Err(_) => (plaintext, false),
         };
 
         let choice = Choice::from(success as u8);

--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -37,9 +37,9 @@ impl Default for Plaintext {
 impl ConditionallySelectable for Plaintext {
     fn conditional_select(a: &Self, b: &Self, c: subtle::Choice) -> Self {
         if bool::from(c) {
-            *a
-        } else {
             *b
+        } else {
+            *a
         }
     }
 }
@@ -204,8 +204,9 @@ mod testing {
             let mut output_fog_hint = random_fog_hint(&mut rng);
 
             let choice = FogHint::ct_decrypt(&z, &ciphertext, &mut output_fog_hint);
-            assert_eq!(fog_hint, output_fog_hint);
+
             assert!(bool::from(choice));
+            assert_eq!(fog_hint, output_fog_hint);
         });
     }
 
@@ -222,8 +223,9 @@ mod testing {
             let mut output_fog_hint = random_fog_hint(&mut rng);
 
             let choice = FogHint::ct_decrypt(&not_z, &ciphertext, &mut output_fog_hint);
-            assert!(fog_hint != output_fog_hint);
+
             assert!(!bool::from(choice));
+            assert!(fog_hint != output_fog_hint);
         });
     }
 }


### PR DESCRIPTION
Soundtrack of this PR: [https://www.youtube.com/watch?v=TxrwImCJCqk](Hazy Shade of Winter)

### Motivation

We need constant time decryption to avoid side channel attacks.  Upstream aes-gcm did not have this, and it also kept its internals private so we could not implement this ourselves without a lot of code duplication.  So here we use a tiny patch on upstream, combined with a new trait for CtAeadDecrypt, and integrate it into cryptobox.

### In this PR
* Use upstream fork to allow access to aes-gcm internals
* Add CtAeadDecrypt trait and use it in cryptobox

Fixes #FOG-96 and FOG-155

### Future Work

