### PR TITLE
main-net-feature

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,6 +6,15 @@ build = "build.rs"
 edition = "2018"
 links = "mc-api"
 
+[features]
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
+
 [dependencies]
 mc-account-keys = { path = "../account-keys" }
 mc-common = { path = "../common" }

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -4,6 +4,15 @@ version = "1.0.0"
 authors = ["MobileCoin"]
 edition = "2018"
 
+[features]
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
+
 [dependencies]
 mc-attest-ake = { path = "../attest/ake" }
 mc-attest-api = { path = "../attest/api" }

--- a/connection/test-utils/Cargo.toml
+++ b/connection/test-utils/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 mc-ledger-db = { path = "../../ledger/db", features = ["test_utils"] }
 mc-connection = { path = "../../connection" }
 mc-util-uri = { path = "../../util/uri" }
-mc-transaction-core = { path = "../../transaction/core" }
+mc-transaction-core = { path = "../../transaction/core", features = ["test-net-fee-keys"] }

--- a/consensus/api/Cargo.toml
+++ b/consensus/api/Cargo.toml
@@ -6,6 +6,15 @@ build = "build.rs"
 edition = "2018"
 links = "mc-consensus-api"
 
+[features]
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
+
 [dependencies]
 mc-api = { path = "../../api" }
 mc-attest-api = { path = "../../attest/api" }

--- a/consensus/enclave/Cargo.toml
+++ b/consensus/enclave/Cargo.toml
@@ -5,6 +5,17 @@ authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Consensus Enclave - Application Code"
 
+[features]
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys",
+    "mc-consensus-enclave-api/main-net-fee-keys",
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys",
+    "mc-consensus-enclave-api/test-net-fee-keys"
+]
+
 [dependencies]
 mc-attest-core = { path = "../../attest/core" }
 mc-attest-enclave-api = { path = "../../attest/enclave-api" }

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -15,6 +15,13 @@ std = [
     "mc-util-serial/std",
     "serde/std"
 ]
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
 
 [dependencies]
 mc-attest-core = { path = "../../../attest/core", default-features = false }

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -23,6 +23,13 @@ std = [
     "mc-consensus-enclave-api/std",
     "mbedtls/std",
 ]
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
 
 [dependencies]
 mc-account-keys = { path = "../../../account-keys" }

--- a/consensus/enclave/measurement/Cargo.toml
+++ b/consensus/enclave/measurement/Cargo.toml
@@ -9,6 +9,9 @@ links = "consensus_enclave_measurement"
 [features]
 # Whether the enclave should be built in simulation mode when it needs to be built
 sgx-sim = []
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = []
+test-net-fee-keys = []
 
 [dependencies]
 mc-sgx-css = { path = "../../../sgx/css" }

--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -69,6 +69,9 @@ fn main() {
         }
     }
 
+    rustc_cfg!("feature=\"mc-transaction-core/main-net-fee-keys\"");
+    rustc_cfg!("feature=\"mc-consensus-enclave-impl/main-net-fee-keys\"");
+
     builder
         .target_dir(env.target_dir().join(CONSENSUS_ENCLAVE_NAME).as_path())
         .config_builder

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -13,7 +13,7 @@ mc-crypto-digestible = { path = "../../../crypto/digestible" }
 mc-crypto-keys = { path = "../../../crypto/keys" }
 mc-crypto-rand = { path = "../../../crypto/rand" }
 mc-sgx-report-cache-api = { path = "../../../sgx/report-cache/api" }
-mc-transaction-core = { path = "../../../transaction/core" }
+mc-transaction-core = { path = "../../../transaction/core", features = ["test-net-fee-keys"] }
 mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-serial = { path = "../../../util/serial" }
 

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -18,6 +18,13 @@ sgx-sim = [
 ias-dev = [
     "mc-attest-core/ias-dev"
 ]
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-consensus-enclave-impl/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-consensus-enclave-impl/test-net-fee-keys"
+]
 
 [dependencies]
 mc-attest-core = { path = "../../../attest/core", default-features = false }

--- a/consensus/scp/play/Cargo.toml
+++ b/consensus/scp/play/Cargo.toml
@@ -8,6 +8,15 @@ edition = "2018"
 name = "scp-play"
 path = "src/main.rs"
 
+[features]
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
+
 [dependencies]
 mc-common = { path = "../../../common", features = ["loggers"] }
 mc-util-serial = { path = "../../../util/serial", features = ["std"] }
@@ -18,3 +27,8 @@ mc-transaction-core = { path = "../../../transaction/core" }
 serde_json = "1.0"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 structopt = "0.3"
+
+[build-dependencies]
+# Even though this is also a dependency, it needs to be here otherwise Cargo brings in some weird mixture of packages/features that refuses to compile.
+# Go figure ¯\_(ツ)_/¯
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -5,13 +5,13 @@ authors = ["MobileCoin"]
 edition = "2018"
 
 [features]
