### PR TITLE
[MCC-498] Catch-up unit tests

### DIFF
--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -368,7 +368,7 @@ impl<
         };
     }
 
-    /// Clear any pending values that are no longer be valid.
+    /// Clear any pending values that are no longer valid.
     fn update_pending_values(&mut self) {
         let tx_manager = self.tx_manager.clone();
         self.pending_values_map
@@ -1036,13 +1036,14 @@ mod tests {
         // is_behind = true, MaybeBehind -> IsBehind
         // This happens when the grace period has elapsed since entering the MaybeBehind state.
         let behind_since = Instant::now();
+        // IS_BEHIND_GRACE_PERIOD + 1 seconds has elapsed
         let now = behind_since
             .add(IS_BEHIND_GRACE_PERIOD)
             .add(Duration::from_secs(1));
         next_sync_state_helper(
             LedgerSyncState::MaybeBehind(behind_since),
             true,
-            now, // no time has passed
+            now,
             LedgerSyncState::IsBehind {
                 attempt_sync_at: now,
                 num_sync_attempts: 0,
@@ -1375,7 +1376,9 @@ mod tests {
         );
 
         // Create more than MAX_PENDING_VALUES_TO_NOMINATE pending values.
-        let tx_hashes: Vec<_> = (0..200).map(|i| TxHash([i as u8; 32])).collect();
+        let tx_hashes: Vec<_> = (0..MAX_PENDING_VALUES_TO_NOMINATE * 2)
+            .map(|i| TxHash([i as u8; 32]))
+            .collect();
         worker.pending_values = tx_hashes.clone();
         worker.pending_values_map = tx_hashes
             .iter()

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -817,7 +817,9 @@ mod tests {
     /// Create test mocks with sensible defaults.
     ///
     /// # Arguments
-    ///
+    /// * `node_id` - The local node's ID.
+    /// * `quorum_set` - The local node's quorum set.
+    /// * `num_blocks` - Number of blocks in the ledger.
     fn get_mocks(
         node_id: &NodeID,
         quorum_set: &QuorumSet,

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -378,7 +378,7 @@ impl<
         self.pending_values
             .retain(|tx_hash| self_pending_values_map.contains_key(tx_hash));
 
-        debug_assert!(self.pending_values_map.len() == self.pending_values.len());
+        assert_eq!(self.pending_values_map.len(), self.pending_values.len());
     }
 
     // Reads tasks from the task queue.
@@ -424,7 +424,7 @@ impl<
 
     // Propose pending values for nomination in the current slot.
     fn propose_pending_values(&mut self) {
-        debug_assert!(!self.pending_values.is_empty());
+        assert!(!self.pending_values.is_empty());
 
         // Fairness heuristics:
         // * Values are proposed in the order that they were received.
@@ -604,7 +604,7 @@ impl<
         self.pending_values
             .retain(|tx_hash| self_pending_values_map.contains_key(tx_hash));
 
-        debug_assert!(self.pending_values_map.len() == self.pending_values.len());
+        assert_eq!(self.pending_values_map.len(), self.pending_values.len());
 
         log::info!(
             self.logger,

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -217,13 +217,7 @@ impl<
             }
 
             // (7) IsBehind --> InSync
-            (
-                LedgerSyncState::IsBehind {
-                    attempt_sync_at: _,
-                    num_sync_attempts: _,
-                },
-                LedgerSyncState::InSync,
-            ) => {
+            (LedgerSyncState::IsBehind { .. }, LedgerSyncState::InSync) => {
                 self.is_behind.store(false, Ordering::SeqCst);
                 self.current_slot_index = self.ledger.num_blocks().unwrap();
                 log::info!(

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -1125,7 +1125,7 @@ mod tests {
         let connection_manager = get_connection_manager(&node_id, &peers, &logger);
         let (_task_sender, task_receiver) = get_channel();
 
-        // `attempt_ledger_sync` should succeed.
+        // `attempt_ledger_sync` should fail.
         ledger_sync
             .expect_attempt_ledger_sync()
             .return_once(|_, _| Err(LedgerSyncError::NoSafeBlocks)); // This is a hack because LedgerSyncError is not Clone.


### PR DESCRIPTION
### Motivation

ByzantineLedgerWorker's catch-up logic has been hard to test, and generally hasn't been unit tested. 

### In this PR
* Splits the logic into a state transition and the action performed by each state transition.
* Creates a separate function for incrementally syncing the ledger.
* Unit tests for the above two things.
* A couple extra unit tests, thrown in for good measure.

The above should be an improvement in maintainability and testability, but shouldn't actually change much, if any, functionality. Once we have testing in place, changes in functionality should be easier. For example, I'd like to encapsulate more of the ledger sync logic in the LedgerSyncService.