### PR TITLE
mobilecoind API: Get -> Create, Read -> Parse

### DIFF
--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -218,15 +218,15 @@ fn public_address(
 
 /// Generates a request code with an optional value and memo
 #[post("/codes/request", format = "json", data = "<request>")]
-fn get_request_code(
+fn create_request_code(
     state: rocket::State<State>,
-    request: Json<JsonGetRequestCodeRequest>,
-) -> Result<Json<JsonGetRequestCodeResponse>, String> {
+    request: Json<JsonCreateRequestCodeRequest>,
+) -> Result<Json<JsonCreateRequestCodeResponse>, String> {
     let receiver = mc_mobilecoind_api::external::PublicAddress::try_from(&request.receiver)
         .map_err(|err| format!("Failed to parse receiver's public address: {}", err))?;
 
     // Generate b58 code
-    let mut req = mc_mobilecoind_api::GetRequestCodeRequest::new();
+    let mut req = mc_mobilecoind_api::CreateRequestCodeRequest::new();
     req.set_receiver(receiver);
     if let Some(value) = request.value {
         req.set_value(value);
@@ -237,67 +237,67 @@ fn get_request_code(
 
     let resp = state
         .mobilecoind_api_client
-        .get_request_code(&req)
-        .map_err(|err| format!("Failed getting request code: {}", err))?;
+        .create_request_code(&req)
+        .map_err(|err| format!("Failed creating request code: {}", err))?;
 
-    Ok(Json(JsonGetRequestCodeResponse::from(&resp)))
+    Ok(Json(JsonCreateRequestCodeResponse::from(&resp)))
 }
 
 /// Retrieves the data in a request b58_code
 #[get("/codes/request/<b58_code>")]
-fn read_request_code(
+fn parse_request_code(
     state: rocket::State<State>,
     b58_code: String,
-) -> Result<Json<JsonReadRequestCodeResponse>, String> {
-    let mut req = mc_mobilecoind_api::ReadRequestCodeRequest::new();
+) -> Result<Json<JsonParseRequestCodeResponse>, String> {
+    let mut req = mc_mobilecoind_api::ParseRequestCodeRequest::new();
     req.set_b58_code(b58_code);
     let resp = state
         .mobilecoind_api_client
-        .read_request_code(&req)
-        .map_err(|err| format!("Failed reading request code: {}", err))?;
+        .parse_request_code(&req)
+        .map_err(|err| format!("Failed parsing request code: {}", err))?;
 
     // The response contains the public keys encoded in the read request, as well as a memo and
     // requested value. This can be used as-is in the transfer call below, or the value can be
     // modified.
-    Ok(Json(JsonReadRequestCodeResponse::from(&resp)))
+    Ok(Json(JsonParseRequestCodeResponse::from(&resp)))
 }
 
 /// Generates an address code
 #[post("/codes/address", format = "json", data = "<request>")]
-fn get_address_code(
+fn create_address_code(
     state: rocket::State<State>,
-    request: Json<JsonGetAddressCodeRequest>,
-) -> Result<Json<JsonGetAddressCodeResponse>, String> {
+    request: Json<JsonCreateAddressCodeRequest>,
+) -> Result<Json<JsonCreateAddressCodeResponse>, String> {
     let receiver = mc_mobilecoind_api::external::PublicAddress::try_from(&request.receiver)
         .map_err(|err| format!("Failed to parse receiver's public address: {}", err))?;
 
     // Generate b58 code
-    let mut req = mc_mobilecoind_api::GetAddressCodeRequest::new();
+    let mut req = mc_mobilecoind_api::CreateAddressCodeRequest::new();
     req.set_receiver(receiver);
 
     let resp = state
         .mobilecoind_api_client
-        .get_address_code(&req)
-        .map_err(|err| format!("Failed getting address code: {}", err))?;
+        .create_address_code(&req)
+        .map_err(|err| format!("Failed creating address code: {}", err))?;
 
-    Ok(Json(JsonGetAddressCodeResponse::from(&resp)))
+    Ok(Json(JsonCreateAddressCodeResponse::from(&resp)))
 }
 
 /// Retrieves the data in an address b58_code
 #[get("/codes/address/<b58_code>")]
-fn read_address_code(
+fn parse_address_code(
     state: rocket::State<State>,
     b58_code: String,
-) -> Result<Json<JsonReadAddressCodeResponse>, String> {
-    let mut req = mc_mobilecoind_api::ReadAddressCodeRequest::new();
+) -> Result<Json<JsonParseAddressCodeResponse>, String> {
+    let mut req = mc_mobilecoind_api::ParseAddressCodeRequest::new();
     req.set_b58_code(b58_code);
     let resp = state
         .mobilecoind_api_client
-        .read_address_code(&req)
-        .map_err(|err| format!("Failed reading address code: {}", err))?;
+        .parse_address_code(&req)
+        .map_err(|err| format!("Failed parding address code: {}", err))?;
 
     // The response contains the public keys encoded in the read request
-    Ok(Json(JsonReadAddressCodeResponse::from(&resp)))
+    Ok(Json(JsonParseAddressCodeResponse::from(&resp)))
 }
 
 /// Performs a transfer from a monitor and subaddress. The public keys and amount are in the POST data.
@@ -641,10 +641,10 @@ fn main() {
                 balance,
                 utxos,
                 public_address,
-                get_request_code,
-                read_request_code,
-                get_address_code,
-                read_address_code,
+                create_request_code,
+                parse_request_code,
+                create_address_code,
+                parse_address_code,
                 build_and_submit,
                 pay_address_code,
                 generate_request_code_transaction,

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -186,19 +186,19 @@ impl From<&mc_mobilecoind_api::GetUnspentTxOutListResponse> for JsonUtxosRespons
 }
 
 #[derive(Deserialize)]
-pub struct JsonGetRequestCodeRequest {
+pub struct JsonCreateRequestCodeRequest {
     pub receiver: JsonPublicAddress,
     pub value: Option<u64>,
     pub memo: Option<String>,
 }
 
 #[derive(Serialize, Default)]
-pub struct JsonGetRequestCodeResponse {
+pub struct JsonCreateRequestCodeResponse {
     pub b58_code: String,
 }
 
-impl From<&mc_mobilecoind_api::GetRequestCodeResponse> for JsonGetRequestCodeResponse {
-    fn from(src: &mc_mobilecoind_api::GetRequestCodeResponse) -> Self {
+impl From<&mc_mobilecoind_api::CreateRequestCodeResponse> for JsonCreateRequestCodeResponse {
+    fn from(src: &mc_mobilecoind_api::CreateRequestCodeResponse) -> Self {
         Self {
             b58_code: String::from(src.get_b58_code()),
         }
@@ -268,14 +268,14 @@ impl TryFrom<&JsonPublicAddress> for PublicAddress {
 }
 
 #[derive(Deserialize, Serialize, Default)]
-pub struct JsonReadRequestCodeResponse {
+pub struct JsonParseRequestCodeResponse {
     pub receiver: JsonPublicAddress,
     pub value: String,
     pub memo: String,
 }
 
-impl From<&mc_mobilecoind_api::ReadRequestCodeResponse> for JsonReadRequestCodeResponse {
-    fn from(src: &mc_mobilecoind_api::ReadRequestCodeResponse) -> Self {
+impl From<&mc_mobilecoind_api::ParseRequestCodeResponse> for JsonParseRequestCodeResponse {
+    fn from(src: &mc_mobilecoind_api::ParseRequestCodeResponse) -> Self {
         Self {
             receiver: JsonPublicAddress::from(src.get_receiver()),
             value: src.get_value().to_string(),
@@ -285,17 +285,17 @@ impl From<&mc_mobilecoind_api::ReadRequestCodeResponse> for JsonReadRequestCodeR
 }
 
 #[derive(Deserialize)]
-pub struct JsonGetAddressCodeRequest {
+pub struct JsonCreateAddressCodeRequest {
     pub receiver: JsonPublicAddress,
 }
 
 #[derive(Serialize, Default)]
-pub struct JsonGetAddressCodeResponse {
+pub struct JsonCreateAddressCodeResponse {
     pub b58_code: String,
 }
 
-impl From<&mc_mobilecoind_api::GetAddressCodeResponse> for JsonGetAddressCodeResponse {
-    fn from(src: &mc_mobilecoind_api::GetAddressCodeResponse) -> Self {
+impl From<&mc_mobilecoind_api::CreateAddressCodeResponse> for JsonCreateAddressCodeResponse {
+    fn from(src: &mc_mobilecoind_api::CreateAddressCodeResponse) -> Self {
         Self {
             b58_code: String::from(src.get_b58_code()),
         }
@@ -303,12 +303,12 @@ impl From<&mc_mobilecoind_api::GetAddressCodeResponse> for JsonGetAddressCodeRes
 }
 
 #[derive(Deserialize, Serialize, Default)]
-pub struct JsonReadAddressCodeResponse {
+pub struct JsonParseAddressCodeResponse {
     pub receiver: JsonPublicAddress,
 }
 
-impl From<&mc_mobilecoind_api::ReadAddressCodeResponse> for JsonReadAddressCodeResponse {
-    fn from(src: &mc_mobilecoind_api::ReadAddressCodeResponse) -> Self {
+impl From<&mc_mobilecoind_api::ParseAddressCodeResponse> for JsonParseAddressCodeResponse {
+    fn from(src: &mc_mobilecoind_api::ParseAddressCodeResponse) -> Self {
         Self {
             receiver: JsonPublicAddress::from(src.get_receiver()),
         }
@@ -357,7 +357,7 @@ impl From<&mc_mobilecoind_api::ReceiverTxReceipt> for JsonReceiverTxReceipt {
 
 #[derive(Deserialize, Serialize)]
 pub struct JsonSendPaymentRequest {
-    pub request_code: JsonReadRequestCodeResponse,
+    pub request_code: JsonParseRequestCodeResponse,
     pub max_input_utxo_value: Option<String>, // String due to u64 limitation.
 }
 
@@ -901,7 +901,7 @@ impl TryFrom<&JsonTxProposal> for mc_mobilecoind_api::TxProposal {
 #[derive(Deserialize, Serialize)]
 pub struct JsonCreateTxProposalRequest {
     pub input_list: Vec<JsonUnspentTxOut>,
-    pub transfer: JsonReadRequestCodeResponse,
+    pub transfer: JsonParseRequestCodeResponse,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -28,12 +28,12 @@ service MobilecoindAPI {
     rpc GetPublicAddress (GetPublicAddressRequest) returns (GetPublicAddressResponse) {}
 
     // b58 Codes
-    rpc ReadRequestCode (ReadRequestCodeRequest) returns (ReadRequestCodeResponse) {}
-    rpc GetRequestCode (GetRequestCodeRequest) returns (GetRequestCodeResponse) {}
-    rpc ReadTransferCode (ReadTransferCodeRequest) returns (ReadTransferCodeResponse) {}
-    rpc GetTransferCode (GetTransferCodeRequest) returns (GetTransferCodeResponse) {}
-    rpc ReadAddressCode (ReadAddressCodeRequest) returns (ReadAddressCodeResponse) {}
-    rpc GetAddressCode (GetAddressCodeRequest) returns (GetAddressCodeResponse) {}
+    rpc ParseRequestCode (ParseRequestCodeRequest) returns (ParseRequestCodeResponse) {}
+    rpc CreateRequestCode (CreateRequestCodeRequest) returns (CreateRequestCodeResponse) {}
+    rpc ParseTransferCode (ParseTransferCodeRequest) returns (ParseTransferCodeResponse) {}
+    rpc CreateTransferCode (CreateTransferCodeRequest) returns (CreateTransferCodeResponse) {}
+    rpc ParseAddressCode (ParseAddressCodeRequest) returns (ParseAddressCodeResponse) {}
+    rpc CreateAddressCode (CreateAddressCodeRequest) returns (CreateAddressCodeResponse) {}
 
     // Txs
     rpc GenerateTx (GenerateTxRequest) returns (GenerateTxResponse) {}
@@ -224,7 +224,7 @@ message ProcessedTxOut {
 
     // Whether the TxOut was received (deposit to subaddress) or spent (withdrawal from subaddress).
     ProcessedTxOutDirection direction = 6;
-    
+
     // The b58-encoded Address Code for the subaddress that owns the TxOut.
     string address_code = 7;
 }
@@ -322,31 +322,31 @@ message GetPublicAddressResponse {
 //
 
 // Decode a base-58 encoded "MobileCoin Request Code" into receiver's public address, value, and memo.
-message ReadRequestCodeRequest {
+message ParseRequestCodeRequest {
     string b58_code = 1;
 }
-message ReadRequestCodeResponse {
+message ParseRequestCodeResponse {
     external.PublicAddress receiver = 1;
     uint64 value = 2;
     string memo = 3;
 }
 
 // Encode receiver's public address, value, and memo into a base-58 "MobileCoin Request Code".
-message GetRequestCodeRequest {
+message CreateRequestCodeRequest {
     external.PublicAddress receiver = 1;
     uint64 value = 2;
     string memo = 3;
 }
-message GetRequestCodeResponse {
+message CreateRequestCodeResponse {
     string b58_code = 1;
 }
 
 // Decode a base-58 encoded "MobileCoin Transfer Code" into entropy/tx_public_key/memo.
 // This code provides a mobile client with everything required to construct a self-payment, allowing funds to be withdrawn from a gift card.
-message ReadTransferCodeRequest {
+message ParseTransferCodeRequest {
     string b58_code = 1;
 }
-message ReadTransferCodeResponse {
+message ParseTransferCodeResponse {
     bytes entropy = 1;
     external.CompressedRistretto tx_public_key = 2;
     string memo = 3;
@@ -354,28 +354,28 @@ message ReadTransferCodeResponse {
 }
 
 // Encode entropy/tx_public_key/memo into a base-58 "MobileCoin Transfer Code".
-message GetTransferCodeRequest {
+message CreateTransferCodeRequest {
     bytes entropy = 1;
     external.CompressedRistretto tx_public_key = 2;
     string memo = 3;
 }
-message GetTransferCodeResponse {
+message CreateTransferCodeResponse {
     string b58_code = 1;
 }
 
 // Decode a base-58 encoded "MobileCoin Address Code" into the receiver's public address.
-message ReadAddressCodeRequest {
+message ParseAddressCodeRequest {
     string b58_code = 1;
 }
-message ReadAddressCodeResponse {
+message ParseAddressCodeResponse {
     external.PublicAddress receiver = 1;
 }
 
 // Encode receiver's public address into a base-58 "MobileCoin Address Code".
-message GetAddressCodeRequest {
+message CreateAddressCodeRequest {
     external.PublicAddress receiver = 1;
 }
-message GetAddressCodeResponse {
+message CreateAddressCodeResponse {
     string b58_code = 1;
 }
 

--- a/mobilecoind/clients/python/jupyter/wallet.ipynb
+++ b/mobilecoind/clients/python/jupyter/wallet.ipynb
@@ -134,7 +134,7 @@
     "\n",
     "# We don't care about the value and memo field, because we already know \n",
     "# how much MobileCoin we want to send.\n",
-    "target_address, _value, _memo = client.read_request_code(request_code)\n",
+    "target_address, _value, _memo = client.parse_request_code(request_code)\n",
     "\n",
     "# Construct the transaction\n",
     "tx_list = client.get_unspent_tx_output_list(monitor_id, subaddress_index)\n",
@@ -159,7 +159,7 @@
    "outputs": [],
    "source": [
     "public_address = client.get_public_address(monitor_id, subaddress_index)\n",
-    "request_code = client.get_request_code(public_address)\n",
+    "request_code = client.create_request_code(public_address)\n",
     "print(f\"Request code = {request_code}\")"
    ]
   }

--- a/mobilecoind/clients/python/lib/mobilecoin/__init__.py
+++ b/mobilecoind/clients/python/lib/mobilecoin/__init__.py
@@ -128,48 +128,48 @@ class Client(object):
             monitor_id=monitor_id, subaddress_index=int(subaddress_index))
         return self.stub.GetPublicAddress(request).public_address
 
-    def read_address_code(self, b58_code):
-        """ Read a b58 encoded public address
+    def parse_address_code(self, b58_code):
+        """ Parse a b58 encoded public address
         """
-        request = ReadAddressCodeRequest(b58_code=b58_code)
-        response = self.stub.ReadAddressCode(request)
+        request = ParseAddressCodeRequest(b58_code=b58_code)
+        response = self.stub.ParseAddressCode(request)
         return response.receiver
 
-    def get_address_code(self, receiver):
+    def create_address_code(self, receiver):
         """ Create a b58 encoding for a public address
         """
-        request = GetAddressCodeRequest(receiver=receiver)
-        return self.stub.GetAddressCode(request).b58_code
+        request = CreateAddressCodeRequest(receiver=receiver)
+        return self.stub.CreateAddressCode(request).b58_code
 
-    def read_request_code(self, b58_code):
-        """ Process a b58 request code to recover content.
+    def parse_request_code(self, b58_code):
+        """ Parse a b58 request code to recover content.
         """
-        request = ReadRequestCodeRequest(b58_code=b58_code)
-        response = self.stub.ReadRequestCode(request)
+        request = ParseRequestCodeRequest(b58_code=b58_code)
+        response = self.stub.ParseRequestCode(request)
         return response.receiver, response.value, response.memo
 
-    def get_request_code(self, receiver, value=0, memo=""):
-        """ Prepare a "request code" used to generate a QR code for wallet apps.
+    def create_request_code(self, receiver, value=0, memo=""):
+        """ Create a "request code" used to generate a QR code for wallet apps.
         """
-        request = GetRequestCodeRequest(receiver=receiver,
-                                            value=value,
-                                            memo=memo)
-        return self.stub.GetRequestCode(request).b58_code
+        request = CreateRequestCodeRequest(receiver=receiver,
+                                           value=value,
+                                           memo=memo)
+        return self.stub.CreateRequestCode(request).b58_code
 
-    def read_transfer_code(self, b58_code):
-        """ Process a b58 transfer code to recover content.
+    def parse_transfer_code(self, b58_code):
+        """ Parse a b58 transfer code to recover content.
         """
-        request = ReadTransferCodeRequest(b58_code=b58_code)
-        response = self.stub.ReadTransferCode(request)
+        request = ParseTransferCodeRequest(b58_code=b58_code)
+        response = self.stub.ParseTransferCode(request)
         return response
 
-    def get_transfer_code(self, entropy, tx_public_key, memo=""):
-        """ Prepare a "transfer code" used to generate a QR code for wallet apps.
+    def crate_transfer_code(self, entropy, tx_public_key, memo=""):
+        """ Create a "transfer code" used to generate a QR code for wallet apps.
         """
-        request = GetTransferCodeRequest(entropy=entropy,
+        request = CreateTransferCodeRequest(entropy=entropy,
                                              tx_public_key=tx_public_key,
                                              memo=memo)
-        return self.stub.GetTransferCode(request).b58_code
+        return self.stub.CreateTransferCode(request).b58_code
 
     #
     # Transactions

--- a/mobilecoind/clients/python/lib/setup.py
+++ b/mobilecoind/clients/python/lib/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mobilecoin",
-    version="0.1.1",
+    version="0.2.0",
     author="MobileCoin",
     author_email="support@mobilecoin.com",
     description="Python bindings for the MobileCoin daemon API.",

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -351,10 +351,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         Ok(response)
     }
 
-    fn read_request_code_impl(
+    fn parse_request_code_impl(
         &mut self,
-        request: mc_mobilecoind_api::ReadRequestCodeRequest,
-    ) -> Result<mc_mobilecoind_api::ReadRequestCodeResponse, RpcStatus> {
+        request: mc_mobilecoind_api::ParseRequestCodeRequest,
+    ) -> Result<mc_mobilecoind_api::ParseRequestCodeResponse, RpcStatus> {
         let wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
             request.get_b58_code().to_string(),
         )
@@ -363,14 +363,14 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         // A request code could be a public address or a payment request
         if wrapper.has_payment_request() {
             let payment_request = wrapper.get_payment_request();
-            let mut response = mc_mobilecoind_api::ReadRequestCodeResponse::new();
+            let mut response = mc_mobilecoind_api::ParseRequestCodeResponse::new();
             response.set_receiver(payment_request.get_public_address().clone());
             response.set_value(payment_request.get_value());
             response.set_memo(payment_request.get_memo().to_string());
             Ok(response)
         } else if wrapper.has_public_address() {
             let public_address = wrapper.get_public_address();
-            let mut response = mc_mobilecoind_api::ReadRequestCodeResponse::new();
+            let mut response = mc_mobilecoind_api::ParseRequestCodeResponse::new();
             response.set_receiver(public_address.clone());
             response.set_value(0);
             response.set_memo(String::new());
@@ -383,10 +383,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         }
     }
 
-    fn get_request_code_impl(
+    fn create_request_code_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetRequestCodeRequest,
-    ) -> Result<mc_mobilecoind_api::GetRequestCodeResponse, RpcStatus> {
+        request: mc_mobilecoind_api::CreateRequestCodeRequest,
+    ) -> Result<mc_mobilecoind_api::CreateRequestCodeResponse, RpcStatus> {
         let receiver = PublicAddress::try_from(request.get_receiver())
             .map_err(|err| rpc_internal_error("PublicAddress.try_from", err, &self.logger))?;
 
@@ -402,15 +402,15 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             .b58_encode()
             .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
 
-        let mut response = mc_mobilecoind_api::GetRequestCodeResponse::new();
+        let mut response = mc_mobilecoind_api::CreateRequestCodeResponse::new();
         response.set_b58_code(encoded);
         Ok(response)
     }
 
-    fn read_transfer_code_impl(
+    fn parse_transfer_code_impl(
         &mut self,
-        request: mc_mobilecoind_api::ReadTransferCodeRequest,
-    ) -> Result<mc_mobilecoind_api::ReadTransferCodeResponse, RpcStatus> {
+        request: mc_mobilecoind_api::ParseTransferCodeRequest,
+    ) -> Result<mc_mobilecoind_api::ParseTransferCodeResponse, RpcStatus> {
         let wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
             request.get_b58_code().to_string(),
         )
@@ -477,7 +477,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             attempted_spend_tombstone: 0,
         };
 
-        let mut response = mc_mobilecoind_api::ReadTransferCodeResponse::new();
+        let mut response = mc_mobilecoind_api::ParseTransferCodeResponse::new();
         response.set_entropy(root_entropy.to_vec());
         response.set_tx_public_key((&tx_public_key).into());
         response.set_memo(transfer_payload.get_memo().to_string());
@@ -486,10 +486,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         Ok(response)
     }
 
-    fn get_transfer_code_impl(
+    fn create_transfer_code_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetTransferCodeRequest,
-    ) -> Result<mc_mobilecoind_api::GetTransferCodeResponse, RpcStatus> {
+        request: mc_mobilecoind_api::CreateTransferCodeRequest,
+    ) -> Result<mc_mobilecoind_api::CreateTransferCodeResponse, RpcStatus> {
         if request.entropy.len() != 32 {
             return Err(RpcStatus::new(
                 RpcStatusCode::INVALID_ARGUMENT,
@@ -515,15 +515,15 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             .b58_encode()
             .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
 
-        let mut response = mc_mobilecoind_api::GetTransferCodeResponse::new();
+        let mut response = mc_mobilecoind_api::CreateTransferCodeResponse::new();
         response.set_b58_code(encoded);
         Ok(response)
     }
 
-    fn read_address_code_impl(
+    fn parse_address_code_impl(
         &mut self,
-        request: mc_mobilecoind_api::ReadAddressCodeRequest,
-    ) -> Result<mc_mobilecoind_api::ReadAddressCodeResponse, RpcStatus> {
+        request: mc_mobilecoind_api::ParseAddressCodeRequest,
+    ) -> Result<mc_mobilecoind_api::ParseAddressCodeResponse, RpcStatus> {
         let wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
             request.get_b58_code().to_string(),
         )
@@ -532,12 +532,12 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         // An address code could be a public address or a payment request
         if wrapper.has_payment_request() {
             let payment_request = wrapper.get_payment_request();
-            let mut response = mc_mobilecoind_api::ReadAddressCodeResponse::new();
+            let mut response = mc_mobilecoind_api::ParseAddressCodeResponse::new();
             response.set_receiver(payment_request.get_public_address().clone());
             Ok(response)
         } else if wrapper.has_public_address() {
             let public_address = wrapper.get_public_address();
-            let mut response = mc_mobilecoind_api::ReadAddressCodeResponse::new();
+            let mut response = mc_mobilecoind_api::ParseAddressCodeResponse::new();
             response.set_receiver(public_address.clone());
             Ok(response)
         } else {
@@ -548,10 +548,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         }
     }
 
-    fn get_address_code_impl(
+    fn create_address_code_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetAddressCodeRequest,
-    ) -> Result<mc_mobilecoind_api::GetAddressCodeResponse, RpcStatus> {
+        request: mc_mobilecoind_api::CreateAddressCodeRequest,
+    ) -> Result<mc_mobilecoind_api::CreateAddressCodeResponse, RpcStatus> {
         let receiver = PublicAddress::try_from(request.get_receiver())
             .map_err(|err| rpc_internal_error("PublicAddress.try_from", err, &self.logger))?;
 
@@ -562,7 +562,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
             .b58_encode()
             .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
 
-        let mut response = mc_mobilecoind_api::GetAddressCodeResponse::new();
+        let mut response = mc_mobilecoind_api::CreateAddressCodeResponse::new();
         response.set_b58_code(encoded);
         Ok(response)
     }
@@ -1390,14 +1390,15 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         }
 
         // Try and decode the address code.
-        let mut read_address_code_request = mc_mobilecoind_api::ReadAddressCodeRequest::new();
-        read_address_code_request.set_b58_code(request.get_receiver_b58_code().to_owned());
-        let read_address_code_response = self.read_address_code_impl(read_address_code_request)?;
+        let mut parse_address_code_request = mc_mobilecoind_api::ParseAddressCodeRequest::new();
+        parse_address_code_request.set_b58_code(request.get_receiver_b58_code().to_owned());
+        let parse_address_code_response =
+            self.parse_address_code_impl(parse_address_code_request)?;
 
         // Forward to SendPayment
         let mut outlay = mc_mobilecoind_api::Outlay::new();
         outlay.set_value(request.get_amount());
-        outlay.set_receiver(read_address_code_response.get_receiver().clone());
+        outlay.set_receiver(parse_address_code_response.get_receiver().clone());
 
         let mut send_payment_request = mc_mobilecoind_api::SendPaymentRequest::new();
         send_payment_request.set_sender_monitor_id(request.get_sender_monitor_id().to_vec());
@@ -1480,12 +1481,12 @@ build_api! {
     generate_entropy Empty GenerateEntropyResponse generate_entropy_impl,
     get_account_key GetAccountKeyRequest GetAccountKeyResponse get_account_key_impl,
     get_public_address GetPublicAddressRequest GetPublicAddressResponse get_public_address_impl,
-    read_request_code ReadRequestCodeRequest ReadRequestCodeResponse read_request_code_impl,
-    get_request_code GetRequestCodeRequest GetRequestCodeResponse get_request_code_impl,
-    read_transfer_code ReadTransferCodeRequest ReadTransferCodeResponse read_transfer_code_impl,
-    get_transfer_code GetTransferCodeRequest GetTransferCodeResponse get_transfer_code_impl,
-    read_address_code ReadAddressCodeRequest ReadAddressCodeResponse read_address_code_impl,
-    get_address_code GetAddressCodeRequest GetAddressCodeResponse get_address_code_impl,
+    parse_request_code ParseRequestCodeRequest ParseRequestCodeResponse parse_request_code_impl,
+    create_request_code CreateRequestCodeRequest CreateRequestCodeResponse create_request_code_impl,
+    parse_transfer_code ParseTransferCodeRequest ParseTransferCodeResponse parse_transfer_code_impl,
+    create_transfer_code CreateTransferCodeRequest CreateTransferCodeResponse create_transfer_code_impl,
+    parse_address_code ParseAddressCodeRequest ParseAddressCodeResponse parse_address_code_impl,
+    create_address_code CreateAddressCodeRequest CreateAddressCodeResponse create_address_code_impl,
     generate_tx GenerateTxRequest GenerateTxResponse generate_tx_impl,
     generate_optimization_tx GenerateOptimizationTxRequest GenerateOptimizationTxResponse generate_optimization_tx_impl,
     generate_transfer_code_tx GenerateTransferCodeTxRequest GenerateTransferCodeTxResponse generate_transfer_code_tx_impl,
@@ -2334,9 +2335,9 @@ mod test {
             let response = client.get_public_address(&request).unwrap();
             let public_address = PublicAddress::try_from(response.get_public_address()).unwrap();
 
-            let mut request = mc_mobilecoind_api::GetAddressCodeRequest::new();
+            let mut request = mc_mobilecoind_api::CreateAddressCodeRequest::new();
             request.set_receiver(mc_api::external::PublicAddress::from(&public_address));
-            let response = client.get_address_code(&request).unwrap();
+            let response = client.create_address_code(&request).unwrap();
             let b58_code = response.get_b58_code();
 
             assert_eq!(tx_out.get_address_code(), b58_code);
@@ -3530,17 +3531,17 @@ mod test {
         // Try with just a receiver
         {
             // Generate a request code
-            let mut request = mc_mobilecoind_api::GetRequestCodeRequest::new();
+            let mut request = mc_mobilecoind_api::CreateRequestCodeRequest::new();
             request.set_receiver(mc_api::external::PublicAddress::from(&receiver));
 
-            let response = client.get_request_code(&request).unwrap();
+            let response = client.create_request_code(&request).unwrap();
             let b58_code = response.get_b58_code();
 
             // Attempt to decode it.
-            let mut request = mc_mobilecoind_api::ReadRequestCodeRequest::new();
+            let mut request = mc_mobilecoind_api::ParseRequestCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
-            let response = client.read_request_code(&request).unwrap();
+            let response = client.parse_request_code(&request).unwrap();
 
             // Check that input equals output.
             assert_eq!(
@@ -3553,18 +3554,18 @@ mod test {
         // Try with receiver and value
         {
             // Generate a request code
-            let mut request = mc_mobilecoind_api::GetRequestCodeRequest::new();
+            let mut request = mc_mobilecoind_api::CreateRequestCodeRequest::new();
             request.set_receiver(mc_api::external::PublicAddress::from(&receiver));
             request.set_value(1234567890);
 
-            let response = client.get_request_code(&request).unwrap();
+            let response = client.create_request_code(&request).unwrap();
             let b58_code = response.get_b58_code();
 
             // Attempt to decode it.
-            let mut request = mc_mobilecoind_api::ReadRequestCodeRequest::new();
+            let mut request = mc_mobilecoind_api::ParseRequestCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
-            let response = client.read_request_code(&request).unwrap();
+            let response = client.parse_request_code(&request).unwrap();
 
             // Check that input equals output.
             assert_eq!(
@@ -3577,19 +3578,19 @@ mod test {
         // Try with receiver, value and memo
         {
             // Generate a request code
-            let mut request = mc_mobilecoind_api::GetRequestCodeRequest::new();
+            let mut request = mc_mobilecoind_api::CreateRequestCodeRequest::new();
             request.set_receiver(mc_api::external::PublicAddress::from(&receiver));
             request.set_value(1234567890);
             request.set_memo("hello there".to_owned());
 
-            let response = client.get_request_code(&request).unwrap();
+            let response = client.create_request_code(&request).unwrap();
             let b58_code = response.get_b58_code();
 
             // Attempt to decode it.
-            let mut request = mc_mobilecoind_api::ReadRequestCodeRequest::new();
+            let mut request = mc_mobilecoind_api::ParseRequestCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
-            let response = client.read_request_code(&request).unwrap();
+            let response = client.parse_request_code(&request).unwrap();
 
             // Check that input equals output.
             assert_eq!(
@@ -3602,10 +3603,10 @@ mod test {
 
         // Attempting to decode junk data should fail
         {
-            let mut request = mc_mobilecoind_api::ReadRequestCodeRequest::new();
+            let mut request = mc_mobilecoind_api::ParseRequestCodeRequest::new();
             request.set_b58_code("junk".to_owned());
 
-            assert!(client.read_request_code(&request).is_err());
+            assert!(client.parse_request_code(&request).is_err());
         }
     }
 
@@ -3642,34 +3643,34 @@ mod test {
 
         // An invalid request should fail to encode.
         {
-            let mut request = mc_mobilecoind_api::GetTransferCodeRequest::new();
+            let mut request = mc_mobilecoind_api::CreateTransferCodeRequest::new();
             request.set_entropy(vec![3u8; 8]); // key is wrong size
             request.set_tx_public_key((&tx_public_key).into());
             request.set_memo("memo".to_owned());
-            assert!(client.get_transfer_code(&request).is_err());
+            assert!(client.create_transfer_code(&request).is_err());
 
-            let mut request = mc_mobilecoind_api::GetTransferCodeRequest::new();
+            let mut request = mc_mobilecoind_api::CreateTransferCodeRequest::new();
             request.set_entropy(vec![4u8; 32]);
             request.set_memo("memo".to_owned()); // forgot to set tx_public_key
-            assert!(client.get_transfer_code(&request).is_err());
+            assert!(client.create_transfer_code(&request).is_err());
         }
 
         // A valid request should allow us to encode to b58 and back to the original data.
         {
             // Encode
-            let mut request = mc_mobilecoind_api::GetTransferCodeRequest::new();
+            let mut request = mc_mobilecoind_api::CreateTransferCodeRequest::new();
             request.set_entropy(root_entropy.to_vec());
             request.set_tx_public_key((&tx_public_key).into());
             request.set_memo("test memo".to_owned());
 
-            let response = client.get_transfer_code(&request).unwrap();
+            let response = client.create_transfer_code(&request).unwrap();
             let b58_code = response.get_b58_code();
 
             // Decode
-            let mut request = mc_mobilecoind_api::ReadTransferCodeRequest::new();
+            let mut request = mc_mobilecoind_api::ParseTransferCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
-            let response = client.read_transfer_code(&request).unwrap();
+            let response = client.parse_transfer_code(&request).unwrap();
 
             // Compare
             assert_eq!(&root_entropy, response.get_entropy());
@@ -3722,17 +3723,17 @@ mod test {
             let receiver = AccountKey::random(&mut rng).default_subaddress();
 
             // Generate a request code
-            let mut request = mc_mobilecoind_api::GetAddressCodeRequest::new();
+            let mut request = mc_mobilecoind_api::CreateAddressCodeRequest::new();
             request.set_receiver(mc_api::external::PublicAddress::from(&receiver));
 
-            let response = client.get_address_code(&request).unwrap();
+            let response = client.create_address_code(&request).unwrap();
             let b58_code = response.get_b58_code();
 
             // Attempt to decode it.
-            let mut request = mc_mobilecoind_api::ReadAddressCodeRequest::new();
+            let mut request = mc_mobilecoind_api::ParseAddressCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
-            let response = client.read_address_code(&request).unwrap();
+            let response = client.parse_address_code(&request).unwrap();
 
             // Check that input equals output.
             assert_eq!(
@@ -3747,19 +3748,19 @@ mod test {
             let receiver = AccountKey::random(&mut rng).default_subaddress();
 
             // Generate a request code
-            let mut request = mc_mobilecoind_api::GetRequestCodeRequest::new();
+            let mut request = mc_mobilecoind_api::CreateRequestCodeRequest::new();
             request.set_receiver(mc_api::external::PublicAddress::from(&receiver));
             request.set_value(1234567890);
             request.set_memo("hello there".to_owned());
 
-            let response = client.get_request_code(&request).unwrap();
+            let response = client.create_request_code(&request).unwrap();
             let b58_code = response.get_b58_code();
 
             // Attempt to decode it.
-            let mut request = mc_mobilecoind_api::ReadAddressCodeRequest::new();
+            let mut request = mc_mobilecoind_api::ParseAddressCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
-            let response = client.read_address_code(&request).unwrap();
+            let response = client.parse_address_code(&request).unwrap();
 
             // Check that input equals output.
             assert_eq!(
@@ -3770,10 +3771,10 @@ mod test {
 
         // Attempting to decode junk data should fail
         {
-            let mut request = mc_mobilecoind_api::ReadAddressCodeRequest::new();
+            let mut request = mc_mobilecoind_api::ParseAddressCodeRequest::new();
             request.set_b58_code("junk".to_owned());
 
-            assert!(client.read_address_code(&request).is_err());
+            assert!(client.parse_address_code(&request).is_err());
         }
     }
 

--- a/testnet-client/src/main.rs
+++ b/testnet-client/src/main.rs
@@ -622,12 +622,12 @@ MobileCoin forums. Visit http://community.mobilecoin.com
         let public_address = resp.take_public_address();
 
         // Generate b58 code
-        let mut req = mc_mobilecoind_api::GetRequestCodeRequest::new();
+        let mut req = mc_mobilecoind_api::CreateRequestCodeRequest::new();
         req.set_receiver(public_address);
         req.set_value(amount);
         req.set_memo(memo);
 
-        let resp = match self.client.get_request_code(&req) {
+        let resp = match self.client.create_request_code(&req) {
             Ok(resp) => resp,
             Err(err) => {
                 println!("Failed generating request code: {}", err);


### PR DESCRIPTION
### Motivation

The verbs related to b58 code stuff were "Get" for creating a b58 code and "Read" for parsing one - which are suboptimal. This PR moves to Create and Parse which are unambiguous.

### In this PR
* Whole bunch of renames
