### PR TITLE
Integration test for mobilecoind / json gateway / mirror

### DIFF
--- a/tools/release-tests/mirror-json-test.py
+++ b/tools/release-tests/mirror-json-test.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+
+# This is an integration test that downloads the latest releases and attempts to run mobilecoind,
+# the mirror services and the JSON gateway in the exact manner that a user might run them, using the 
+# provided shell scripts and compiled binaries.
+
+import argparse
+import os
+from signal import default_int_handler
+import requests
+import signal
+import subprocess
+import sys
+import tarfile
+import time
+
+parser = argparse.ArgumentParser(description='Download and test mobilecoind / mirror and json gateway')
+parser.add_argument('entropy', metavar='e', type=str, help='Root entropy of account for testing')
+parser.add_argument('--url', metavar='u', type=str, help='URL of release tarball', default='https://github.com/mobilecoinofficial/mobilecoin/releases/latest/download/mobilecoind-mirror-tls.tar.gz')
+args = parser.parse_args()
+
+target_path = 'mobilecoind-mirror-tls.tar.gz'
+
+# Cleanup any previous runs
+subprocess.run("rm -r /tmp/mobilecoin", shell=True)
+subprocess.run("pkill -f mobilecoind", shell=True)
+
+os.chdir('/tmp')
+
+# Download the release
+response = requests.get(args.url, stream=True)
+if response.status_code == 200:
+    with open(target_path, 'wb') as f:
+        f.write(response.raw.read())
+else:
+    print("Failed to download latest tarball")
+    sys.exit(1)
+
+# Extract it
+tar = tarfile.open(target_path)
+tar.extractall()
+tar.close()
+
+os.chdir('/tmp/mobilecoind-mirror')
+
+# Launch both sides of the mirror and the mobilecoind test
+public_process = subprocess.Popen("./mobilecoind-mirror-public.sh", shell=True, preexec_fn=os.setsid)
+private_process = subprocess.Popen("echo %s |./mobilecoind-mirror-private.sh localhost:10080" % (args.entropy), shell=True, preexec_fn=os.setsid)
+json_process = subprocess.Popen("bin/mobilecoind-json", shell=True, preexec_fn=os.setsid)
+
+def shutdown(exit_code):
+    # Shut down all the process groups
+    os.killpg(os.getpgid(public_process.pid), signal.SIGTERM)
+    os.killpg(os.getpgid(private_process.pid), signal.SIGTERM)
+    os.killpg(os.getpgid(json_process.pid), signal.SIGTERM)
+    sys.exit(exit_code)
+
+# Give everything a chance to start up
+print("Waiting for startup of all services")
+time.sleep(10)
+
+# Check the block API
+print("Testing mirror block API")
+response = requests.get("http://localhost:8001/block/0")
+if response.status_code == 200:
+    data = response.json()
+    if data['index'] != '0': 
+        print("Block API returned invalid data")
+        shutdown(1)
+    print("Block API call succeeded")
+else:
+    print("Block API returned status code %d" % response.status_code)
+    shutdown(1)
+
+# Get ledger status, poll until caught up
+last_block = 0
+print("Downloading ledger blocks")
+while True:
+    response = requests.get("http://localhost:9090/ledger/local")
+    if response.status_code == 200:
+        block_count = int(response.json()['block_count'])
+        print("Blocks downloaded = %d" % block_count)
+        if block_count == last_block: break
+        last_block = block_count
+        time.sleep(5)
+    else:
+        print("Ledger local endpoint returned status code %d" % response.status_code)
+        shutdown(1)
+
+# Get the account key for the provided entropy
+response = requests.get("http://localhost:9090/entropy/%s" % args.entropy)
+if response.status_code == 200:
+    account_key = response.json()
+    print("Account key = %s" % str(account_key))
+else:
+    print("Account key endpoint returned status code %d" % response.status_code)
+    shutdown(1)
+
+# Get the monitor for the account
+monitor_data = {"account_key": account_key, "first_subaddress": 0, "num_subaddresses": 1000}
+response = requests.post("http://localhost:9090/monitors", json=monitor_data)
+if response.status_code == 200:
+    monitor_id = response.json()['monitor_id']
+    print("Monitor id = %s" % monitor_id)
+else:
+    print("Monitor endpoint returned status code %d" % response.status_code)
+    shutdown(1)
+
+# Get the public address for the monitor and subaddress
+response = requests.get("http://localhost:9090/monitors/%s/subaddresses/0/public-address" % monitor_id)
+if response.status_code == 200:
+    public_address = response.json()
+    print("Public address = %s" % str(public_address))
+else:
+    print("Public address endpoint returned status code %d" % response.status_code)
+    shutdown(1)
+
+# Generate a request code for the account
+# TODO: I believe the code has been updated with "receiver" rather than public address
+request_data = {"public_address": public_address, "amount": 1, "memo": "Please pay me"}
+response = requests.post("http://localhost:9090/codes/request", json=request_data)
+if response.status_code == 200:
+    request_code = response.json()['request_code']
+    print("Request code = %s" % str(request_code))
+else:
+    print("Request code endpoint returned status code %d" % response.status_code)
+    shutdown(1)
+
+# Loop until monitor is synced
+while True:
+    response = requests.get("http://localhost:9090/monitors/%s" % monitor_id)
+    if response.status_code == 200:
+        next_block = int(response.json()['next_block'])
+        print("Monitor next block = %d" % next_block)
+    else:
+        print("Monitor status returned status code %d" % response.status_code)
+        shutdown(1)
+    if next_block >= block_count: break
+    time.sleep(1)
+
+time.sleep(2)
+
+# Do a balance check
+url = "http://localhost:9090/monitors/%s/subaddresses/0/balance" % monitor_id
+response = requests.get(url)
+if response.status_code == 200:
+    balance = int(response.json()['balance'])
+    print("balance = %d" % balance)
+else:
+    print("Ledger local endpoint returned status code %d" % response.status_code)
+    shutdown(1)
+
+# Testing transfers requires the account to have a positive balance
+if balance == 0:
+    print("Cannot continue testing with a non-funded account")
+    shutdown(1)
+
+# Initiate a transfer, to the same account
+url = "http://localhost:9090/monitors/%s/subaddresses/0/build-and-submit" % monitor_id
+# TODO: Again this reveals an API mismatch between request code generation and payment generation
+payment_data = {"receiver": public_address, "value": "1", "memo": "Please pay me"}
+response = requests.post(url, json=payment_data)
+if response.status_code == 200:
+    receipts = response.json()
+    receiver_tx_receipt = response.json()['receiver_tx_receipt_list'][0]
+else:
+    print("build-tx-and-submit returned status code %d" % response.status_code)
+    shutdown(1)
+
+print("Polling for transaction status")
+while True:
+    response = requests.post("http://localhost:9090/tx/status-as-sender", json=receipts)
+    if response.status_code == 200:
+        status = response.json()['status']
+        print('status = %s' % status)
+        if status == 'verified': break
+        time.sleep(1)
+    else:
+        print("status-as-sender returned status code %d" % response.status_code)
+        shutdown(1)
+
+print("All tests succeeded!")
+shutdown(0)

