### PR TITLE
Ensure origin block contains at least 16 txos

### DIFF
--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -38,6 +38,8 @@ pub fn bootstrap_ledger(
     let mut db = LedgerDB::open(path.clone()).expect("Could not open ledger_db");
 
     let num_outputs: u64 = (recipients.len() * outputs_per_recipient_per_block * num_blocks) as u64;
+    assert!(num_outputs >= 16);
+
     let picomob_per_output: u64 = (TOTAL_MOB / num_outputs) * 1_000_000_000_000;
 
     println!("recipients: {}", recipients.len());


### PR DESCRIPTION
### Motivation

The origin block should not be created with fewer than 16 outputs. Technically 14 and 15 would work, but don't divide evenly into 250M MOB, so there would be fractional MOBs in the origin block. 

(250_000_000*1_000_000_000_000)/18_446_744_073_709_551_615 = 13.55

### In this PR
* Adds an assert, which enforces a comment in the docstring that it should panic if < 16 txs.
