### PR TITLE
Removes sgx_backtrace and sgx_debug edl interfaces in consensus_enclave edl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3214,14 +3214,12 @@ version = "1.0.0"
 name = "mc-sgx-urts"
 version = "1.0.0"
 dependencies = [
- "lazy_static",
  "mc-common",
  "mc-sgx-build",
  "mc-sgx-libc-types",
  "mc-sgx-slog",
  "mc-sgx-types",
  "prost",
- "rustc-demangle",
 ]
 
 [[package]]

--- a/consensus/enclave/build.rs
+++ b/consensus/enclave/build.rs
@@ -36,14 +36,7 @@ fn main() {
 
     let mut edger8r = Edger8r::new(&env, libraries.as_slice()).expect("Could not create linkage");
 
-    for edl_data in [
-        "SGX_BACKTRACE_EDL_SEARCH_PATH",
-        "SGX_DEBUG_EDL_SEARCH_PATH",
-        "SGX_PANIC_EDL_SEARCH_PATH",
-        "SGX_SLOG_EDL_SEARCH_PATH",
-    ]
-    .iter()
-    {
+    for edl_data in ["SGX_PANIC_EDL_SEARCH_PATH", "SGX_SLOG_EDL_SEARCH_PATH"].iter() {
         for path_str in env
             .depvar(edl_data)
             .expect("Could not read EDL dep var")

--- a/consensus/enclave/edl/enclave.edl
+++ b/consensus/enclave/edl/enclave.edl
@@ -2,8 +2,6 @@
 
 enclave {
     from "sgx_tstdc.edl" import *;
-    from "sgx_backtrace.edl" import *;
-    from "sgx_debug.edl" import *;
     from "sgx_panic.edl" import *;
     from "sgx_slog.edl" import *;
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -758,9 +758,7 @@ dependencies = [
  "mc-consensus-enclave-impl 1.0.0",
  "mc-crypto-keys 1.0.0",
  "mc-enclave-boundary 1.0.0",
- "mc-sgx-backtrace-edl 1.0.0",
  "mc-sgx-compat 1.0.0",
- "mc-sgx-debug-edl 1.0.0",
  "mc-sgx-enclave-id 1.0.0",
  "mc-sgx-panic-edl 1.0.0",
  "mc-sgx-report-cache-api 1.0.0",
@@ -942,13 +940,6 @@ name = "mc-sgx-alloc"
 version = "1.0.0"
 
 [[package]]
-name = "mc-sgx-backtrace-edl"
-version = "1.0.0"
-dependencies = [
- "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "mc-sgx-build"
 version = "1.0.0"
 dependencies = [
@@ -982,13 +973,6 @@ dependencies = [
 [[package]]
 name = "mc-sgx-debug"
 version = "1.0.0"
-
-[[package]]
-name = "mc-sgx-debug-edl"
-version = "1.0.0"
-dependencies = [
- "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "mc-sgx-enclave-id"

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -29,9 +29,7 @@ mc-consensus-enclave-impl = { path = "../impl", default-features = false }
 mc-enclave-boundary = { path = "../../../enclave-boundary" }
 mc-crypto-keys = { path = "../../../crypto/keys", default-features = false }
 mc-util-serial = { path = "../../../util/serial"}
-mc-sgx-backtrace-edl = { path = "../../../sgx/backtrace-edl" }
 mc-sgx-compat = { path = "../../../sgx/compat", features = ["sgx"] }
-mc-sgx-debug-edl = { path = "../../../sgx/debug-edl" }
 mc-sgx-enclave-id = { path = "../../../sgx/enclave-id" }
 mc-sgx-panic-edl = { path = "../../../sgx/panic-edl" }
 mc-sgx-report-cache-api = { path = "../../../sgx/report-cache/api" }

--- a/consensus/enclave/trusted/build.rs
+++ b/consensus/enclave/trusted/build.rs
@@ -39,14 +39,7 @@ fn main() {
 
     let mut edger8r = Edger8r::new(&env, libraries.as_slice()).expect("Could not create linkage");
 
-    for edl_data in [
-        "SGX_BACKTRACE_EDL_SEARCH_PATH",
-        "SGX_DEBUG_EDL_SEARCH_PATH",
-        "SGX_PANIC_EDL_SEARCH_PATH",
-        "SGX_SLOG_EDL_SEARCH_PATH",
-    ]
-    .iter()
-    {
+    for edl_data in ["SGX_PANIC_EDL_SEARCH_PATH", "SGX_SLOG_EDL_SEARCH_PATH"].iter() {
         for path_str in env
             .depvar(edl_data)
             .expect("Could not read EDL dep var")

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -4,7 +4,10 @@ version = "1.0.0"
 authors = ["MobileCoin"]
 
 [features]
-default = [ "backtrace" ]
+default = [ ]
+# enables the backtrace EDL definition and handler
+# This is not known to have actually worked in a real enclave
+# and should probably go away completely and be redesigned
 backtrace = [ "rustc-demangle", "lazy_static" ]
 
 [dependencies]


### PR DESCRIPTION
The sgx_backtrace thing was an attempt to port Baidu's sgx backtrace
functionality so that it would work without making system calls.
We got it working in sim mode but never actually figured out about offsets
in SGX HW mode.
Since then we became worried that it's a security hole and turned it off,
we are building in panic=abort mode for sgx, so nothing is actually using
this OCALL.

We definitly aren't going to fix this before launch, it would need major
redesign. So there's no reason for it to be in the consensus edl at all.
Probably we should go further and just delete the sgx/backtrace crate entirely.
I'm putting up this smaller commit just for discussion first.