### PR TITLE
Moves ScpNode trait into separate file.

### DIFF
--- a/consensus/scp/src/node/mod.rs
+++ b/consensus/scp/src/node/mod.rs
@@ -5,5 +5,5 @@
 mod node_impl;
 mod node_trait;
 
-pub use node_impl::*;
-pub use node_trait::*;
+pub use node_impl::Node;
+pub use node_trait::ScpNode;

--- a/consensus/scp/src/node/mod.rs
+++ b/consensus/scp/src/node/mod.rs
@@ -7,3 +7,6 @@ mod node_trait;
 
 pub use node_impl::Node;
 pub use node_trait::ScpNode;
+
+#[cfg(test)]
+pub use node_trait::MockScpNode;

--- a/consensus/scp/src/node/mod.rs
+++ b/consensus/scp/src/node/mod.rs
@@ -1,0 +1,9 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! A node of the consensus network.
+
+mod node_impl;
+mod node_trait;
+
+pub use node_impl::*;
+pub use node_trait::*;

--- a/consensus/scp/src/node/node_impl.rs
+++ b/consensus/scp/src/node/node_impl.rs
@@ -12,7 +12,6 @@ use mc_common::{
     logger::{log, Logger},
     NodeID,
 };
-
 use std::{
     collections::{BTreeSet, HashMap},
     fmt::Display,

--- a/consensus/scp/src/node/node_impl.rs
+++ b/consensus/scp/src/node/node_impl.rs
@@ -6,13 +6,13 @@ use crate::{
     msg::{ExternalizePayload, Msg, Topic},
     quorum_set::QuorumSet,
     slot::{ScpSlot, Slot, SlotMetrics},
+    ScpNode,
 };
 use mc_common::{
     logger::{log, Logger},
     NodeID,
 };
-#[cfg(test)]
-use mockall::*;
+
 use std::{
     collections::{BTreeSet, HashMap},
     fmt::Display,
@@ -144,49 +144,6 @@ impl<V: Value, ValidationError: Clone + Display + 'static> Node<V, ValidationErr
             .find(|slot| slot.get_index() == slot_index)
             .map(|slot| slot.as_ref())
     }
-}
-
-/// A node capable of participating in SCP.
-#[cfg_attr(test, automock)]
-pub trait ScpNode<V: Value>: Send {
-    /// Get local node ID.
-    fn node_id(&self) -> NodeID;
-
-    /// Get local node quorum set.
-    fn quorum_set(&self) -> QuorumSet;
-
-    /// Propose values for this node to nominate.
-    fn propose_values(&mut self, values: BTreeSet<V>) -> Result<Option<Msg<V>>, String>;
-
-    /// Handle incoming message from the network.
-    fn handle_message(&mut self, msg: &Msg<V>) -> Result<Option<Msg<V>>, String>;
-
-    /// Handle incoming messages from the network.
-    fn handle_messages(&mut self, msgs: Vec<Msg<V>>) -> Result<Vec<Msg<V>>, String>;
-
-    /// Maximum number of stored externalized slots.
-    fn max_externalized_slots(&self) -> usize;
-
-    /// Set the maximum number of stored externalized slots. Must be non-zero.
-    fn set_max_externalized_slots(&mut self, n: usize);
-
-    /// Get externalized values (or an empty vector) for a given slot index.
-    fn get_externalized_values(&self, slot_index: SlotIndex) -> Option<Vec<V>>;
-
-    /// Process pending timeouts.
-    fn process_timeouts(&mut self) -> Vec<Msg<V>>;
-
-    /// Get the current slot's index.
-    fn current_slot_index(&self) -> SlotIndex;
-
-    /// Get metrics for the current slot.
-    fn get_current_slot_metrics(&mut self) -> SlotMetrics;
-
-    /// Additional debug info, e.g. a JSON representation of the Slot's state.
-    fn get_slot_debug_snapshot(&mut self, slot_index: SlotIndex) -> Option<String>;
-
-    /// Set the node's current slot index, abandoning any current and externalized slots.
-    fn reset_slot_index(&mut self, slot_index: SlotIndex);
 }
 
 impl<V: Value, ValidationError: Clone + Display + 'static> ScpNode<V> for Node<V, ValidationError> {

--- a/consensus/scp/src/node/node_trait.rs
+++ b/consensus/scp/src/node/node_trait.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+use crate::{slot::SlotMetrics, Msg, QuorumSet, SlotIndex, Value};
+use mc_common::NodeID;
+#[cfg(test)]
+use mockall::*;
+use std::collections::BTreeSet;
+
+/// A node capable of participating in SCP.
+#[cfg_attr(test, automock)]
+pub trait ScpNode<V: Value>: Send {
+    /// Get local node ID.
+    fn node_id(&self) -> NodeID;
+
+    /// Get local node quorum set.
+    fn quorum_set(&self) -> QuorumSet;
+
+    /// Propose values for this node to nominate.
+    fn propose_values(&mut self, values: BTreeSet<V>) -> Result<Option<Msg<V>>, String>;
+
+    /// Handle incoming message from the network.
+    fn handle_message(&mut self, msg: &Msg<V>) -> Result<Option<Msg<V>>, String>;
+
+    /// Handle incoming messages from the network.
+    fn handle_messages(&mut self, msgs: Vec<Msg<V>>) -> Result<Vec<Msg<V>>, String>;
+
+    /// Maximum number of stored externalized slots.
+    fn max_externalized_slots(&self) -> usize;
+
+    /// Set the maximum number of stored externalized slots. Must be non-zero.
+    fn set_max_externalized_slots(&mut self, n: usize);
+
+    /// Get externalized values (or an empty vector) for a given slot index.
+    fn get_externalized_values(&self, slot_index: SlotIndex) -> Option<Vec<V>>;
+
+    /// Process pending timeouts.
+    fn process_timeouts(&mut self) -> Vec<Msg<V>>;
+
+    /// Get the current slot's index.
+    fn current_slot_index(&self) -> SlotIndex;
+
+    /// Get metrics for the current slot.
+    fn get_current_slot_metrics(&mut self) -> SlotMetrics;
+
+    /// Additional debug info, e.g. a JSON representation of the Slot's state.
+    fn get_slot_debug_snapshot(&mut self, slot_index: SlotIndex) -> Option<String>;
+
+    /// Set the node's current slot index, abandoning any current and externalized slots.
+    fn reset_slot_index(&mut self, slot_index: SlotIndex);
+}


### PR DESCRIPTION
### Motivation

I often find that I want to quickly get to the ScpNode trait, which is 150 lines down into node.rs, or I want to hop back and forth between the Node implementation and its unit tests, in which case the ScpNode trait is just 50 lines of clutter.

### In this PR
- Moves the ScpNode trait into a separate file. It may just be personal preference, but I feel like this is more pleasant to navigate. 