### PR TITLE
Remove unnecessary mutex around ByzantineLedger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,6 +2534,7 @@ dependencies = [
  "mc-util-serial",
  "mc-util-uri",
  "mockall",
+ "once_cell",
  "prost",
  "protobuf",
  "rand 0.7.3",
@@ -3919,9 +3920,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "once_cell"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
+checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
 name = "oorandom"

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -54,6 +54,7 @@ futures = "0.3"
 grpcio = "0.6.0"
 hex = "0.4"
 lazy_static = "1.4"
+once_cell = "1.4"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 protobuf = "2.12"
 rand = "0.7"


### PR DESCRIPTION
The ByzantineLedger API is thread-safe, but a mutex was being used
in order to resolve a circular dependency issue.

The three major components of consensus service:
- `consensus_msgs_from_network` (background work queue taking messages)
- `broadcaster` (sends messages to our peers)
- `byzantine ledger` (processes messages and oversees SCP progress)

have needs to send messages in both directions, and so require handles
to eachother. That is, the two parts that are sending messages, sometimes
need to ask `byzantine ledger` about the state, but also, ByzantineLedger
needs to be able to push messages to the broadcaster etc.

Even though there are circular dependencies, one of them has to be
initialized last. Currently that is `ByzantineLedger`.
This means that the handles passed to those that
are initialized earlier can't be `Arc<ByzantineLedger>`, there has to
be some kind of additional wrapper between `Arc` and `ByzantineLedger`
that will allow us to initialize the `ByzantineLedger` after passing
the proxy to the components that are initialized earlier.

Before this commit, that wrapper was `Mutex`. But this serializes all
interactions with the ByzantineLedger, even those that would be thread-safe.

Since the only reason mutability is needed is to permit later initialization
of the ledger, this commit changes it to be `Arc<OnceCell<ByzantineLedger>>`.
`OnceCell` is a thread-safe shared-value which can be initialized exactly once.
It is similar to the guard around a `lazy_static` variable, and has essentially
no overhead.
This avoids all the contention problems of the Mutex.

This also changes most of the handles from `Arc` to `Weak`. By making
them `Weak` we avoid strong reference cycles which could prevent us
from releasing resources.

---

This is one of several PRs which may come as a result of MCC-1722
We should likely investigate doing this same thing with `ThreadedBroadcaster` and `PeerKeepalive` etc. once we have validated this change