### PR TITLE
Fixes field names/type in json gateway, update README and test

### DIFF
--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -102,7 +102,7 @@ $ curl localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/pay-addres
 ```
 
 #### Check the status of a transaction with a key image and tombstone block
-The return value from `pay-address-code` (and `build-and-submit` below) can be passed directly directly to `status-as-sender`
+The return value from `pay-address-code` (and `build-and-submit` below) can be passed directly to `status-as-sender`
 ```
 $ curl localhost:9090/tx/status-as-sender \
   -d '{"sender_tx_receipt":{"key_images":

--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -145,7 +145,7 @@ $ curl localhost:9090/codes/request \
         "value": "10", "memo": "Please pay me"}' \
   -X POST -H 'Content-Type: application/json'
 
-{"request_code":"ufTwqVqF2rXmFVBZ1CWWS3ntdajVZGfZ5A2YZqAwhVnaVYrFpS9Z8iAg44CBGDeyjFDX8Hj4W7ZzArBn1xSp9wu8NriqQAogN8fUybKmoWgaz92kT4M7fbjRYKZmoY8"}
+{"b58_request_code":"ufTwqVqF2rXmFVBZ1CWWS3ntdajVZGfZ5A2YZqAwhVnaVYrFpS9Z8iAg44CBGDeyjFDX8Hj4W7ZzArBn1xSp9wu8NriqQAogN8fUybKmoWgaz92kT4M7fbjRYKZmoY8"}
 ```
 
 #### Read all the information in a request code

--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -162,7 +162,13 @@ This JSON can be passed directly to `build-and-submit` or you can change the amo
 #### Build and submit a payment from a monitor/subaddress to a request code
 Using the information in the `read-request`, creates and submits a transaction. If this succeeds, funds will be transferred.
 ```
