### PR TITLE
Remove erroneous .api from GenerateTxFromTxOutListRequest

### DIFF
--- a/mobilecoind/clients/python/lib/mobilecoin/__init__.py
+++ b/mobilecoind/clients/python/lib/mobilecoin/__init__.py
@@ -223,7 +223,7 @@ class Client(object):
         return response.tx_proposal, response.entropy
 
     def generate_tx_from_tx_out_list(self, account_key, input_list, receiver, fee):
-        request = api.GenerateTxFromTxOutListRequest(
+        request = GenerateTxFromTxOutListRequest(
             account_key=account_key,
             input_list=input_list,
             receiver=receiver,


### PR DESCRIPTION
### Motivation

A merge error for the PyPI package left an incorrect namespace, which this PR fixes

### In this PR
* Remove erroneous .api
