### PR TITLE
Return b58 encoding of public address as part of public address endpoint

### DIFF
--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -198,7 +198,7 @@ fn public_address(
     state: rocket::State<State>,
     monitor_hex: String,
     subaddress_index: u64,
-) -> Result<Json<JsonPublicAddress>, String> {
+) -> Result<Json<JsonPublicAddressResponse>, String> {
     let monitor_id =
         hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
 
@@ -212,8 +212,7 @@ fn public_address(
         .get_public_address(&req)
         .map_err(|err| format!("Failed getting public address: {}", err))?;
 
-    let public_address = resp.get_public_address();
-    Ok(Json(JsonPublicAddress::from(public_address)))
+    Ok(Json(JsonPublicAddressResponse::from(&resp)))
 }
 
 /// Generates a request code with an optional value and memo

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -264,7 +264,9 @@ impl From<&mc_mobilecoind_api::GetPublicAddressResponse> for JsonPublicAddressRe
             spend_public_key: hex::encode(&public_address.get_spend_public_key().get_data()),
             fog_report_url: String::from(public_address.get_fog_report_url()),
             fog_report_id: String::from(public_address.get_fog_report_id()),
-            fog_authority_fingerprint_sig: hex::encode(&public_address.get_fog_authority_fingerprint_sig()),
+            fog_authority_fingerprint_sig: hex::encode(
+                &public_address.get_fog_authority_fingerprint_sig(),
+            ),
             b58_address_code: src.get_b58_code().to_string(),
         }
     }

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -7,7 +7,6 @@ use mc_api::external::{
     SignatureRctBulletproofs, Tx, TxIn, TxOutMembershipElement, TxOutMembershipHash,
     TxOutMembershipProof, TxPrefix,
 };
-use mc_api::printable::PrintableWrapper;
 use protobuf::RepeatedField;
 use serde_derive::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::TryFrom, iter::FromIterator};
@@ -222,9 +221,6 @@ pub struct JsonPublicAddress {
 
     /// String label for fog reports
     pub fog_report_id: String,
-
-    /// b58-encoded public address
-    pub b58_address_code: String,
 }
 
 impl From<&PublicAddress> for JsonPublicAddress {
@@ -235,7 +231,41 @@ impl From<&PublicAddress> for JsonPublicAddress {
             fog_report_url: String::from(src.get_fog_report_url()),
             fog_report_id: String::from(src.get_fog_report_id()),
             fog_authority_fingerprint_sig: hex::encode(&src.get_fog_authority_fingerprint_sig()),
-            b58_address_code: (),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Default)]
+pub struct JsonPublicAddressResponse {
+    /// Hex encoded compressed ristretto bytes
+    pub view_public_key: String,
+
+    /// Hex encoded compressed ristretto bytes
+    pub spend_public_key: String,
+
+    /// Fog Report Server Url
+    pub fog_report_url: String,
+
+    /// Hex encoded signature bytes
+    pub fog_authority_fingerprint_sig: String,
+
+    /// String label for fog reports
+    pub fog_report_id: String,
+
+    /// b58-encoded public address
+    pub b58_address_code: String,
+}
+
+impl From<&mc_mobilecoind_api::GetPublicAddressResponse> for JsonPublicAddressResponse {
+    fn from(src: &mc_mobilecoind_api::GetPublicAddressResponse) -> Self {
+        let public_address = src.get_public_address();
+        Self {
+            view_public_key: hex::encode(&public_address.get_view_public_key().get_data()),
+            spend_public_key: hex::encode(&public_address.get_spend_public_key().get_data()),
+            fog_report_url: String::from(public_address.get_fog_report_url()),
+            fog_report_id: String::from(public_address.get_fog_report_id()),
+            fog_authority_fingerprint_sig: hex::encode(&public_address.get_fog_authority_fingerprint_sig()),
+            b58_address_code: src.get_b58_code().to_string(),
         }
     }
 }

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -7,6 +7,7 @@ use mc_api::external::{
     SignatureRctBulletproofs, Tx, TxIn, TxOutMembershipElement, TxOutMembershipHash,
     TxOutMembershipProof, TxPrefix,
 };
+use mc_api::printable::PrintableWrapper;
 use protobuf::RepeatedField;
 use serde_derive::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::TryFrom, iter::FromIterator};
@@ -221,6 +222,9 @@ pub struct JsonPublicAddress {
 
     /// String label for fog reports
     pub fog_report_id: String,
+
+    /// b58-encoded public address
+    pub b58_address_code: String,
 }
 
 impl From<&PublicAddress> for JsonPublicAddress {
@@ -231,6 +235,7 @@ impl From<&PublicAddress> for JsonPublicAddress {
             fog_report_url: String::from(src.get_fog_report_url()),
             fog_report_id: String::from(src.get_fog_report_id()),
             fog_authority_fingerprint_sig: hex::encode(&src.get_fog_authority_fingerprint_sig()),
+            b58_address_code: (),
         }
     }
 }

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -315,6 +315,7 @@ message GetPublicAddressRequest {
 }
 message GetPublicAddressResponse {
     external.PublicAddress public_address = 1;
+    string b58_code = 2;
 }
 
 //

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1923,10 +1923,7 @@ mod test {
         let mut wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
         wrapper.set_public_address((&account_key.subaddress(10)).into());
         let b58_code = wrapper.b58_encode().unwrap();
-        assert_eq!(
-            response.get_b58_code(),
-            b58_code,
-        );
+        assert_eq!(response.get_b58_code(), b58_code,);
 
         // Subaddress that is out of index or an invalid monitor id should error.
         let request = mc_mobilecoind_api::GetPublicAddressRequest::new();


### PR DESCRIPTION
### Motivation
Requesting a printable public address currently requires two round-trips, we have a feature request to simplify this by including the b58 code in GetPublicAddress

This has been run through integration testing

### In this PR
* Adds b58-encoded Public Address in GetPublicAddress in mobilecoind
* Add to JSON interface

### Future Work
* Potentially allow b58 codes used directly in transaction creation functions, further reducing round-trips