### PR TITLE
Removes TxManagerError::AlreadyInCache error variant [MCC-1707]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,6 +2485,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "curve25519-dalek",
+ "displaydoc",
  "failure",
  "fs_extra",
  "futures 0.3.5",

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -39,6 +39,7 @@ mc-util-uri = { path = "../../util/uri" }
 base64 = "0.11"
 cfg-if = "0.1"
 chrono = "0.4"
+displaydoc = { version = "0.1.7", default-features = false }
 failure = "0.1.5"
 fs_extra = "1.1"
 futures = "0.3"

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -6,7 +6,7 @@ use crate::{
         MAX_PENDING_VALUES_TO_NOMINATE,
     },
     counters,
-    tx_manager::{TxManager, TxManagerError},
+    tx_manager::TxManager,
 };
 use mc_common::{
     logger::{log, Logger},
@@ -665,7 +665,7 @@ impl<
                         (self.tx_manager.clone(), self.logger.clone()),
                         move |(tx_manager, logger), tx_context| match tx_manager.insert(tx_context)
                         {
-                            Ok(_) | Err(TxManagerError::AlreadyInCache) => {}
+                            Ok(_) => {}
                             Err(err) => {
                                 log::crit!(
                                     logger,

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -125,8 +125,6 @@ impl<E: ConsensusEnclave, L: Ledger, TXM: TxManager + Clone> PeerApiService<E, L
                     );
                 }
 
-                Err(TxManagerError::AlreadyInCache) => {}
-
                 Err(TxManagerError::TransactionValidation(err)) => {
                     log::debug!(
                         logger,

--- a/consensus/service/src/tx_manager/error.rs
+++ b/consensus/service/src/tx_manager/error.rs
@@ -13,9 +13,6 @@ pub enum TxManagerError {
     #[fail(display = "Transaction validation error: {}", _0)]
     TransactionValidation(TransactionValidationError),
 
-    #[fail(display = "Tx already in cache")]
-    AlreadyInCache,
-
     #[fail(display = "Tx(s) not in cache ({:?})", _0)]
     NotInCache(Vec<TxHash>),
 

--- a/consensus/service/src/tx_manager/error.rs
+++ b/consensus/service/src/tx_manager/error.rs
@@ -1,22 +1,22 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
-use failure::Fail;
+use displaydoc::Display;
 use mc_consensus_enclave::Error as ConsensusEnclaveError;
 use mc_ledger_db::Error as LedgerDbError;
 use mc_transaction_core::{tx::TxHash, validation::TransactionValidationError};
 
-#[derive(Clone, Debug, Fail)]
+#[derive(Clone, Debug, Display)]
 pub enum TxManagerError {
-    #[fail(display = "Enclave error: {}", _0)]
+    /// Enclave error: {0}
     Enclave(ConsensusEnclaveError),
 
-    #[fail(display = "Transaction validation error: {}", _0)]
+    /// Transaction validation error: {0}
     TransactionValidation(TransactionValidationError),
 
-    #[fail(display = "Tx(s) not in cache ({:?})", _0)]
+    /// Tx(s) not in cache {0:?}
     NotInCache(Vec<TxHash>),
 
-    #[fail(display = "Ledger error: {}", _0)]
+    /// Ledger error: {0}
     LedgerDb(LedgerDbError),
 }
 


### PR DESCRIPTION
### Motivation

Seems like we don't consider re-inserting into the cache to be an error, so we generally end up ignoring this error variant.

### In this PR
* Removes the AlreadyInCache error variant.
* Switches TxManagerError from `failure` to `displaydoc`
