### PR TITLE
MCC-1756: Add convenience method to mobilecoind/mobilecoind-json for paying an address code 

### DIFF
--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -381,6 +381,13 @@ impl From<&mc_mobilecoind_api::SendPaymentResponse> for JsonSendPaymentResponse 
 }
 
 #[derive(Deserialize, Serialize)]
+pub struct JsonPayAddressCodeRequest {
+    pub receiver_b58_code: String,
+    pub amount: String,
+    pub max_input_utxo_value: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
 pub struct JsonOutlay {
     pub value: String,
     pub receiver: JsonPublicAddress,

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -53,6 +53,7 @@ service MobilecoindAPI {
     // Convenience calls
     rpc GetBalance (GetBalanceRequest) returns (GetBalanceResponse) {}
     rpc SendPayment (SendPaymentRequest) returns (SendPaymentResponse) {}
+    rpc PayAddressCode (PayAddressCodeRequest) returns (SendPaymentResponse) {}
 
     // Network status
     rpc GetNetworkStatus (google.protobuf.Empty) returns (GetNetworkStatusResponse) {}
@@ -622,6 +623,33 @@ message SendPaymentResponse {
     // The TxProposal that was submitted to the network. The fee that was paid can be checked at
     // tx_proposal.tx.prefix.fee
     TxProposal tx_proposal = 3;
+}
+
+// Build and submit a simple payment to an address provided by a b58 address code
+message PayAddressCodeRequest {
+    // Monitor id sending the funds.
+    bytes sender_monitor_id = 1;
+
+    // Subaddress the funds are coming from.
+    uint64 sender_subaddress = 2;
+
+    // Base-58 encoded "MobileCoin Address Code"
+    string receiver_b58_code = 3;
+
+    // Amount to pay
+    uint64 amount = 4;
+
+    // Fee in picoMOB (setting to 0 causes mobilecoind to choose a value).
+    // The value used can be checked (but not changed) in tx_proposal.tx.prefix.fee
+    uint64 fee = 5;
+
+    // Tombstone block (setting to 0 causes mobilecoind to choose a value).
+    // The value used can be checked (but not changed) in tx_proposal.tx.prefix.tombstone_block
+    uint64 tombstone = 6;
+
+    // Optional: When selecting input UTXOs for the transaction, limit selection only to UTXOs whose
+    // value is lower or equal to to this.
+    uint64 max_input_utxo_value = 7;
 }
 
 //


### PR DESCRIPTION
### Motivation

Requested by a user.

### In this PR
* Add a new API call to `mobilecoind` that combines `ReadAddressCode` + `SendPayment`.
* Do the same to `mobilecoind-json`.