### PR TITLE
MCC-1822 Copy data into enclave before deserialization

### DIFF
--- a/consensus/enclave/edl/enclave.edl
+++ b/consensus/enclave/edl/enclave.edl
@@ -11,7 +11,7 @@ enclave {
         /*
          * Entry point for enclave functionality.
          */
-        public sgx_status_t mobileenclave_call([user_check] const uint8_t* inbuf,
+        public sgx_status_t mobileenclave_call([in, size=inbuf_len] const uint8_t* inbuf,
                                                size_t inbuf_len,
                                                [user_check] uint8_t *outbuf,
                                                size_t outbuf_len,

--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -120,7 +120,7 @@ pub extern "C" fn mobileenclave_call(
         || outbuf.is_null()
         || outbuf_used.is_null()
         || outbuf_retry_id.is_null()
-        || unsafe { sgx_is_outside_enclave(inbuf as *const c_void, inbuf_len) } != 1
+        || unsafe { sgx_is_outside_enclave(inbuf as *const c_void, inbuf_len) } == 1
         || unsafe { sgx_is_outside_enclave(outbuf as *const c_void, outbuf_len) } != 1
         || unsafe {
             sgx_is_outside_enclave(outbuf_used as *const c_void, core::mem::size_of::<usize>())


### PR DESCRIPTION
### Motivation

Fixes deserialization data-race uncovered by ioactive.

### In this PR
* Replace `[user_check]` with `[in]` in enclave EDL file.
* Invert the `sgx_is_outside_enclave` check of the inbuf in `mobileenclave_call`

### Future Work
* Update other enclaves which use this convention.

