### PR TITLE
Remove more unnecessary mutex (based on #441)

### DIFF
--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -101,8 +101,9 @@ pub struct ConsensusService<
 
     peer_manager: ConnectionManager<PeerConnection<E>>,
     // This mutex is required because ThreadedBroadcaster API cannot be used concurrently,
-    // the LRU cache is not thread-safe among othter reasons.
-    // But there is only one ByzantineLedger worker thread anyways, so this should be uncontended.
+    // the LRU cache requires exclusive access, among other reasons.
+    // The contention for this is (at time of writing), (one) ByzantineLedger worker thread,
+    // and the client and peer api services, via the ProposeTxCallback
     broadcaster: Arc<Mutex<ThreadedBroadcaster>>,
     tx_manager: Arc<TXM>,
     // Option is only here because we need a way to drop the PeerKeepalive without mutex,


### PR DESCRIPTION
    Remove unnecessary mutex around peer_keepalive
    
    This follows up on the commit that removes the mutex around
    byzantine ledger. The peer_keepalive mutex is only there to allow
    stopping the service. We change this from `Arc<Mutex<PeerKeepalive>`
    to `Option<Arc<PeerKeepalive>>`, and replace to call to `lock().stop()`
    in the stop function with `= None` which simply drops the value.
    
    We also make the other Arc's that are holding this, in lambda functions,
    into weak references. This prevents strong reference cycles which would
    prevent the drop from happening and cause a resource leak.
    
    We also put a code comment about why not to remove the mutex around
    threaded broadcaster.