--- a/tools/release-tests/mirror-json-test.py
+++ b/tools/release-tests/mirror-json-test.py
@@ -115,11 +115,11 @@ else:
     shutdown(1)
 
 # Generate a request code for the account
-# TODO: I believe the code has been updated with "receiver" rather than public address
-request_data = {"public_address": public_address, "amount": 1, "memo": "Please pay me"}
+# TODO: This call takes an integer for value, while the payment request takes a string
+request_data = {"receiver": public_address, "value": 1, "memo": "Please pay me"}
 response = requests.post("http://localhost:9090/codes/request", json=request_data)
 if response.status_code == 200:
-    request_code = response.json()['request_code']
+    request_code = response.json()['b58_code']
     print("Request code = %s" % str(request_code))
 else:
     print("Request code endpoint returned status code %d" % response.status_code)
@@ -156,14 +156,13 @@ if balance == 0:
 
 # Initiate a transfer, to the same account
 url = "http://localhost:9090/monitors/%s/subaddresses/0/build-and-submit" % monitor_id
-# TODO: Again this reveals an API mismatch between request code generation and payment generation
-payment_data = {"receiver": public_address, "value": "1", "memo": "Please pay me"}
+payment_data = {"request_code": {"receiver": public_address, "value": "1", "memo": "Please pay me"}}
 response = requests.post(url, json=payment_data)
 if response.status_code == 200:
     receipts = response.json()
     receiver_tx_receipt = response.json()['receiver_tx_receipt_list'][0]
 else:
-    print("build-tx-and-submit returned status code %d" % response.status_code)
+    print("build-and-submit returned status code %d" % response.status_code)
     shutdown(1)
 
 print("Polling for transaction status")

--- a/tools/release-tests/mirror-json-test.py
+++ b/tools/release-tests/mirror-json-test.py
@@ -6,7 +6,6 @@
 
 import argparse
 import os
-from signal import default_int_handler
 import requests
 import signal
 import subprocess

--- a/tools/release-tests/requirements.txt
+++ b/tools/release-tests/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
### Motivation

We have been checking our binary releases for various client-side components manually. This script automates downloading, extracting and running all the executables and verifies that they works as expected.

### In this PR
* Creates `mirror-test-json.py`
* Downloads specified tarball, defaulting to latest
* Launches mobilecoind, mirror-public, mirror-private and mobilecoind-json
* Runs a series of requests against the REST services to ensure they act as expected

### Future Work
* More tests on mirror service
* Set up to run against fresh builds for CI testing