-$ curl localhost:9090/monitors/<monitor_id>/subaddresses/0/build-and-submit -d '{"request_data": {"receiver":{"view_public_key":"40f884563ff10fb1b37b589036db9abbf1ab7afcf88f17a4ea6ec0077e883263","spend_public_key":"ecf9f2fdb8714afd16446d530cf27f2775d9e356e17a6bba8ad395d16d1bbd45","fog_url":""},"value":"10","memo":"Please pay me"}}' -X POST -H 'Content-Type: application/json'
+$ curl localhost:9090/monitors/<monitor_id>/subaddresses/0/build-and-submit \
+  -d '{"request_data": 
+          {"receiver":{"view_public_key":"40f884563ff10fb1b37b589036db9abbf1ab7afcf88f17a4ea6ec0077e883263",
+                       "spend_public_key":"ecf9f2fdb8714afd16446d530cf27f2775d9e356e17a6bba8ad395d16d1bbd45",
+                       "fog_url":""},
+        "value":"10","memo":"Please pay me"}}' \
+  -X POST -H 'Content-Type: application/json'
 
 {"sender_tx_receipt":{"key_images":
                       ["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132",

--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -82,7 +82,7 @@ This call initiates a transfer to a public address encoded as a b58 string. If t
 submitted to the network. It returns receipts which you can use in calls below to determine if the transaction succeeded.
 
 ```
-$ curl http://localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/pay-address-code" \ 
+$ curl localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/pay-address-code" \ 
   -d '{"receiver_b58_address_code": "7Q6gtA5EqSxkEsqsf5p2j7qEHkA8fBZYNsfuWTZTQaFAqo3FPo8PvhrrUobZfXagrLopzpxqxGBs7Hphwhsc56ryWriPWLCRadhRpnZW6AT",
        "value": "1"}' \
   -X POST -H 'Content-Type: application/json'

--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -30,13 +30,15 @@ $ curl localhost:9090/entropy -X POST
 $ curl localhost:9090/entropy/706db549844bc7b5c8328368d4b8276e9aa03a26ac02474d54aa99b7c3369e2e
 
 {"view_private_key":"e0d42caf6edd0dc8a762c665ad5682a87e0a7159e60653827be3911af49d2b01",
-"spend_private_key":"e90849e9dcbbb7aa425cfb34ae3978c14e3dfffd18652e7a6a4821cb1557b703"}
+ "spend_private_key":"e90849e9dcbbb7aa425cfb34ae3978c14e3dfffd18652e7a6a4821cb1557b703"}
 ```
 
 #### Add a monitor for a key over a range of subaddress indices
 ```
 $ curl localhost:9090/monitors \
-  -d '{"account_key": \ {"view_private_key":"<view_private_key>", "spend_private_key":"<spend_private_key>"}, "first_subaddress": 0, "num_subaddresses": 10}' \
+  -d '{"account_key": {"view_private_key":"e0d42caf6edd0dc8a762c665ad5682a87e0a7159e60653827be3911af49d2b01", 
+       "spend_private_key":"e90849e9dcbbb7aa425cfb34ae3978c14e3dfffd18652e7a6a4821cb1557b703"}, 
+       "first_subaddress": 0, "num_subaddresses": 10}' \
   -X POST -H 'Content-Type: application/json'
 
 {"monitor_id":"a0cf8b79c9f8d74eb935ab4eeeb771f3809a408ad47246be47cf40315be9876e"}
@@ -80,7 +82,10 @@ This call initiates a transfer to a public address encoded as a b58 string. If t
 submitted to the network. It returns receipts which you can use in calls below to determine if the transaction succeeded.
 
 ```
-$ curl http://localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/pay-address-code" -d '{"receiver_b58_address_code": "7Q6gtA5EqSxkEsqsf5p2j7qEHkA8fBZYNsfuWTZTQaFAqo3FPo8PvhrrUobZfXagrLopzpxqxGBs7Hphwhsc56ryWriPWLCRadhRpnZW6AT", "value": "1"}' -X POST -H 'Content-Type: application/json'
+$ curl http://localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/pay-address-code" \ 
+  -d '{"receiver_b58_address_code": "7Q6gtA5EqSxkEsqsf5p2j7qEHkA8fBZYNsfuWTZTQaFAqo3FPo8PvhrrUobZfXagrLopzpxqxGBs7Hphwhsc56ryWriPWLCRadhRpnZW6AT",
+       "value": "1"}' \
+  -X POST -H 'Content-Type: application/json'
 
 {"sender_tx_receipt":{"key_images":["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132","7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"],"tombstone":2121},
  "receiver_tx_receipt_list":[{"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71","spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""},"tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b","tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112","tombstone":2329,"confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}]}
@@ -89,7 +94,12 @@ $ curl http://localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/pay
 #### Check the status of a transaction with a key image and tombstone block
 The return value from `pay-address-code` (and `build-and-submit` below) can be passed directly directly to `status-as-sender`
 ```
-$ curl localhost:9090/tx/status-as-sender -d '{"sender_tx_receipt":{"key_images":["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132","7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"],"tombstone":2121}}'  -X POST -H 'Content-Type: application/json'
+$ curl localhost:9090/tx/status-as-sender \
+  -d '{"sender_tx_receipt":{"key_images":
+        ["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132", 
+         "7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"], 
+       "tombstone":2121}, "receiver_tx_receipt_list":[]}' \
+  -X POST -H 'Content-Type: application/json'
 
 {"status":"verified"}
 ```
@@ -99,7 +109,8 @@ The return value from `pay-address-code` includes a list called `receiver_tx_rec
 the list can be send to the recipient over a separate channel (e.g. a secure chat application) and they can use it to 
 verify that they were paid by the sender.
 ```
-$ curl localhost:9090/tx/status-as-receiver -d '{"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71","spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""},"tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b","tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112","tombstone":2329,"confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}' -X POST -H 'Content-Type: application/json'
+$ curl localhost:9090/tx/status-as-receiver \
+  -d '{"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71","spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""},"tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b","tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112","tombstone":2329,"confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}' -X POST -H 'Content-Type: application/json'
 
 {"status":"verified"}
 ```
@@ -154,7 +165,10 @@ $ curl localhost:9090/ledger/blocks/1/header
 ```
 $ curl localhost:9090/ledger/blocks/1
 
-{"block_id":"7b06f8d069f7c169a5a2be51b24331394af832b1453d679e0cca502d3b131bf1","version":0,"parent_id":"e498010ee6a19b4ac9313af43d8274c53d54a1bbc275c06374dbe0095872a6ee","index":"1","cumulative_txo_count":"10003","contents_hash":"c0486e70c50055ecb54ca1f2e8b02fabd1b2322dcd2c133710c3e3149359adec"}
+{"block_id":"7b06f8d069f7c169a5a2be51b24331394af832b1453d679e0cca502d3b131bf1",
+ "version":0,"parent_id":"e498010ee6a19b4ac9313af43d8274c53d54a1bbc275c06374dbe0095872a6ee",
+ "index":"1","cumulative_txo_count":"10003",
+ "contents_hash":"c0486e70c50055ecb54ca1f2e8b02fabd1b2322dcd2c133710c3e3149359adec"}
 ```
 
 ### Offline Transactions
@@ -172,7 +186,9 @@ $ curl localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/utxos
 On the airgapped machine, generate a tx proposal.
 
 ```
-$ curl localhost:9090/monitors/<monitor-id>/subaddresses/<subaddress>/generate-tx -d ‘{“input_list”: [<paste output of utxos response>], “transfer”: ‘$(cat request_code.json)’}’ -X POST -H ‘Content-Type: application/json’ > tx_proposal.json
+$ curl localhost:9090/monitors/<monitor-id>/subaddresses/<subaddress>/generate-tx \
+  -d ‘{“input_list”: [<paste output of utxos response>], “transfer”: ‘$(cat request_code.json)’}’ \ 
+  -X POST -H ‘Content-Type: application/json’ > tx_proposal.json
 ```
 
 ### Submit Propsoal

--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -162,7 +162,7 @@ This JSON can be passed directly to `build-and-submit` or you can change the amo
 #### Build and submit a payment from a monitor/subaddress to a request code
 Using the information in the `read-request`, creates and submits a transaction. If this succeeds, funds will be transferred.
 ```
-$ curl localhost:9090/monitors/<monitor_id>/subaddresses/0/build-and-submit \
+$ curl localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/build-and-submit \
   -d '{"request_data": 
           {"receiver":{"view_public_key":"40f884563ff10fb1b37b589036db9abbf1ab7afcf88f17a4ea6ec0077e883263",
                        "spend_public_key":"ecf9f2fdb8714afd16446d530cf27f2775d9e356e17a6bba8ad395d16d1bbd45",

--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -29,40 +29,46 @@ $ curl localhost:9090/entropy -X POST
 ```
 $ curl localhost:9090/entropy/706db549844bc7b5c8328368d4b8276e9aa03a26ac02474d54aa99b7c3369e2e
 
-{"view_private_key":"e0d42caf6edd0dc8a762c665ad5682a87e0a7159e60653827be3911af49d2b01","spend_private_key":"e90849e9dcbbb7aa425cfb34ae3978c14e3dfffd18652e7a6a4821cb1557b703"}
+{"view_private_key":"e0d42caf6edd0dc8a762c665ad5682a87e0a7159e60653827be3911af49d2b01",
+"spend_private_key":"e90849e9dcbbb7aa425cfb34ae3978c14e3dfffd18652e7a6a4821cb1557b703"}
 ```
 
 #### Add a monitor for a key over a range of subaddress indices
 ```
-$ curl localhost:9090/monitors -d '{"account_key": {"view_private_key":"e0d42caf6edd0dc8a762c665ad5682a87e0a7159e60653827be3911af49d2b01","spend_private_key":"e90849e9dcbbb7aa425cfb34ae3978c14e3dfffd18652e7a6a4821cb1557b703"}, "first_subaddress": 0, "num_subaddresses": 10}' -X POST -H 'Content-Type: application/json'
+$ curl localhost:9090/monitors \
+  -d '{"account_key": \ {"view_private_key":"<view_private_key>", "spend_private_key":"<spend_private_key>"}, "first_subaddress": 0, "num_subaddresses": 10}' \
+  -X POST -H 'Content-Type: application/json'
 
 {"monitor_id":"a0cf8b79c9f8d74eb935ab4eeeb771f3809a408ad47246be47cf40315be9876e"}
 ```
 
 #### Get the status of an existing monitor
 ```
-$ curl localhost:9090/monitors/a0cf8b79c9f8d74eb935ab4eeeb771f3809a408ad47246be47cf40315be9876e
+$ curl localhost:9090/monitors/<monitor_id>
 
 {"first_subaddress":0,"num_subaddresses":10,"first_block":0,"next_block":2068}
 ```
 
 #### Remove an existing monitor
 ```
-$ curl -X DELETE localhost:9090/monitors/a0cf8b79c9f8d74eb935ab4eeeb771f3809a408ad47246be47cf40315be9876e
+$ curl -X DELETE localhost:9090/monitors/<monitor_id>
 
 ```
 
 #### Check the balance for a monitor and subaddress index
 ```
-$ curl localhost:9090/monitors/a0cf8b79c9f8d74eb935ab4eeeb771f3809a408ad47246be47cf40315be9876e/subaddresses/0/balance
+$ curl localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/balance
 
 {"balance":199999999999990}
 ```
 #### Get the public address for a monitor and subaddress
 ```
-$ curl localhost:9090/monitors/a0cf8b79c9f8d74eb935ab4eeeb771f3809a408ad47246be47cf40315be9876e/subaddresses/0/public-address
+$ curl localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/public-address
 
-{"view_public_key":"543b376e9d5b949dd8694f065d95a98a89e6f17a20c621621a808605d1904324","spend_public_key":"58dba855a885dd535dc5180af443abae67c790b860d5adadb4d6a2ecb71abd28","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":"", "b58_address_code": "7Q6gtA5EqSxkEsqsf5p2j7qEHkA8fBZYNsfuWTZTQaFAqo3FPo8PvhrrUobZfXagrLopzpxqxGBs7Hphwhsc56ryWriPWLCRadhRpnZW6AT"}
+{"view_public_key":"543b376e9d5b949dd8694f065d95a98a89e6f17a20c621621a808605d1904324", 
+ "spend_public_key":"58dba855a885dd535dc5180af443abae67c790b860d5adadb4d6a2ecb71abd28",
+ "fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":"", 
+ "b58_address_code": "7Q6gtA5EqSxkEsqsf5p2j7qEHkA8fBZYNsfuWTZTQaFAqo3FPo8PvhrrUobZfXagrLopzpxqxGBs7Hphwhsc56ryWriPWLCRadhRpnZW6AT"}
 ```
 
 ### Simple payment flow
@@ -74,9 +80,10 @@ This call initiates a transfer to a public address encoded as a b58 string. If t
 submitted to the network. It returns receipts which you can use in calls below to determine if the transaction succeeded.
 
 ```
-$ curl http://localhost:9090/monitors/%s/subaddresses/0/pay-address-code" -d '{"receiver_b58_address_code": "7Q6gtA5EqSxkEsqsf5p2j7qEHkA8fBZYNsfuWTZTQaFAqo3FPo8PvhrrUobZfXagrLopzpxqxGBs7Hphwhsc56ryWriPWLCRadhRpnZW6AT", "value": "1"}' -X POST -H 'Content-Type: application/json'
+$ curl http://localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/pay-address-code" -d '{"receiver_b58_address_code": "7Q6gtA5EqSxkEsqsf5p2j7qEHkA8fBZYNsfuWTZTQaFAqo3FPo8PvhrrUobZfXagrLopzpxqxGBs7Hphwhsc56ryWriPWLCRadhRpnZW6AT", "value": "1"}' -X POST -H 'Content-Type: application/json'
 
-{"sender_tx_receipt":{"key_images":["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132","7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"],"tombstone":2121}, ,"receiver_tx_receipt_list":[{"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71","spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""},"tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b","tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112","tombstone":2329,"confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}]}
+{"sender_tx_receipt":{"key_images":["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132","7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"],"tombstone":2121},
+ "receiver_tx_receipt_list":[{"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71","spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""},"tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b","tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112","tombstone":2329,"confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}]}
 ```
 
 #### Check the status of a transaction with a key image and tombstone block
@@ -119,7 +126,7 @@ This JSON can be passed directly to `build-and-submit` or you can change the amo
 #### Build and submit a payment from a monitor/subaddress to a request code
 Using the information in the `read-request`, creates and submits a transaction. If this succeeds, funds will be transferred.
 ```
-$ curl localhost:9090/monitors/fca4ffa1a1b1faf8ad775d0cf020426ba7f161720403a76126bc8e40550d9872/subaddresses/0/build-and-submit -d '{"receiver":{"view_public_key":"40f884563ff10fb1b37b589036db9abbf1ab7afcf88f17a4ea6ec0077e883263","spend_public_key":"ecf9f2fdb8714afd16446d530cf27f2775d9e356e17a6bba8ad395d16d1bbd45","fog_url":""},"value":"10","memo":"Please pay me"}' -X POST -H 'Content-Type: application/json'
+$ curl localhost:9090/monitors/<monitor_id>/subaddresses/0/build-and-submit -d '{"request_data": {"receiver":{"view_public_key":"40f884563ff10fb1b37b589036db9abbf1ab7afcf88f17a4ea6ec0077e883263","spend_public_key":"ecf9f2fdb8714afd16446d530cf27f2775d9e356e17a6bba8ad395d16d1bbd45","fog_url":""},"value":"10","memo":"Please pay me"}}' -X POST -H 'Content-Type: application/json'
 
 {"sender_tx_receipt":{"key_images":["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132","7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"],"tombstone":2121}, ,"receiver_tx_receipt_list":[{"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71","spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""},"tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b","tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112","tombstone":2329,"confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}]}
 ```
@@ -158,14 +165,14 @@ First, run the mobilecoind binary in offline mode, and run mobilecoind-json, bot
 On the airgapped machine, get the utxos in the local ledger.
 
 ```
-$ curl localhost:9090/monitors/<monitor_id>/subaddresses/0/utxos
+$ curl localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/utxos
 ```
 
 ### GenerateTx
 On the airgapped machine, generate a tx proposal.
 
 ```
-$ curl localhost:9090/monitors/<monitor-id>/subaddresses/0/generate-tx -d ‘{“input_list”: [<paste output of utxos response>], “transfer”: ‘$(cat request_code.json)’}’ -X POST -H ‘Content-Type: application/json’ > tx_proposal.json
+$ curl localhost:9090/monitors/<monitor-id>/subaddresses/<subaddress>/generate-tx -d ‘{“input_list”: [<paste output of utxos response>], “transfer”: ‘$(cat request_code.json)’}’ -X POST -H ‘Content-Type: application/json’ > tx_proposal.json
 ```
 
 ### Submit Propsoal

--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -87,8 +87,18 @@ $ curl http://localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/pay
        "value": "1"}' \
   -X POST -H 'Content-Type: application/json'
 
-{"sender_tx_receipt":{"key_images":["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132","7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"],"tombstone":2121},
- "receiver_tx_receipt_list":[{"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71","spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""},"tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b","tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112","tombstone":2329,"confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}]}
+{"sender_tx_receipt":{"key_images":
+                      ["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132",
+                      "7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"],
+                      "tombstone":2121},                      
+ "receiver_tx_receipt_list":[
+    {"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71",
+                  "spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d",
+                  "fog_report_url":"", "fog_authority_fingerprint_sig":"", "fog_report_id":""},
+    "tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b",
+    "tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112",
+    "tombstone":2329,
+    "confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}]}
 ```
 
 #### Check the status of a transaction with a key image and tombstone block
@@ -110,7 +120,14 @@ the list can be send to the recipient over a separate channel (e.g. a secure cha
 verify that they were paid by the sender.
 ```
 $ curl localhost:9090/tx/status-as-receiver \
-  -d '{"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71","spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""},"tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b","tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112","tombstone":2329,"confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}' -X POST -H 'Content-Type: application/json'
+  -d '{"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71",
+                    "spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d",
+                    "fog_report_url":"", "fog_authority_fingerprint_sig":"", "fog_report_id":""},
+        "tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b",
+        "tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112",
+        "tombstone":2329,
+        "confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}' \
+  -X POST -H 'Content-Type: application/json'
 
 {"status":"verified"}
 ```
@@ -121,7 +138,12 @@ A potential sender interpreting a b58 request code must first read the informati
 
 #### Generate a request code from a public address and optional other information
 ```
-$ curl localhost:9090/codes/request -d '{"receiver": {"view_public_key":"543b376e9d5b949dd8694f065d95a98a89e6f17a20c621621a808605d1904324","spend_public_key":"58dba855a885dd535dc5180af443abae67c790b860d5adadb4d6a2ecb71abd28","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""}, "value": "10", "memo": "Please pay me"}'  -X POST -H 'Content-Type: application/json'
+$ curl localhost:9090/codes/request \
+  -d '{"receiver": {"view_public_key":"543b376e9d5b949dd8694f065d95a98a89e6f17a20c621621a808605d1904324",
+                    "spend_public_key":"58dba855a885dd535dc5180af443abae67c790b860d5adadb4d6a2ecb71abd28",
+                    "fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""}, 
+        "value": "10", "memo": "Please pay me"}' \
+  -X POST -H 'Content-Type: application/json'
 
 {"request_code":"ufTwqVqF2rXmFVBZ1CWWS3ntdajVZGfZ5A2YZqAwhVnaVYrFpS9Z8iAg44CBGDeyjFDX8Hj4W7ZzArBn1xSp9wu8NriqQAogN8fUybKmoWgaz92kT4M7fbjRYKZmoY8"}
 ```
@@ -130,7 +152,10 @@ $ curl localhost:9090/codes/request -d '{"receiver": {"view_public_key":"543b376
 ```
 $ curl localhost:9090/codes/request/HUGpTreNKe4ziGAwDNYeW1iayWJgZ4DgiYRk9fw8E7f21PXQRUt4kbFsWBxzcJj12K6atUMuAyRNnwCybw5oJcm6xYXazdZzx4Tc5QuKdFdH2XSuUYM8pgQ1jq2ZBBi
 
-{"receiver":{"view_public_key":"40f884563ff10fb1b37b589036db9abbf1ab7afcf88f17a4ea6ec0077e883263","spend_public_key":"ecf9f2fdb8714afd16446d530cf27f2775d9e356e17a6bba8ad395d16d1bbd45","fog_url":""},"value":"10","memo":"Please pay me"}
+{"receiver":{"view_public_key":"40f884563ff10fb1b37b589036db9abbf1ab7afcf88f17a4ea6ec0077e883263",
+             "spend_public_key":"ecf9f2fdb8714afd16446d530cf27f2775d9e356e17a6bba8ad395d16d1bbd45",
+             "fog_url":""},
+ "value":"10","memo":"Please pay me"}
 ```
 This JSON can be passed directly to `build-and-submit` or you can change the amount if desired.
 
@@ -139,7 +164,18 @@ Using the information in the `read-request`, creates and submits a transaction. 
 ```
 $ curl localhost:9090/monitors/<monitor_id>/subaddresses/0/build-and-submit -d '{"request_data": {"receiver":{"view_public_key":"40f884563ff10fb1b37b589036db9abbf1ab7afcf88f17a4ea6ec0077e883263","spend_public_key":"ecf9f2fdb8714afd16446d530cf27f2775d9e356e17a6bba8ad395d16d1bbd45","fog_url":""},"value":"10","memo":"Please pay me"}}' -X POST -H 'Content-Type: application/json'
 
-{"sender_tx_receipt":{"key_images":["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132","7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"],"tombstone":2121}, ,"receiver_tx_receipt_list":[{"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71","spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d","fog_report_url":"","fog_authority_fingerprint_sig":"","fog_report_id":""},"tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b","tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112","tombstone":2329,"confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}]}
+{"sender_tx_receipt":{"key_images":
+                      ["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132",
+                      "7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"],
+                      "tombstone":2121},                      
+ "receiver_tx_receipt_list":[
+    {"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71",
+                  "spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d",
+                  "fog_report_url":"", "fog_authority_fingerprint_sig":"", "fog_report_id":""},
+    "tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b",
+    "tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112",
+    "tombstone":2329,
+    "confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}]}
 ```
 
 This returns receipt information that can be used by the sender to verify their transaction went through and also receipts to give to the receivers

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -188,7 +188,7 @@ impl From<&mc_mobilecoind_api::GetUnspentTxOutListResponse> for JsonUtxosRespons
 #[derive(Deserialize)]
 pub struct JsonCreateRequestCodeRequest {
     pub receiver: JsonPublicAddress,
-    pub value: Option<u64>,
+    pub value: Option<String>,
     pub memo: Option<String>,
 }
 
@@ -394,7 +394,7 @@ impl From<&mc_mobilecoind_api::ReceiverTxReceipt> for JsonReceiverTxReceipt {
 
 #[derive(Deserialize, Serialize)]
 pub struct JsonSendPaymentRequest {
-    pub request_code: JsonParseRequestCodeResponse,
+    pub request_data: JsonParseRequestCodeResponse,
     pub max_input_utxo_value: Option<String>, // String due to u64 limitation.
 }
 
@@ -419,8 +419,8 @@ impl From<&mc_mobilecoind_api::SendPaymentResponse> for JsonSendPaymentResponse 
 
 #[derive(Deserialize, Serialize)]
 pub struct JsonPayAddressCodeRequest {
-    pub receiver_b58_code: String,
-    pub amount: String,
+    pub receiver_b58_address_code: String,
+    pub value: String,
     pub max_input_utxo_value: Option<String>,
 }
 

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -194,13 +194,13 @@ pub struct JsonCreateRequestCodeRequest {
 
 #[derive(Serialize, Default)]
 pub struct JsonCreateRequestCodeResponse {
-    pub b58_code: String,
+    pub b58_request_code: String,
 }
 
 impl From<&mc_mobilecoind_api::CreateRequestCodeResponse> for JsonCreateRequestCodeResponse {
     fn from(src: &mc_mobilecoind_api::CreateRequestCodeResponse) -> Self {
         Self {
-            b58_code: String::from(src.get_b58_code()),
+            b58_request_code: String::from(src.get_b58_code()),
         }
     }
 }

--- a/tools/release-tests/mirror-json-test.py
+++ b/tools/release-tests/mirror-json-test.py
@@ -119,7 +119,7 @@ else:
 request_data = {"receiver": public_address, "value": "1", "memo": "Please pay me"}
 response = requests.post("http://localhost:9090/codes/request", json=request_data)
 if response.status_code == 200:
-    request_code = response.json()['b58_code']
+    request_code = response.json()['b58_request_code']
     print("Request code = %s" % str(request_code))
 else:
     print("Request code endpoint returned status code %d" % response.status_code)

--- a/tools/release-tests/mirror-json-test.py
+++ b/tools/release-tests/mirror-json-test.py
@@ -110,13 +110,13 @@ response = requests.get("http://localhost:9090/monitors/%s/subaddresses/0/public
 if response.status_code == 200:
     public_address = response.json()
     print("Public address = %s" % str(public_address))
+    b58_address_code = response.json()['b58_address_code']
 else:
     print("Public address endpoint returned status code %d" % response.status_code)
     shutdown(1)
 
 # Generate a request code for the account
-# TODO: This call takes an integer for value, while the payment request takes a string
-request_data = {"receiver": public_address, "value": 1, "memo": "Please pay me"}
+request_data = {"receiver": public_address, "value": "1", "memo": "Please pay me"}
 response = requests.post("http://localhost:9090/codes/request", json=request_data)
 if response.status_code == 200:
     request_code = response.json()['b58_code']
@@ -156,13 +156,39 @@ if balance == 0:
 
 # Initiate a transfer, to the same account
 url = "http://localhost:9090/monitors/%s/subaddresses/0/build-and-submit" % monitor_id
-payment_data = {"request_code": {"receiver": public_address, "value": "1", "memo": "Please pay me"}}
+payment_data = {"request_data": {"receiver": public_address, "value": "1", "memo": "Please pay me"}}
 response = requests.post(url, json=payment_data)
 if response.status_code == 200:
     receipts = response.json()
     receiver_tx_receipt = response.json()['receiver_tx_receipt_list'][0]
 else:
     print("build-and-submit returned status code %d" % response.status_code)
+    shutdown(1)
+
+print("Polling for transaction status")
+while True:
+    response = requests.post("http://localhost:9090/tx/status-as-sender", json=receipts)
+    if response.status_code == 200:
+        status = response.json()['status']
+        print('status = %s' % status)
+        if status == 'verified': break
+        time.sleep(1)
+    else:
+        print("status-as-sender returned status code %d" % response.status_code)
+        shutdown(1)
+
+# Monitor must update to avoid a double-spend
+time.sleep(10)
+
+# Test pay address code also
+url = "http://localhost:9090/monitors/%s/subaddresses/0/pay-address-code" % monitor_id
+payment_data = {"receiver_b58_address_code": b58_address_code, "value": "1"}
+response = requests.post(url, json=payment_data)
+if response.status_code == 200:
+    receipts = response.json()
+    receiver_tx_receipt = response.json()['receiver_tx_receipt_list'][0]
+else:
+    print("pay-address-code returned status code %d" % response.status_code)
     shutdown(1)
 
 print("Polling for transaction status")


### PR DESCRIPTION
### Motivation

There were a few inconsistent names and values in the JSON gateway and the README was missing some useful calls.

### In this PR
* Change `amount` to `value` for all literal values
* Use strings for u64 amounts (JSON limitation)
* Add `pay-address-code` as a simple payment flow to README
* Update integration test with new fields / values / `pay-address-code`

### Future Work
* Make sure other documentation is in-sync
* Cut a new release