-default = ["test-net-fee-keys"]
-
 # Specifies whether to use test net or main net fee output keys
 main-net-fee-keys = [
     "mc-transaction-core/main-net-fee-keys"
 ]
-test-net-fee-keys = []
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
 
 [lib]
 path = "src/lib.rs"

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -7,6 +7,14 @@ edition = "2018"
 [features]
 test_utils = ["rand"]
 
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
+
 # The migration_support feature exposes some internals that should only be used by the `mc-ledger-migration` tool.
 migration_support = []
 

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -8,6 +8,16 @@ edition = "2018"
 name = "ledger-distribution"
 path = "src/main.rs"
 
+[features]
+test_utils = []
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
+
 [dependencies]
 mc-api = { path = "../../api" }
 mc-common = { path = "../../common", features = ["loggers"] }
@@ -25,3 +35,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
 url = "2.1"
+
+[build-dependencies]
+# Even though this is also a dependency, it needs to be here otherwise Cargo brings in some weird mixture of packages/features that refuses to compile.
+# Go figure ¯\_(ツ)_/¯
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -8,6 +8,16 @@ edition = "2018"
 name = "ledger-sync-test-app"
 path = "src/test_app/main.rs"
 
+[features]
+test_utils = []
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
+
 [dependencies]
 mc-account-keys = { path = "../../account-keys" }
 mc-api = { path = "../../api" }

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -11,7 +11,9 @@ default = ["test-net-fee-keys"]
 main-net-fee-keys = [
     "mc-transaction-core/main-net-fee-keys"
 ]
-test-net-fee-keys = []
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
 
 [[bin]]
 name = "mobilecoind"

--- a/mobilecoind/api/Cargo.toml
+++ b/mobilecoind/api/Cargo.toml
@@ -6,6 +6,15 @@ build = "build.rs"
 edition = "2018"
 links = "mc-mobilecoind-api"
 
+[features]
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
+
 [dependencies]
 mc-api = { path = "../../api" }
 mc-common = { path = "../../common", features = ["log"] }

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -6,6 +6,13 @@ edition = "2018"
 
 [features]
 test_utils = []
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
 
 [dependencies]
 mc-attest-api = { path = "../attest/api" }

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -13,7 +13,7 @@ mc-consensus-scp = { path = "../../consensus/scp" }
 mc-crypto-keys = { path = "../../crypto/keys" }
 mc-ledger-db = { path = "../../ledger/db", features = ["test_utils"] }
 mc-peers = { path = "../../peers" }
-mc-transaction-core = { path = "../../transaction/core" }
+mc-transaction-core = { path = "../../transaction/core", features = ["test-net-fee-keys"] }
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-uri = { path = "../../util/uri" }
 

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -5,8 +5,6 @@ authors = ["MobileCoin"]
 edition = "2018"
 
 [features]
-default = ["test-net-fee-keys"]
-
 # Specifies whether to use test net or main net fee output keys
 main-net-fee-keys = []
 test-net-fee-keys = []

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -13,6 +13,6 @@ mc-account-keys = { path = "../../../account-keys" }
 mc-crypto-keys = { path = "../../../crypto/keys", default-features = false }
 mc-crypto-rand = { path = "../../../crypto/rand" }
 mc-ledger-db = { path = "../../../ledger/db" }
-mc-transaction-core = { path = "../../../transaction/core" }
-mc-transaction-std = { path = "../../../transaction/std" }
+mc-transaction-core = { path = "../../../transaction/core", features = [ "test-net-fee-keys" ] }
+mc-transaction-std = { path = "../../../transaction/std", features = [ "test-net-fee-keys" ] }
 mc-util-from-random = { path = "../../../util/from-random" }

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -4,6 +4,15 @@ version = "1.0.0"
 authors = ["MobileCoin"]
 edition = "2018"
 
+[features]
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
+
 [dependencies]
 # External dependencies
 failure = "0.1.5"

--- a/util/generate-sample-ledger/Cargo.toml
+++ b/util/generate-sample-ledger/Cargo.toml
@@ -8,6 +8,15 @@ edition = "2018"
 name = "generate-sample-ledger"
 path = "src/bin/generate_sample_ledger.rs"
 
+[features]
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
+
 [dependencies]
 mc-account-keys = { path = "../../account-keys" }
 mc-crypto-keys = { path = "../../crypto/keys" }

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -8,6 +8,15 @@ edition = "2018"
 name = "watcher"
 path = "src/bin/main.rs"
 
+[features]
+# Specifies whether to use test net or main net fee output keys
+main-net-fee-keys = [
+    "mc-transaction-core/main-net-fee-keys"
+]
+test-net-fee-keys = [
+    "mc-transaction-core/test-net-fee-keys"
+]
+
 [dependencies]
 mc-api = { path = "../api" }
 mc-common = { path = "../common", features = ["log"] }


### PR DESCRIPTION
### Motivation

The fee key feature needs to be plumbed for every crate that depends on transaction core.

### In this PR
* Removes default setting to test-net-fee-key
* Enforce feature toggle for every crate that depends on transaction-core
