### PR TITLE
Don't tear-down and copy the entire Tx cache

### DIFF
--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -556,8 +556,6 @@ impl<
                 self.tx_manager.remove_expired(index)
             };
 
-            counters::TX_CACHE_NUM_ENTRIES.set(self.tx_manager.num_entries() as i64);
-
             // Drop pending values that are no longer considered valid.
             let tx_manager = self.tx_manager.clone();
             self.pending_values.retain(|tx_hash| {

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -74,7 +74,7 @@ pub struct ByzantineLedgerWorker<
     // 1) Efficiently see if we already have a given value and ignore duplicates
     // 2) Track how long each value took to externalize.
     // To accomplish both of this goals we store, in addition to the queue of pending values, a
-    // BTreeMap that maps a value to when we first encountered it. Note that we only store a
+    // map that maps a value to when we first encountered it. Note that we only store a
     // timestamp for values that were handed to us directly from a client. We skip tracking
     // processing times for relayed values since we want to track the time from when the network
     // first saw a value, and not when a specific node saw it.

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -30,7 +30,7 @@ use mc_util_metered_channel::Receiver;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::{
     cmp::min,
-    collections::{btree_map::Entry::Vacant, BTreeMap, BTreeSet, HashMap},
+    collections::{hash_map::Entry::Vacant, BTreeSet, HashMap},
     iter::FromIterator,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -79,7 +79,7 @@ pub struct ByzantineLedgerWorker<
     // processing times for relayed values since we want to track the time from when the network
     // first saw a value, and not when a specific node saw it.
     pending_values: Vec<TxHash>,
-    pending_values_map: BTreeMap<TxHash, Option<Instant>>,
+    pending_values_map: HashMap<TxHash, Option<Instant>>,
 
     // Do we need to nominate anything?
     need_nominate: bool,
@@ -152,7 +152,7 @@ impl<
             prev_block_id,
             pending_consensus_msgs: Default::default(),
             pending_values: Vec::new(),
-            pending_values_map: BTreeMap::default(),
+            pending_values_map: Default::default(),
             need_nominate: false,
             network_state,
             ledger_sync_service,
@@ -291,15 +291,14 @@ impl<
 
                 // Clear any pending values that might no longer be valid.
                 let tx_manager = self.tx_manager.clone();
+                self.pending_values_map
+                    .retain(|tx_hash, _| tx_manager.validate(tx_hash).is_ok());
+                // help the borrow checker
+                let self_pending_values_map = &self.pending_values_map;
                 self.pending_values
-                    .retain(|tx_hash| tx_manager.validate(tx_hash).is_ok());
+                    .retain(|tx_hash| self_pending_values_map.contains_key(tx_hash));
 
-                // Re-construct the BTreeMap with the remaining values, using the old timestamps.
-                let mut new_pending_values_map = BTreeMap::new();
-                for val in self.pending_values.iter() {
-                    new_pending_values_map.insert(*val, *self.pending_values_map.get(val).unwrap());
-                }
-                self.pending_values_map = new_pending_values_map;
+                debug_assert!(self.pending_values_map.len() == self.pending_values.len());
 
                 // Nominate if needed.
                 if !self.pending_values.is_empty() {
@@ -558,16 +557,15 @@ impl<
 
             // Drop pending values that are no longer considered valid.
             let tx_manager = self.tx_manager.clone();
-            self.pending_values.retain(|tx_hash| {
+            self.pending_values_map.retain(|tx_hash, _| {
                 !purged_hashes.contains(tx_hash) && tx_manager.validate(tx_hash).is_ok()
             });
+            // help the borrow checker
+            let self_pending_values_map = &self.pending_values_map;
+            self.pending_values
+                .retain(|tx_hash| self_pending_values_map.contains_key(tx_hash));
 
-            // Re-construct the BTreeMap with the remaining values, using the old timestamps.
-            let mut new_pending_values_map = BTreeMap::new();
-            for val in self.pending_values.iter() {
-                new_pending_values_map.insert(*val, *self.pending_values_map.get(val).unwrap());
-            }
-            self.pending_values_map = new_pending_values_map;
+            debug_assert!(self.pending_values_map.len() == self.pending_values.len());
 
             log::info!(
                 self.logger,


### PR DESCRIPTION
One of the main jobs of the TxManager is to keep track of what
transcations have been validated or partially validated by the enclave,
and keep a cache mapping their hashes to the data that untrusted
has about them.

Any part of the system that needs to know something about a particular
Tx, or add new Tx's, or purge old Tx's, or form blocks, needs to talk
to this cache object. So ideally, this cache object would be like a
thread-safe map, similar to Java's concurrent hashmap, so that we
don't bottleneck essentially all the threads in the server on this.

We haven't gotten to the point of using a concurrent hashmap for this,
in part because there are several implementations of varying quality
and choosing one is not straightforward.

We also don't have infrastructure for measuring contention of these
various locks, so we don't know that it's worth it. Right now we don't
have a good way to measure perf improvements at all,
other than just slamming the network. Usually you should find or build
such tools to measure contention at individual locks before making
changes that might or might not actually improve perfs.

Before we get to that point, there are simple things we can do to
that are obvious, strict perf improvements that don't require
detailed measurement to validate. These changes will also help make sure that
nothing holds the lock for an unnecessarily long amount of time.

IMO before we start to do measurements of contention on individual
locks we should do a once-over making changes like this.

----

In this particular commit, we change the `remove_expired` function,
which previously was tearing down the entire `cache` and separating
it into two hashmaps. Then all the entries in the expired section
get copied again, and the old `self.cache` variable gets overwritten
with the new value.

This is bad for a few reasons:
- It copies everything in the cache unnecessarily.
  The size of a mobilecoin transaction with 11 ring inputs is at least
  10-20k ballpark, just considering the size of merkle proofs.
  If you want to do 50 transactions per second, that's 250 transactions
  per block. If the tombstone block setting is like 10 or 20 blocks into
  the future, that's several thousand transactions.
  So copying the entire tx cache is like, ballpark, copying 100 megabytes at
  least, and ten times this if the tombstone block value is like 100 blocks
  into the future.
  And we are doing this every time we call `remove_expired`, which is
  every block.
  Arguably, a better way to do this is to use a priority queue based
  on the tombstone block, so then we don't have to scan the entire cache
  once per block. But that is a larger change that we can do later.
- Tearing down the cache means that we don't get to reuse the dynamic
  memory allocation for it, so we have to reallocate 100's of megabytes
  every time instead.
- Because the cache object is moving around randomly in memory every
  time we finish a block, the memory hierarchy cannot hope to properly
  cache it, so every thread is likely to experience cache misses
  whenever they try to talk to it. By trying to keep it in one place,
  we can avoid thrashing the caches.

This also removes a duplicate write to a prometheus counter