### PR TITLE
[MCC-1791] Resolve Homebrew issues in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ executors:
 
   macos:
     macos:
-      xcode: 11.6.0
+      xcode: 11.7.0
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "1"
       HOMEBREW_NO_INSTALL_CLEANUP: "1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,12 @@ defaults:
   default-environment: &default-environment
     IAS_MODE: DEV
     SGX_MODE: SW
-    RUST_BACKTRACE: 1
-    SKIP_SLOW_TESTS: 1
-    CARGO_INCREMENTAL: 0
+    RUST_BACKTRACE: "1"
+    SKIP_SLOW_TESTS: "1"
+    CARGO_INCREMENTAL: "0"
 
     # sccache config
-    SCCACHE_IDLE_TIMEOUT: 1200
+    SCCACHE_IDLE_TIMEOUT: "1200"
     SCCACHE_CACHE_SIZE: 1G
     SCCACHE_ERROR_LOG: /tmp/sccache.log
 
@@ -39,9 +39,9 @@ executors:
     macos:
       xcode: 11.6.0
     environment:
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      HOMEBREW_NO_INSTALL_CLEANUP: 1
-      HOMEBREW_BUNDLE_NO_LOCK: 1
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
+      HOMEBREW_BUNDLE_NO_LOCK: "1"
 
 commands:
   print_versions:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,15 +180,19 @@ commands:
       - restore_cache:
           name: Restore Homebrew cache
           key: v0-homebrew-{{ arch }}
+      - when:
+          condition: { equal: [ << pipeline.git.branch >>, master ] }
+          steps:
+            - run:
+                name: Update Homebrew
+                command: |
+                  brew --version
+                  brew update --preinstall
       - run:
           name: Install Homebrew dependencies
-          # Update Homebrew before running `brew bundle` to fix a bug in the
-          # version of Homebrew that comes preinstalled on CircleCI's macOS
-          # image. Once the CircleCI macOS image comes preinstalled with the
-          # updated version, then we should be able to remove `brew update`
-          # from this step.
-          # See: https://github.com/Homebrew/homebrew-bundle/issues/751
-          command: brew update --preinstall && brew bundle --no-upgrade
+          command: |
+            brew --version
+            brew bundle --no-upgrade
 
   save-homebrew-cache:
     steps:


### PR DESCRIPTION
### Motivation

PR https://github.com/mobilecoinofficial/mobilecoin/pull/326 added `brew update` to all CI builds to resolve an issue with using an old version of Homebrew on CircleCI. Running `brew update` solved the issue by updating Homebrew before using it to install any dependencies. This added ~33s to each CI run.

This PR assumes that CircleCI is using a newer version of Homebrew by now. As such, this PR removes the call to `brew update` for all CI runs, and instead only runs it when building on master, which is done to ensure that the lastest versions of dependencies are saved to the cache (which is saved as part of the CI run on master).

This PR also fixes a minor yaml schema issue where parameters that are meant to be strings are considered by yaml to be integers because they are parsable as such. This issue should be harmless but is fixed regardless.

### In this PR
* Updates CircleCI's macOS executor image to Xcode 11.7.0
* Only run `brew update` during CI setup on master
* Quote integers that are meant to be strings in CircleCI config

Fixes [MCC-1791]

[MCC-1791]: https://mobilecoin.atlassian.net/browse/MCC-1791