### PR TITLE
MCC-1818: Optional authentication support in consensus-service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3522,6 +3522,7 @@ version = "1.0.0"
 dependencies = [
  "hex 0.4.2",
  "mc-util-grpc",
+ "percent-encoding 2.1.0",
  "serde",
  "structopt",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3517,6 +3517,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-util-grpc-token-generator"
+version = "1.0.0"
+dependencies = [
+ "hex 0.4.2",
+ "mc-util-grpc",
+ "serde",
+ "structopt",
+]
+
+[[package]]
 name = "mc-util-host-cert"
 version = "1.0.0"
 
@@ -3642,6 +3652,7 @@ dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
  "mc-util-host-cert",
+ "percent-encoding 2.1.0",
  "rand 0.7.3",
  "rand_hc 0.2.0",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3521,6 +3521,7 @@ name = "mc-util-grpc-token-generator"
 version = "1.0.0"
 dependencies = [
  "hex 0.4.2",
+ "mc-common",
  "mc-util-grpc",
  "percent-encoding 2.1.0",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.2.3",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1535,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac 0.8.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
+dependencies = [
+ "crypto-mac 0.9.1",
  "digest 0.9.0",
 ]
 
@@ -3472,9 +3492,14 @@ dependencies = [
 name = "mc-util-grpc"
 version = "1.0.0"
 dependencies = [
+ "base64 0.12.1",
+ "digest 0.9.0",
+ "displaydoc",
  "futures 0.3.5",
  "grpcio",
+ "hex 0.4.2",
  "hex_fmt",
+ "hmac 0.9.0",
  "lazy_static",
  "mc-common",
  "mc-util-build-grpc",
@@ -3486,6 +3511,9 @@ dependencies = [
  "prost",
  "protobuf",
  "rand 0.6.5",
+ "sha2 0.9.1",
+ "subtle 2.2.3",
+ "zeroize 1.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ members = [
     "util/from-random",
     "util/generate-sample-ledger",
     "util/grpc",
+    "util/grpc-token-generator",
     "util/host-cert",
     "util/keyfile",
     "util/lmdb",

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -15,6 +15,8 @@ mod responder_id;
 pub mod lru;
 pub use lru::LruCache;
 
+pub mod time;
+
 pub use node_id::NodeID;
 pub use responder_id::{ResponderId, ResponderIdParseError};
 
@@ -51,12 +53,5 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(feature = "loggers")] {
         pub mod sentry;
-    }
-}
-
-// Time
-cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
-        pub mod time;
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -53,3 +53,10 @@ cfg_if::cfg_if! {
         pub mod sentry;
     }
 }
+
+// Time
+cfg_if::cfg_if! {
+    if #[cfg(feature = "std")] {
+        pub mod time;
+    }
+}

--- a/common/src/time.rs
+++ b/common/src/time.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! Utilities for handling time.
+
+use std::{
+    fmt::Debug,
+    sync::{Arc, Mutex},
+    time::{Duration, SystemTime, SystemTimeError},
+};
+
+/// Abstraction for getting the current time.
+pub trait TimeProvider {
+    type Error: Clone + Debug;
+
+    /// Get the duration of time passed since the unix epoch.
+    fn from_epoch(&self) -> Result<Duration, Self::Error>;
+}
+
+/// An implementation of TimeProvider that relies on Rust's builtin `SystemTime`.
+#[derive(Clone, Debug, Default)]
+pub struct SystemTimeProvider;
+
+impl TimeProvider for SystemTimeProvider {
+    type Error = SystemTimeError;
+
+    fn from_epoch(&self) -> Result<Duration, Self::Error> {
+        SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)
+    }
+}
+
+/// A mock time provider that always returns the same value.
+#[derive(Clone, Debug)]
+pub struct MockTimeProvider {
+    cur_from_epoch: Arc<Mutex<Duration>>,
+}
+
+impl Default for MockTimeProvider {
+    fn default() -> Self {
+        Self {
+            cur_from_epoch: Arc::new(Mutex::new(
+                SystemTimeProvider::default()
+                    .from_epoch()
+                    .expect("failed getting initial value for cur_from_epoch"),
+            )),
+        }
+    }
+}
+
+impl TimeProvider for MockTimeProvider {
+    type Error = ();
+
+    fn from_epoch(&self) -> Result<Duration, Self::Error> {
+        Ok(*self.cur_from_epoch.lock().expect("mutex poisoned"))
+    }
+}
+
+impl MockTimeProvider {
+    pub fn set_cur_from_epoch(&self, new_cur_from_epoch: Duration) {
+        let mut inner = self.cur_from_epoch.lock().expect("mutex poisoned");
+        *inner = new_cur_from_epoch;
+    }
+}
+
+// Blanket implementations
+
+impl<TP: TimeProvider> TimeProvider for Arc<TP> {
+    type Error = TP::Error;
+
+    fn from_epoch(&self) -> Result<Duration, Self::Error> {
+        (**self).from_epoch()
+    }
+}
+
+impl<TP: TimeProvider> TimeProvider for Box<TP> {
+    type Error = TP::Error;
+
+    fn from_epoch(&self) -> Result<Duration, Self::Error> {
+        (**self).from_epoch()
+    }
+}

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -44,7 +44,7 @@ pub trait AttestedConnection: Connection {
         let result = func(self);
 
         if let Err(GrpcError::RpcFailure(rpc_status)) = &result {
-            if rpc_status.status == RpcStatusCode::UNAUTHENTICATED {
+            if rpc_status.status == RpcStatusCode::PERMISSION_DENIED {
                 self.deattest();
             }
         }

--- a/consensus/service/src/attested_api_service.rs
+++ b/consensus/service/src/attested_api_service.rs
@@ -130,7 +130,7 @@ mod peer_tests {
         ChannelBuilder, Environment, Error as GrpcError, RpcStatusCode, Server, ServerBuilder,
     };
     use mc_attest_api::attest_grpc::{self, AttestedApiClient};
-    use mc_common::logger::test_with_logger;
+    use mc_common::{logger::test_with_logger, time::SystemTimeProvider};
     use mc_consensus_enclave_mock::MockConsensusEnclave;
     use mc_util_grpc::auth::TokenAuthenticator;
     use std::{
@@ -162,7 +162,11 @@ mod peer_tests {
     #[test_with_logger]
     // `auth` should reject unauthenticated responses when configured with an authenticator.
     fn test_peer_auth_unauthenticated(logger: Logger) {
-        let authenticator = Arc::new(TokenAuthenticator::new([1; 32], Duration::from_secs(60)));
+        let authenticator = Arc::new(TokenAuthenticator::new(
+            [1; 32],
+            Duration::from_secs(60),
+            SystemTimeProvider::default(),
+        ));
         let enclave = Arc::new(MockConsensusEnclave::new());
 
         let attested_api_service =
@@ -191,7 +195,7 @@ mod client_tests {
         ChannelBuilder, Environment, Error as GrpcError, RpcStatusCode, Server, ServerBuilder,
     };
     use mc_attest_api::attest_grpc::{self, AttestedApiClient};
-    use mc_common::logger::test_with_logger;
+    use mc_common::{logger::test_with_logger, time::SystemTimeProvider};
     use mc_consensus_enclave_mock::MockConsensusEnclave;
     use mc_util_grpc::auth::TokenAuthenticator;
     use std::{
@@ -225,7 +229,11 @@ mod client_tests {
     #[test_with_logger]
     // `auth` should reject unauthenticated responses when configured with an authenticator.
     fn test_client_auth_unauthenticated(logger: Logger) {
-        let authenticator = Arc::new(TokenAuthenticator::new([1; 32], Duration::from_secs(60)));
+        let authenticator = Arc::new(TokenAuthenticator::new(
+            [1; 32],
+            Duration::from_secs(60),
+            SystemTimeProvider::default(),
+        ));
         let enclave = Arc::new(MockConsensusEnclave::new());
 
         let attested_api_service =

--- a/consensus/service/src/attested_api_service.rs
+++ b/consensus/service/src/attested_api_service.rs
@@ -133,7 +133,10 @@ mod peer_tests {
     use mc_common::logger::test_with_logger;
     use mc_consensus_enclave_mock::MockConsensusEnclave;
     use mc_util_grpc::auth::TokenAuthenticator;
-    use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+    use std::{
+        sync::atomic::{AtomicUsize, Ordering::SeqCst},
+        time::Duration,
+    };
 
     fn get_free_port() -> u16 {
         static PORT_NR: AtomicUsize = AtomicUsize::new(0);
@@ -159,7 +162,7 @@ mod peer_tests {
     #[test_with_logger]
     // `auth` should reject unauthenticated responses when configured with an authenticator.
     fn test_peer_auth_unauthenticated(logger: Logger) {
-        let authenticator = Arc::new(TokenAuthenticator::new([1; 32]));
+        let authenticator = Arc::new(TokenAuthenticator::new([1; 32], Duration::from_secs(60)));
         let enclave = Arc::new(MockConsensusEnclave::new());
 
         let attested_api_service =
@@ -191,11 +194,14 @@ mod client_tests {
     use mc_common::logger::test_with_logger;
     use mc_consensus_enclave_mock::MockConsensusEnclave;
     use mc_util_grpc::auth::TokenAuthenticator;
-    use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+    use std::{
+        sync::atomic::{AtomicUsize, Ordering::SeqCst},
+        time::Duration,
+    };
 
     fn get_free_port() -> u16 {
         static PORT_NR: AtomicUsize = AtomicUsize::new(0);
-        PORT_NR.fetch_add(1, SeqCst) as u16 + 30300
+        PORT_NR.fetch_add(1, SeqCst) as u16 + 30350
     }
 
     /// Starts the service on localhost and connects a client to it.
@@ -219,7 +225,7 @@ mod client_tests {
     #[test_with_logger]
     // `auth` should reject unauthenticated responses when configured with an authenticator.
     fn test_client_auth_unauthenticated(logger: Logger) {
-        let authenticator = Arc::new(TokenAuthenticator::new([1; 32]));
+        let authenticator = Arc::new(TokenAuthenticator::new([1; 32], Duration::from_secs(60)));
         let enclave = Arc::new(MockConsensusEnclave::new());
 
         let attested_api_service =

--- a/consensus/service/src/bin/main.rs
+++ b/consensus/service/src/bin/main.rs
@@ -4,7 +4,10 @@
 
 use mc_attest_core::DEBUG_ENCLAVE;
 use mc_attest_net::{Client, RaClient};
-use mc_common::logger::{create_app_logger, log, o};
+use mc_common::{
+    logger::{create_app_logger, log, o},
+    time::SystemTimeProvider,
+};
 use mc_consensus_enclave::{ConsensusServiceSgxEnclave, ENCLAVE_FILE};
 use mc_consensus_service::{
     config::Config,
@@ -96,6 +99,7 @@ fn main() -> Result<(), ConsensusServiceError> {
         local_ledger,
         ias_client,
         Arc::new(tx_manager),
+        Arc::new(SystemTimeProvider::default()),
         logger.clone(),
     );
     consensus_service

--- a/consensus/service/src/blockchain_api_service.rs
+++ b/consensus/service/src/blockchain_api_service.rs
@@ -158,7 +158,7 @@ impl<L: Ledger + Clone> BlockchainApi for BlockchainApiService<L> {
 mod tests {
     use super::*;
     use grpcio::{ChannelBuilder, Environment, Error as GrpcError, Server, ServerBuilder};
-    use mc_common::logger::test_with_logger;
+    use mc_common::{logger::test_with_logger, time::SystemTimeProvider};
     use mc_consensus_api::consensus_common_grpc::{self, BlockchainApiClient};
     use mc_transaction_core_test_utils::{create_ledger, initialize_ledger, AccountKey};
     use mc_util_grpc::auth::{AnonymousAuthenticator, TokenAuthenticator};
@@ -219,7 +219,11 @@ mod tests {
     // authenticator.
     fn test_get_last_block_info_rejects_unauthenticated(logger: Logger) {
         let ledger_db = create_ledger();
-        let authenticator = Arc::new(TokenAuthenticator::new([1; 32], Duration::from_secs(60)));
+        let authenticator = Arc::new(TokenAuthenticator::new(
+            [1; 32],
+            Duration::from_secs(60),
+            SystemTimeProvider::default(),
+        ));
 
         let blockchain_api_service = BlockchainApiService::new(ledger_db, authenticator, logger);
 
@@ -331,7 +335,11 @@ mod tests {
     // authenticator.
     fn test_get_blocks_rejects_unauthenticated(logger: Logger) {
         let ledger_db = create_ledger();
-        let authenticator = Arc::new(TokenAuthenticator::new([1; 32], Duration::from_secs(60)));
+        let authenticator = Arc::new(TokenAuthenticator::new(
+            [1; 32],
+            Duration::from_secs(60),
+            SystemTimeProvider::default(),
+        ));
 
         let blockchain_api_service = BlockchainApiService::new(ledger_db, authenticator, logger);
 

--- a/consensus/service/src/blockchain_api_service.rs
+++ b/consensus/service/src/blockchain_api_service.rs
@@ -163,7 +163,10 @@ mod tests {
     use mc_transaction_core_test_utils::{create_ledger, initialize_ledger, AccountKey};
     use mc_util_grpc::auth::{AnonymousAuthenticator, TokenAuthenticator};
     use rand::{rngs::StdRng, SeedableRng};
-    use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+    use std::{
+        sync::atomic::{AtomicUsize, Ordering::SeqCst},
+        time::Duration,
+    };
 
     fn get_free_port() -> u16 {
         static PORT_NR: AtomicUsize = AtomicUsize::new(0);
@@ -216,7 +219,7 @@ mod tests {
     // authenticator.
     fn test_get_last_block_info_rejects_unauthenticated(logger: Logger) {
         let ledger_db = create_ledger();
-        let authenticator = Arc::new(TokenAuthenticator::new([1; 32]));
+        let authenticator = Arc::new(TokenAuthenticator::new([1; 32], Duration::from_secs(60)));
 
         let blockchain_api_service = BlockchainApiService::new(ledger_db, authenticator, logger);
 
@@ -328,7 +331,7 @@ mod tests {
     // authenticator.
     fn test_get_blocks_rejects_unauthenticated(logger: Logger) {
         let ledger_db = create_ledger();
-        let authenticator = Arc::new(TokenAuthenticator::new([1; 32]));
+        let authenticator = Arc::new(TokenAuthenticator::new([1; 32], Duration::from_secs(60)));
 
         let blockchain_api_service = BlockchainApiService::new(ledger_db, authenticator, logger);
 

--- a/consensus/service/src/client_api_service.rs
+++ b/consensus/service/src/client_api_service.rs
@@ -150,6 +150,7 @@ mod client_api_tests {
     use mc_attest_api::attest::Message;
     use mc_common::{
         logger::{test_with_logger, Logger},
+        time::SystemTimeProvider,
         NodeID, ResponderId,
     };
     use mc_consensus_api::{
@@ -493,7 +494,11 @@ mod client_api_tests {
             |_tx_hash: TxHash, _node_id: Option<&NodeID>, _responder_id: Option<&ResponderId>| {},
         );
 
-        let authenticator = TokenAuthenticator::new([1; 32], Duration::from_secs(60));
+        let authenticator = TokenAuthenticator::new(
+            [1; 32],
+            Duration::from_secs(60),
+            SystemTimeProvider::default(),
+        );
 
         let instance = ClientApiService::new(
             Arc::new(enclave),

--- a/consensus/service/src/client_api_service.rs
+++ b/consensus/service/src/client_api_service.rs
@@ -164,9 +164,12 @@ mod client_api_tests {
     };
     use mc_util_grpc::auth::{AnonymousAuthenticator, TokenAuthenticator};
     use serial_test_derive::serial;
-    use std::sync::{
-        atomic::{AtomicUsize, Ordering::SeqCst},
-        Arc,
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering::SeqCst},
+            Arc,
+        },
+        time::Duration,
     };
 
     fn get_free_port() -> u16 {
@@ -490,7 +493,7 @@ mod client_api_tests {
             |_tx_hash: TxHash, _node_id: Option<&NodeID>, _responder_id: Option<&ResponderId>| {},
         );
 
-        let authenticator = TokenAuthenticator::new([1; 32]);
+        let authenticator = TokenAuthenticator::new([1; 32], Duration::from_secs(60));
 
         let instance = ClientApiService::new(
             Arc::new(enclave),

--- a/consensus/service/src/config.rs
+++ b/consensus/service/src/config.rs
@@ -85,7 +85,7 @@ pub struct Config {
 
     /// Enables authenticating client requests using Authorization tokens using the provided
     /// hex-encoded 32 bytes shared secret.
-    #[structopt(long, parse(try_from_str=from_hex_32))]
+    #[structopt(long, parse(try_from_str=hex::FromHex::from_hex))]
     pub client_auth_token_secret: Option<[u8; 32]>,
 
     /// Maximal client authentication token lifetime, in seconds (only relevant when
@@ -105,20 +105,6 @@ fn keypair_from_base64(private_key: &str) -> Result<Arc<Ed25519Pair>, String> {
     let secret_key = Ed25519Private::try_from_der(privkey_bytes.as_slice())
         .map_err(|err| format!("Could not get Ed25519Private from der {:?}", err))?;
     Ok(Arc::new(Ed25519Pair::from(secret_key)))
-}
-
-/// Converts a hex-encoded string into an array of 32 bytes.
-fn from_hex_32(src: &str) -> Result<[u8; 32], String> {
-    if src.len() != 64 {
-        return Err(format!(
-            "Invalid length, got {} while expecting 64",
-            src.len()
-        ));
-    }
-
-    let mut retval = [0u8; 32];
-    hex::decode_to_slice(src, &mut retval).map_err(|err| format!("Invalid hex string: {}", err))?;
-    Ok(retval)
 }
 
 /// Converts a string containing number of seconds to a Duration object.

--- a/consensus/service/src/config.rs
+++ b/consensus/service/src/config.rs
@@ -109,17 +109,16 @@ fn keypair_from_base64(private_key: &str) -> Result<Arc<Ed25519Pair>, String> {
 
 /// Converts a hex-encoded string into an array of 32 bytes.
 fn from_hex_32(src: &str) -> Result<[u8; 32], String> {
-    let bytes = hex::decode(src).map_err(|err| format!("Invalid input: {}", err))?;
-    if bytes.len() != 32 {
+    if src.len() != 64 {
         return Err(format!(
-            "Invalid input length, got {} bytes while expecting 32",
-            bytes.len()
+            "Invalid length, got {} while expecting 64",
+            src.len()
         ));
     }
 
-    let mut output = [0; 32];
-    output.copy_from_slice(&bytes[..]);
-    Ok(output)
+    let mut retval = [0u8; 32];
+    hex::decode_to_slice(src, &mut retval).map_err(|err| format!("Invalid hex string: {}", err))?;
+    Ok(retval)
 }
 
 /// Converts a string containing number of seconds to a Duration object.

--- a/consensus/service/src/config.rs
+++ b/consensus/service/src/config.rs
@@ -524,13 +524,4 @@ mod tests {
 
         assert!(keypair_from_base64(private_key).is_ok());
     }
-
-    #[test]
-    /// Should successfully decode a 32-byte array encoded as a hex string.
-    fn test_from_hex_32() {
-        assert!(from_hex_32("abcd").is_err());
-
-        let bytes = [3; 32];
-        assert_eq!(bytes, from_hex_32(&hex::encode(&bytes)).unwrap());
-    }
 }

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -708,6 +708,8 @@ impl<
                     "admin_listen_uri": config.admin_listen_uri,
                     "ledger_path": config.ledger_path,
                     "scp_debug_dump": config.scp_debug_dump,
+                    "client_auth_token_enabled": config.client_auth_token_secret.map(|_| true).unwrap_or(false),
+                    "client_auth_token_max_lifetime": config.client_auth_token_max_lifetime.as_secs(),
                 },
                 "network": config.network(),
                 "status": {

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -16,6 +16,7 @@ use mc_attest_enclave_api::{ClientSession, PeerSession};
 use mc_attest_net::RaClient;
 use mc_common::{
     logger::{log, Logger},
+    time::TimeProvider,
     NodeID, ResponderId,
 };
 use mc_connection::{Connection, ConnectionManager};
@@ -127,12 +128,13 @@ impl<
         TXM: TxManager + Clone + Send + Sync + 'static,
     > ConsensusService<E, R, TXM>
 {
-    pub fn new(
+    pub fn new<TP: TimeProvider + Send + Sync + 'static>(
         config: Config,
         enclave: E,
         ledger_db: LedgerDB,
         ra_client: R,
         tx_manager: Arc<TXM>,
+        time_provider: Arc<TP>,
         logger: Logger,
     ) -> Self {
         // gRPC environment.
@@ -186,6 +188,7 @@ impl<
                 Arc::new(TokenAuthenticator::new(
                     *shared_secret,
                     config.client_auth_token_max_lifetime,
+                    time_provider.clone(),
                 ))
             } else {
                 Arc::new(AnonymousAuthenticator::default())

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -183,7 +183,10 @@ impl<
         // Authenticator
         let client_authenticator: Arc<dyn Authenticator + Sync + Send> =
             if let Some(shared_secret) = config.client_auth_token_secret.as_ref() {
-                Arc::new(TokenAuthenticator::new(shared_secret.clone()))
+                Arc::new(TokenAuthenticator::new(
+                    shared_secret.clone(),
+                    config.client_auth_token_max_lifetime,
+                ))
             } else {
                 Arc::new(AnonymousAuthenticator::default())
             };

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -128,7 +128,7 @@ impl<
         TXM: TxManager + Clone + Send + Sync + 'static,
     > ConsensusService<E, R, TXM>
 {
-    pub fn new<TP: TimeProvider + Send + Sync + 'static>(
+    pub fn new<TP: TimeProvider + 'static>(
         config: Config,
         enclave: E,
         ledger_db: LedgerDB,

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -184,7 +184,7 @@ impl<
         let client_authenticator: Arc<dyn Authenticator + Sync + Send> =
             if let Some(shared_secret) = config.client_auth_token_secret.as_ref() {
                 Arc::new(TokenAuthenticator::new(
-                    shared_secret.clone(),
+                    *shared_secret,
                     config.client_auth_token_max_lifetime,
                 ))
             } else {

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -27,9 +27,8 @@ use mc_peers::{PeerConnection, ThreadedBroadcaster, VerifiedConsensusMsg};
 use mc_sgx_report_cache_untrusted::{Error as ReportCacheError, ReportCacheThread};
 use mc_transaction_core::tx::TxHash;
 use mc_util_grpc::{
-    auth::{anonymous_authenticator::AnonymousAuthenticator, Authenticator},
-    AdminServer, BuildInfoService, ConnectionUriGrpcioServer, GetConfigJsonFn, HealthCheckStatus,
-    HealthService,
+    auth::anonymous_authenticator::AnonymousAuthenticator, AdminServer, BuildInfoService,
+    ConnectionUriGrpcioServer, GetConfigJsonFn, HealthCheckStatus, HealthService,
 };
 use mc_util_uri::{ConnectionUri, ConsensusPeerUriApi};
 use once_cell::sync::OnceCell;
@@ -290,8 +289,7 @@ impl<
         );
 
         // Setup GRPC services.
-        let authenticator: Arc<dyn Authenticator + Send + Sync> =
-            Arc::new(AnonymousAuthenticator::default());
+        let authenticator = Arc::new(AnonymousAuthenticator::default());
 
         let client_service = consensus_client_grpc::create_consensus_client_api(
             client_api_service::ClientApiService::new(

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -188,7 +188,7 @@ impl<
                 Arc::new(TokenAuthenticator::new(
                     *shared_secret,
                     config.client_auth_token_max_lifetime,
-                    time_provider.clone(),
+                    time_provider,
                 ))
             } else {
                 Arc::new(AnonymousAuthenticator::default())

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -27,6 +27,7 @@ use mc_peers::{PeerConnection, ThreadedBroadcaster, VerifiedConsensusMsg};
 use mc_sgx_report_cache_untrusted::{Error as ReportCacheError, ReportCacheThread};
 use mc_transaction_core::tx::TxHash;
 use mc_util_grpc::{
+    auth::{anonymous_authenticator::AnonymousAuthenticator, Authenticator},
     AdminServer, BuildInfoService, ConnectionUriGrpcioServer, GetConfigJsonFn, HealthCheckStatus,
     HealthService,
 };
@@ -289,6 +290,9 @@ impl<
         );
 
         // Setup GRPC services.
+        let authenticator: Arc<dyn Authenticator + Send + Sync> =
+            Arc::new(AnonymousAuthenticator::default());
+
         let client_service = consensus_client_grpc::create_consensus_client_api(
             client_api_service::ClientApiService::new(
                 Arc::new(self.enclave.clone()),
@@ -296,6 +300,7 @@ impl<
                 Arc::new(self.ledger_db.clone()),
                 self.tx_manager.clone(),
                 self.create_is_serving_user_requests_fn(),
+                authenticator,
                 self.logger.clone(),
             ),
         );

--- a/consensus/service/src/grpc_error.rs
+++ b/consensus/service/src/grpc_error.rs
@@ -99,10 +99,10 @@ impl From<ConsensusGrpcError> for RpcStatus {
                 Some("Temporarily not serving requests".into()),
             ),
             ConsensusGrpcError::Enclave(EnclaveError::Attest(err)) => {
-                global_log::error!("Unauthenticated: {}", err);
+                global_log::error!("Permission denied: {}", err);
                 RpcStatus::new(
-                    RpcStatusCode::UNAUTHENTICATED,
-                    Some("Unauthenticated".into()),
+                    RpcStatusCode::PERMISSION_DENIED,
+                    Some("Permission Denied (attestation)".into()),
                 )
             }
             ConsensusGrpcError::Other(err) => RpcStatus::new(RpcStatusCode::INTERNAL, Some(err)),

--- a/util/grpc-token-generator/Cargo.toml
+++ b/util/grpc-token-generator/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/bin/main.rs"
 mc-util-grpc = { path = "../grpc" }
 
 hex = "0.4"
+percent-encoding = "2.1.0"
 structopt = "0.3"
 
 [build-dependencies]

--- a/util/grpc-token-generator/Cargo.toml
+++ b/util/grpc-token-generator/Cargo.toml
@@ -9,6 +9,7 @@ name = "mc-util-grpc-token-generator"
 path = "src/bin/main.rs"
 
 [dependencies]
+mc-common = { path = "../../common", features = ["std"] }
 mc-util-grpc = { path = "../grpc" }
 
 hex = "0.4"

--- a/util/grpc-token-generator/Cargo.toml
+++ b/util/grpc-token-generator/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mc-util-grpc-token-generator"
+version = "1.0.0"
+authors = ["MobileCoin"]
+edition = "2018"
+
+[[bin]]
+name = "mc-util-grpc-token-generator"
+path = "src/bin/main.rs"
+
+[dependencies]
+mc-util-grpc = { path = "../grpc" }
+
+hex = "0.4"
+structopt = "0.3"
+
+[build-dependencies]
+# Even though this is unused, it needs to be here otherwise Cargo brings in some weird mixture of packages/features that refuses to compile.
+# Go figure ¯\_(ツ)_/¯
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }

--- a/util/grpc-token-generator/src/bin/main.rs
+++ b/util/grpc-token-generator/src/bin/main.rs
@@ -3,6 +3,7 @@
 //! A utility for generating GRPC authentication tokens.
 
 use mc_util_grpc::auth::TokenBasicCredentialsGenerator;
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use structopt::StructOpt;
 
 #[derive(Clone, Debug, StructOpt)]
@@ -28,6 +29,10 @@ fn main() {
         .expect("Failed generating token");
     println!("Username: {}", creds.username());
     println!("Password: {}", creds.password());
+    println!(
+        "Password (percent-encoded): {}",
+        utf8_percent_encode(creds.password(), NON_ALPHANUMERIC).to_string()
+    );
 }
 
 /// Converts a hex-encoded string into an array of 32 bytes.

--- a/util/grpc-token-generator/src/bin/main.rs
+++ b/util/grpc-token-generator/src/bin/main.rs
@@ -2,6 +2,7 @@
 
 //! A utility for generating GRPC authentication tokens.
 
+use mc_common::time::SystemTimeProvider;
 use mc_util_grpc::auth::TokenBasicCredentialsGenerator;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use structopt::StructOpt;
@@ -23,7 +24,8 @@ pub struct Config {
 
 fn main() {
     let config = Config::from_args();
-    let token_generator = TokenBasicCredentialsGenerator::new(config.shared_secret);
+    let token_generator =
+        TokenBasicCredentialsGenerator::new(config.shared_secret, SystemTimeProvider::default());
     let creds = token_generator
         .generate_for(&config.username)
         .expect("Failed generating token");
@@ -37,15 +39,14 @@ fn main() {
 
 /// Converts a hex-encoded string into an array of 32 bytes.
 fn from_hex_32(src: &str) -> Result<[u8; 32], String> {
-    let bytes = hex::decode(src).map_err(|err| format!("Invalid input: {}", err))?;
-    if bytes.len() != 32 {
+    if src.len() != 64 {
         return Err(format!(
-            "Invalid input length, got {} bytes while expecting 32",
-            bytes.len()
+            "Invalid length, got {} while expecting 64",
+            src.len()
         ));
     }
 
-    let mut output = [0; 32];
-    output.copy_from_slice(&bytes[..]);
-    Ok(output)
+    let mut retval = [0u8; 32];
+    hex::decode_to_slice(src, &mut retval).map_err(|err| format!("Invalid hex string: {}", err))?;
+    Ok(retval)
 }

--- a/util/grpc-token-generator/src/bin/main.rs
+++ b/util/grpc-token-generator/src/bin/main.rs
@@ -14,7 +14,7 @@ use structopt::StructOpt;
 )]
 pub struct Config {
     /// Secret shared between the token generator and the token validator.
-    #[structopt(long, parse(try_from_str=from_hex_32))]
+    #[structopt(long, parse(try_from_str=hex::FromHex::from_hex))]
     pub shared_secret: [u8; 32],
 
     /// Username to generator the token for
@@ -35,18 +35,4 @@ fn main() {
         "Password (percent-encoded): {}",
         utf8_percent_encode(creds.password(), NON_ALPHANUMERIC).to_string()
     );
-}
-
-/// Converts a hex-encoded string into an array of 32 bytes.
-fn from_hex_32(src: &str) -> Result<[u8; 32], String> {
-    if src.len() != 64 {
-        return Err(format!(
-            "Invalid length, got {} while expecting 64",
-            src.len()
-        ));
-    }
-
-    let mut retval = [0u8; 32];
-    hex::decode_to_slice(src, &mut retval).map_err(|err| format!("Invalid hex string: {}", err))?;
-    Ok(retval)
 }

--- a/util/grpc-token-generator/src/bin/main.rs
+++ b/util/grpc-token-generator/src/bin/main.rs
@@ -23,7 +23,7 @@ pub struct Config {
 
 fn main() {
     let config = Config::from_args();
-    let token_generator = TokenBasicCredentialsGenerator::new(config.shared_secret.clone());
+    let token_generator = TokenBasicCredentialsGenerator::new(config.shared_secret);
     let creds = token_generator
         .generate_for(&config.username)
         .expect("Failed generating token");

--- a/util/grpc-token-generator/src/bin/main.rs
+++ b/util/grpc-token-generator/src/bin/main.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! A utility for generating GRPC authentication tokens.
+
+use mc_util_grpc::auth::TokenBasicCredentialsGenerator;
+use structopt::StructOpt;
+
+#[derive(Clone, Debug, StructOpt)]
+#[structopt(
+    name = "mc-util-grpc-token-generator",
+    about = "GRPC Token Generator Utility"
+)]
+pub struct Config {
+    /// Secret shared between the token generator and the token validator.
+    #[structopt(long, parse(try_from_str=from_hex_32))]
+    pub shared_secret: [u8; 32],
+
+    /// Username to generator the token for
+    #[structopt(long)]
+    pub username: String,
+}
+
+fn main() {
+    let config = Config::from_args();
+    let token_generator = TokenBasicCredentialsGenerator::new(config.shared_secret.clone());
+    let creds = token_generator
+        .generate_for(&config.username)
+        .expect("Failed generating token");
+    println!("Username: {}", creds.username());
+    println!("Password: {}", creds.password());
+}
+
+/// Converts a hex-encoded string into an array of 32 bytes.
+fn from_hex_32(src: &str) -> Result<[u8; 32], String> {
+    let bytes = hex::decode(src).map_err(|err| format!("Invalid input: {}", err))?;
+    if bytes.len() != 32 {
+        return Err(format!(
+            "Invalid input length, got {} bytes while expecting 32",
+            bytes.len()
+        ));
+    }
+
+    let mut output = [0; 32];
+    output.copy_from_slice(&bytes[..]);
+    Ok(output)
+}

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -12,14 +12,22 @@ mc-util-metrics = { path = "../metrics" }
 mc-util-serial = { path = "../serial", features = ["std"]}
 mc-util-uri = { path = "../uri" }
 
+base64 = "0.12"
+digest = "0.9"
+displaydoc = { version = "0.1.7", default-features = false }
 futures = "0.3"
 grpcio = "0.6.0"
+hex = "0.4"
 hex_fmt = "0.3"
+hmac = "0.9"
 lazy_static = "1.4"
 prometheus = "0.9"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 protobuf = "2.12"
 rand = "0.6.5"
+sha2 = "0.9"
+subtle = { version = "2.2", default-features = false, features = ["i128"] }
+zeroize = { version = "1", default-features = false }
 
 [build-dependencies]
 mc-util-build-grpc = { path = "../build/grpc" }

--- a/util/grpc/src/auth/anonymous_authenticator.rs
+++ b/util/grpc/src/auth/anonymous_authenticator.rs
@@ -1,0 +1,17 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! GRPC authenticator that authenticates everything as an anonymous user.
+
+use super::*;
+
+/// The username returned for all authenticate calls.
+pub const ANONYMOUS_USER: &str = "<anonymous>";
+
+#[derive(Default)]
+pub struct AnonymousAuthenticator;
+
+impl Authenticator for AnonymousAuthenticator {
+    fn authenticate(&self, _maybe_credentials: Option<BasicCredentials>) -> Result<String, AuthenticatorError> {
+        Ok(ANONYMOUS_USER.to_owned()) 
+    }
+}

--- a/util/grpc/src/auth/anonymous_authenticator.rs
+++ b/util/grpc/src/auth/anonymous_authenticator.rs
@@ -11,7 +11,10 @@ pub const ANONYMOUS_USER: &str = "<anonymous>";
 pub struct AnonymousAuthenticator;
 
 impl Authenticator for AnonymousAuthenticator {
-    fn authenticate(&self, _maybe_credentials: Option<BasicCredentials>) -> Result<String, AuthenticatorError> {
-        Ok(ANONYMOUS_USER.to_owned()) 
+    fn authenticate(
+        &self,
+        _maybe_credentials: Option<BasicCredentials>,
+    ) -> Result<String, AuthenticatorError> {
+        Ok(ANONYMOUS_USER.to_owned())
     }
 }

--- a/util/grpc/src/auth/mod.rs
+++ b/util/grpc/src/auth/mod.rs
@@ -176,7 +176,10 @@ mod test {
     use super::*;
     use anonymous_authenticator::{AnonymousAuthenticator, ANONYMOUS_USER};
     use grpcio::MetadataBuilder;
+    use std::time::Duration;
     use token_authenticator::{TokenAuthenticator, TokenBasicCredentialsGenerator};
+
+    const TOKEN_MAX_LIFETIME: Duration = Duration::from_secs(60);
 
     #[test]
     fn authenticate_anonymous() {
@@ -231,7 +234,7 @@ mod test {
     #[test]
     fn authenticate_token() {
         let shared_secret = [66; 32];
-        let authenticator = TokenAuthenticator::new(shared_secret.clone());
+        let authenticator = TokenAuthenticator::new(shared_secret.clone(), TOKEN_MAX_LIFETIME);
         const TEST_USERNAME: &str = "user123";
 
         // Authorizing without any headers should fail.

--- a/util/grpc/src/auth/mod.rs
+++ b/util/grpc/src/auth/mod.rs
@@ -2,26 +2,45 @@
 
 //! GRPC authentication utilities.
 
+pub mod anonymous_authenticator;
 pub mod token_authenticator;
 
 use displaydoc::Display;
-use std::{fmt, str};
+use grpcio::Metadata;
+use std::{ops::Deref, str};
 
+/// Error values for authentication.
+#[derive(Display, Debug)]
+pub enum AuthenticatorError {
+    /// Unauthenticated
+    Unauthenticated,
+
+    /// Invalid user authorization token
+    InvalidAuthorizationToken,
+
+    /// Expired user authorization token
+    ExpiredAuthorizationToken,
+
+    /// Other: {0}
+    Other(String),
+}
+
+/// Interface for performing an authentication using `BasicCredentials`, resulting in a String
+/// username or an error.
 pub trait Authenticator {
-    type User: Send + 'static;
-    type Error: fmt::Display;
     fn authenticate(
         &self,
         maybe_credentials: Option<BasicCredentials>,
-    ) -> Result<Self::User, Self::Error>;
+    ) -> Result<String, AuthenticatorError>;
 }
 
+/// Standard username/password credentials.
 pub struct BasicCredentials {
     username: String,
     password: String,
 }
 
-#[derive(Display)]
+#[derive(Display, Debug)]
 pub enum AuthorizationHeaderError {
     /// Unsupported authorization method
     UnsupportedAuthorizationMethod,
@@ -41,6 +60,7 @@ impl BasicCredentials {
         }
     }
 
+    /// Try and construct `BasicCredentials` from an HTTP Basic Authorization header.
     pub fn try_from(header_value: &[u8]) -> Result<Self, AuthorizationHeaderError> {
         let header = str::from_utf8(header_value)
             .map_err(|_| AuthorizationHeaderError::InvalidAuthorizationHeader)?;
@@ -81,5 +101,146 @@ impl BasicCredentials {
 
     pub fn password(&self) -> &str {
         &self.password
+    }
+
+    pub fn authorization_header(&self) -> String {
+        format!(
+            "Basic {}",
+            base64::encode(format!("{}:{}", self.username, self.password))
+        )
+    }
+}
+
+/// Error values for the `authorize` helper method.
+#[derive(Display, Debug)]
+pub enum AuthorizeError {
+    /// Authentication error: {0}
+    Authentication(AuthenticatorError),
+
+    /// Authorization header error: {0},
+    AuthorizationHeader(AuthorizationHeaderError),
+}
+
+impl From<AuthenticatorError> for AuthorizeError {
+    fn from(src: AuthenticatorError) -> Self {
+        Self::Authentication(src)
+    }
+}
+
+impl From<AuthorizationHeaderError> for AuthorizeError {
+    fn from(src: AuthorizationHeaderError) -> Self {
+        Self::AuthorizationHeader(src)
+    }
+}
+
+/// A utility method for performing authorization using the HTTP Authorization header in an
+/// `Metadata` object.
+pub fn authorize<Auth: Authenticator>(
+    authenticator: impl Deref<Target = Auth>,
+    metadata: &Metadata,
+) -> Result<String, AuthorizeError> {
+    let creds = metadata
+        .iter()
+        .find_map(|(key, value)| {
+            if key.to_lowercase() == "authorization" {
+                Some(value)
+            } else {
+                None
+            }
+        })
+        .map(BasicCredentials::try_from)
+        .transpose()?;
+
+    Ok(authenticator.authenticate(creds)?)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use anonymous_authenticator::{AnonymousAuthenticator, ANONYMOUS_USER};
+    use grpcio::MetadataBuilder;
+    use token_authenticator::{TokenAuthenticator, TokenBasicCredentialsGenerator};
+
+    #[test]
+    fn authorize_anonymous() {
+        let authenticator = AnonymousAuthenticator::default();
+
+        // Authorizing without any headers should work.
+        let metadata = MetadataBuilder::new().build();
+        let user = authorize(&authenticator, &metadata).expect("authorize failed");
+        assert_eq!(user, ANONYMOUS_USER);
+
+        // Authorizing with an unrelated header should work.
+        let mut metadata_builder = MetadataBuilder::new();
+        metadata_builder.add_str("test", "header").unwrap();
+        let user = authorize(&authenticator, &metadata_builder.build()).expect("authorize failed");
+        assert_eq!(user, ANONYMOUS_USER);
+
+        // Authorizing with an invalid Authorization header should fail.
+        for test_header_value in &[
+            "NotBasic",
+            "NotBasic XXX",
+            "Basic",
+            "Basic XXX",
+            "Basic YWI=",
+        ] {
+            let mut metadata_builder = MetadataBuilder::new();
+            metadata_builder
+                .add_str("Authorization", test_header_value)
+                .unwrap();
+            if authorize(&authenticator, &metadata_builder.build()).is_ok() {
+                panic!("Unexpected success with header {:?}", test_header_value);
+            }
+        }
+
+        // Authorizing with a valid Authorization error should succeed.
+        let mut metadata_builder = MetadataBuilder::new();
+        metadata_builder
+            .add_str("Authorization", "Basic YTpi")
+            .unwrap();
+        let user = authorize(&authenticator, &metadata_builder.build()).expect("authorize failed");
+        assert_eq!(user, ANONYMOUS_USER);
+    }
+
+    #[test]
+    fn authorize_token() {
+        let shared_secret = [66; 32];
+        let authenticator = TokenAuthenticator::new(shared_secret.clone());
+        const TEST_USERNAME: &str = "user123";
+
+        // Authorizing without any headers should fail.
+        let metadata = MetadataBuilder::new().build();
+        assert!(authorize(&authenticator, &metadata).is_err());
+
+        // Authorizing with an invalid Authorization header should fail.
+        for test_header_value in &[
+            "NotBasic",
+            "NotBasic XXX",
+            "Basic",
+            "Basic XXX",
+            "Basic YWI=",
+        ] {
+            let mut metadata_builder = MetadataBuilder::new();
+            metadata_builder
+                .add_str("Authorization", test_header_value)
+                .unwrap();
+            if authorize(&authenticator, &metadata_builder.build()).is_ok() {
+                panic!("Unexpected success with header {:?}", test_header_value);
+            }
+        }
+
+        // Authorizing with a valid Authorization header should succeed.
+        let generator = TokenBasicCredentialsGenerator::new(shared_secret.clone());
+        let creds = generator
+            .generate_for(TEST_USERNAME)
+            .expect("failed generating token");
+
+        let mut metadata_builder = MetadataBuilder::new();
+        metadata_builder
+            .add_str("Authorization", &creds.authorization_header())
+            .unwrap();
+        let username =
+            authorize(&authenticator, &metadata_builder.build()).expect("authorize failed");
+        assert_eq!(username, TEST_USERNAME);
     }
 }

--- a/util/grpc/src/auth/mod.rs
+++ b/util/grpc/src/auth/mod.rs
@@ -2,8 +2,8 @@
 
 //! GRPC authentication utilities.
 
-pub mod anonymous_authenticator;
-pub mod token_authenticator;
+mod anonymous_authenticator;
+mod token_authenticator;
 
 pub use anonymous_authenticator::{AnonymousAuthenticator, ANONYMOUS_USER};
 pub use token_authenticator::{TokenAuthenticator, TokenBasicCredentialsGenerator};
@@ -176,6 +176,7 @@ mod test {
     use super::*;
     use anonymous_authenticator::{AnonymousAuthenticator, ANONYMOUS_USER};
     use grpcio::MetadataBuilder;
+    use mc_common::time::SystemTimeProvider;
     use std::time::Duration;
     use token_authenticator::{TokenAuthenticator, TokenBasicCredentialsGenerator};
 
@@ -234,7 +235,11 @@ mod test {
     #[test]
     fn authenticate_token() {
         let shared_secret = [66; 32];
-        let authenticator = TokenAuthenticator::new(shared_secret.clone(), TOKEN_MAX_LIFETIME);
+        let authenticator = TokenAuthenticator::new(
+            shared_secret.clone(),
+            TOKEN_MAX_LIFETIME,
+            SystemTimeProvider::default(),
+        );
         const TEST_USERNAME: &str = "user123";
 
         // Authorizing without any headers should fail.
@@ -262,7 +267,10 @@ mod test {
         }
 
         // Authorizing with a valid Authorization header should succeed.
-        let generator = TokenBasicCredentialsGenerator::new(shared_secret.clone());
+        let generator = TokenBasicCredentialsGenerator::new(
+            shared_secret.clone(),
+            SystemTimeProvider::default(),
+        );
         let creds = generator
             .generate_for(TEST_USERNAME)
             .expect("failed generating token");

--- a/util/grpc/src/auth/mod.rs
+++ b/util/grpc/src/auth/mod.rs
@@ -108,7 +108,7 @@ impl BasicCredentials {
     pub fn try_from(header_value: &[u8]) -> Result<Self, AuthorizationHeaderError> {
         let header = str::from_utf8(header_value)
             .map_err(|_| AuthorizationHeaderError::InvalidAuthorizationHeader)?;
-        let mut header_parts = header.split(" ");
+        let mut header_parts = header.split(' ');
 
         if "Basic"
             != header_parts
@@ -125,7 +125,7 @@ impl BasicCredentials {
             .map_err(|_| AuthorizationHeaderError::InvalidAuthorizationHeader)?;
         let concatenated_values = str::from_utf8(&concatenated_values_bytes)
             .map_err(|_| AuthorizationHeaderError::InvalidCredentials)?;
-        let mut credential_parts = concatenated_values.splitn(2, ":");
+        let mut credential_parts = concatenated_values.splitn(2, ':');
 
         Ok(Self {
             username: credential_parts

--- a/util/grpc/src/auth/mod.rs
+++ b/util/grpc/src/auth/mod.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! GRPC authentication utilities.
+
+pub mod token_authenticator;
+
+use displaydoc::Display;
+use std::{fmt, str};
+
+pub trait Authenticator {
+    type User: Send + 'static;
+    type Error: fmt::Display;
+    fn authenticate(
+        &self,
+        maybe_credentials: Option<BasicCredentials>,
+    ) -> Result<Self::User, Self::Error>;
+}
+
+pub struct BasicCredentials {
+    username: String,
+    password: String,
+}
+
+#[derive(Display)]
+pub enum AuthorizationHeaderError {
+    /// Unsupported authorization method
+    UnsupportedAuthorizationMethod,
+
+    /// Invalid authorization header
+    InvalidAuthorizationHeader,
+
+    /// Invalid credentials
+    InvalidCredentials,
+}
+
+impl BasicCredentials {
+    pub fn new(username: &str, password: &str) -> Self {
+        Self {
+            username: username.to_owned(),
+            password: password.to_owned(),
+        }
+    }
+
+    pub fn try_from(header_value: &[u8]) -> Result<Self, AuthorizationHeaderError> {
+        let header = str::from_utf8(header_value)
+            .map_err(|_| AuthorizationHeaderError::InvalidAuthorizationHeader)?;
+        let mut header_parts = header.split(" ");
+
+        if "Basic"
+            != header_parts
+                .next()
+                .ok_or(AuthorizationHeaderError::InvalidAuthorizationHeader)?
+        {
+            return Err(AuthorizationHeaderError::UnsupportedAuthorizationMethod);
+        }
+
+        let base64_value = header_parts
+            .next()
+            .ok_or(AuthorizationHeaderError::InvalidAuthorizationHeader)?;
+        let concatenated_values_bytes = base64::decode(base64_value)
+            .map_err(|_| AuthorizationHeaderError::InvalidAuthorizationHeader)?;
+        let concatenated_values = str::from_utf8(&concatenated_values_bytes)
+            .map_err(|_| AuthorizationHeaderError::InvalidCredentials)?;
+        let mut credential_parts = concatenated_values.splitn(2, ":");
+
+        Ok(Self {
+            username: credential_parts
+                .next()
+                .ok_or(AuthorizationHeaderError::InvalidCredentials)?
+                .to_string(),
+            password: credential_parts
+                .next()
+                .ok_or(AuthorizationHeaderError::InvalidCredentials)?
+                .to_string(),
+        })
+    }
+
+    pub fn username(&self) -> &str {
+        &self.username
+    }
+
+    pub fn password(&self) -> &str {
+        &self.password
+    }
+}

--- a/util/grpc/src/auth/mod.rs
+++ b/util/grpc/src/auth/mod.rs
@@ -5,6 +5,9 @@
 pub mod anonymous_authenticator;
 pub mod token_authenticator;
 
+pub use anonymous_authenticator::{AnonymousAuthenticator, ANONYMOUS_USER};
+pub use token_authenticator::TokenAuthenticator;
+
 use displaydoc::Display;
 use grpcio::{Metadata, RpcContext, RpcStatus, RpcStatusCode};
 use std::str;

--- a/util/grpc/src/auth/token_authenticator.rs
+++ b/util/grpc/src/auth/token_authenticator.rs
@@ -6,31 +6,32 @@ use super::*;
 
 use displaydoc::Display;
 use hmac::{Hmac, Mac, NewMac};
-use std::{
-    str,
-    time::{Duration, SystemTime},
-};
+use mc_common::time::TimeProvider;
+use std::{str, time::Duration};
 use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
 
 /// Token-based authentication: An object that implements `Authenticator`, allowing to authenticate
 /// users using HMAC-generated tokens.
-pub struct TokenAuthenticator {
+pub struct TokenAuthenticator<TP: TimeProvider> {
     /// Secret shared between the authenticator and then token generator, allowing for generated
     /// tokens to be cryptographically-verified by the authenticator.
     shared_secret: [u8; 32],
 
     /// The maximum duration a token is valid for.
     max_token_lifetime: Duration,
+
+    /// Time provider.
+    time_provider: TP,
 }
 
-impl Drop for TokenAuthenticator {
+impl<TP: TimeProvider> Drop for TokenAuthenticator<TP> {
     fn drop(&mut self) {
         self.shared_secret.zeroize();
     }
 }
 
-impl Authenticator for TokenAuthenticator {
+impl<TP: TimeProvider> Authenticator for TokenAuthenticator<TP> {
     fn authenticate(
         &self,
         maybe_credentials: Option<BasicCredentials>,
@@ -52,7 +53,7 @@ impl Authenticator for TokenAuthenticator {
         if username != credentials.username {
             return Err(AuthenticatorError::InvalidAuthorizationToken);
         }
-        if !self.is_valid_time(timestamp, SystemTime::now())? {
+        if !self.is_valid_time(timestamp)? {
             return Err(AuthenticatorError::ExpiredAuthorizationToken);
         }
         if !self.is_valid_signature(&format!("{}:{}", username, timestamp), signature)? {
@@ -62,22 +63,24 @@ impl Authenticator for TokenAuthenticator {
     }
 }
 
-impl TokenAuthenticator {
-    pub fn new(shared_secret: [u8; 32], max_token_lifetime: Duration) -> Self {
+impl<TP: TimeProvider> TokenAuthenticator<TP> {
+    pub fn new(shared_secret: [u8; 32], max_token_lifetime: Duration, time_provider: TP) -> Self {
         Self {
             shared_secret,
             max_token_lifetime,
+            time_provider,
         }
     }
 
-    fn is_valid_time(&self, timestamp: &str, now: SystemTime) -> Result<bool, AuthenticatorError> {
+    fn is_valid_time(&self, timestamp: &str) -> Result<bool, AuthenticatorError> {
         let token_time: Duration = Duration::from_secs(
             timestamp
                 .parse()
                 .map_err(|_| AuthenticatorError::InvalidAuthorizationToken)?,
         );
-        let our_time: Duration = now
-            .duration_since(SystemTime::UNIX_EPOCH)
+        let our_time = self
+            .time_provider
+            .from_epoch()
             .map_err(|_| AuthenticatorError::ExpiredAuthorizationToken)?;
         let distance: Duration = our_time
             .checked_sub(token_time)
@@ -86,13 +89,14 @@ impl TokenAuthenticator {
     }
 
     fn is_valid_signature(&self, data: &str, signature: &str) -> Result<bool, AuthenticatorError> {
+        let their_suffix: Vec<u8> =
+            hex::decode(signature).map_err(|_| AuthenticatorError::InvalidAuthorizationToken)?;
+
         let mut mac = Hmac::<sha2::Sha256>::new_varkey(&self.shared_secret)
             .map_err(|_| AuthenticatorError::Other("Invalid HMAC key".to_owned()))?;
         mac.update(data.as_bytes());
         let our_signature = mac.finalize().into_bytes();
 
-        let their_suffix: Vec<u8> =
-            hex::decode(signature).map_err(|_| AuthenticatorError::InvalidAuthorizationToken)?;
         let our_suffix: &[u8] = &our_signature[..10];
         Ok(bool::from(our_suffix.ct_eq(&their_suffix)))
     }
@@ -101,31 +105,35 @@ impl TokenAuthenticator {
 /// Error values for token generator.
 #[derive(Display, Debug)]
 pub enum TokenBasicCredentialsGeneratorError {
-    /// SystemTime error
-    SystemTime,
+    /// TimeProvider error
+    TimeProvider,
 
     /// Invalid HMAC key
     InvalidHmacKey,
 }
 
 /// Token generator - an object that can generate HMAC authentication tokens.
-#[derive(Zeroize)]
-pub struct TokenBasicCredentialsGenerator {
+pub struct TokenBasicCredentialsGenerator<TP: TimeProvider> {
     shared_secret: [u8; 32],
+    time_provider: TP,
 }
 
-impl TokenBasicCredentialsGenerator {
-    pub fn new(shared_secret: [u8; 32]) -> Self {
-        Self { shared_secret }
+impl<TP: TimeProvider> TokenBasicCredentialsGenerator<TP> {
+    pub fn new(shared_secret: [u8; 32], time_provider: TP) -> Self {
+        Self {
+            shared_secret,
+            time_provider,
+        }
     }
 
     pub fn generate_for(
         &self,
         user_id: &str,
     ) -> Result<BasicCredentials, TokenBasicCredentialsGeneratorError> {
-        let current_time_seconds = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map_err(|_| TokenBasicCredentialsGeneratorError::SystemTime)?
+        let current_time_seconds = self
+            .time_provider
+            .from_epoch()
+            .map_err(|_| TokenBasicCredentialsGeneratorError::TimeProvider)?
             .as_secs();
         let prefix = format!("{}:{}", user_id, current_time_seconds);
 
@@ -146,18 +154,32 @@ impl TokenBasicCredentialsGenerator {
     }
 }
 
+impl<TP: TimeProvider> Drop for TokenBasicCredentialsGenerator<TP> {
+    fn drop(&mut self) {
+        self.shared_secret.zeroize();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     const TOKEN_MAX_LIFETIME: Duration = Duration::from_secs(60);
+    use mc_common::time::{MockTimeProvider, SystemTimeProvider};
 
     #[test]
     fn valid_token_authenticates_successfully() {
         let shared_secret = [3; 32];
         const TEST_USERNAME: &str = "test user";
 
-        let generator = TokenBasicCredentialsGenerator::new(shared_secret.clone());
-        let authenticator = TokenAuthenticator::new(shared_secret, TOKEN_MAX_LIFETIME);
+        let generator = TokenBasicCredentialsGenerator::new(
+            shared_secret.clone(),
+            SystemTimeProvider::default(),
+        );
+        let authenticator = TokenAuthenticator::new(
+            shared_secret,
+            TOKEN_MAX_LIFETIME,
+            SystemTimeProvider::default(),
+        );
 
         let creds = generator.generate_for(TEST_USERNAME).unwrap();
         let user = authenticator
@@ -170,7 +192,11 @@ mod tests {
     #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Unauthenticated")]
     fn missing_creds_fails_authentication() {
         let shared_secret = [3; 32];
-        let authenticator = TokenAuthenticator::new(shared_secret, TOKEN_MAX_LIFETIME);
+        let authenticator = TokenAuthenticator::new(
+            shared_secret,
+            TOKEN_MAX_LIFETIME,
+            SystemTimeProvider::default(),
+        );
 
         // We expect this to panic.
         let _ = authenticator.authenticate(None).unwrap();
@@ -184,10 +210,14 @@ mod tests {
         let shared_secret = [3; 32];
         const TEST_USERNAME: &str = "test user";
 
-        let generator = TokenBasicCredentialsGenerator::new(shared_secret.clone());
+        let generator = TokenBasicCredentialsGenerator::new(
+            shared_secret.clone(),
+            SystemTimeProvider::default(),
+        );
 
         // Signature will fail if authenticator uses a different shared secret.
-        let authenticator = TokenAuthenticator::new([4; 32], TOKEN_MAX_LIFETIME);
+        let authenticator =
+            TokenAuthenticator::new([4; 32], TOKEN_MAX_LIFETIME, SystemTimeProvider::default());
 
         let creds = generator.generate_for(TEST_USERNAME).unwrap();
 
@@ -197,21 +227,23 @@ mod tests {
 
     #[test]
     fn is_valid_time_rejects_expired() {
-        let authenticator = TokenAuthenticator::new([4; 32], TOKEN_MAX_LIFETIME);
+        let time_provider = MockTimeProvider::default();
 
-        let now = SystemTime::now();
-        let now_in_seconds = now
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let authenticator =
+            TokenAuthenticator::new([4; 32], TOKEN_MAX_LIFETIME, time_provider.clone());
 
-        let expired = now_in_seconds - TOKEN_MAX_LIFETIME.as_secs();
-
+        // Initially, we should be valid.
+        let now_in_seconds = time_provider.from_epoch().unwrap().as_secs();
         assert!(authenticator
-            .is_valid_time(&now_in_seconds.to_string(), now.clone())
+            .is_valid_time(&now_in_seconds.to_string())
             .unwrap());
+
+        // Set the time such that we are no longer considered vald.
+        let expired = time_provider.from_epoch().unwrap() + TOKEN_MAX_LIFETIME;
+        time_provider.set_cur_from_epoch(expired);
+
         assert!(!authenticator
-            .is_valid_time(&expired.to_string(), now)
+            .is_valid_time(&now_in_seconds.to_string())
             .unwrap());
     }
 }

--- a/util/grpc/src/auth/token_authenticator.rs
+++ b/util/grpc/src/auth/token_authenticator.rs
@@ -36,7 +36,7 @@ impl Authenticator for TokenAuthenticator {
         maybe_credentials: Option<BasicCredentials>,
     ) -> Result<String, AuthenticatorError> {
         let credentials = maybe_credentials.ok_or(AuthenticatorError::Unauthenticated)?;
-        let mut parts = credentials.password.split(":");
+        let mut parts = credentials.password.split(':');
         let username = parts
             .next()
             .ok_or(AuthenticatorError::InvalidAuthorizationToken)?;

--- a/util/grpc/src/auth/token_authenticator.rs
+++ b/util/grpc/src/auth/token_authenticator.rs
@@ -1,0 +1,241 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! GRPC authenticator that relies on a shared secret for generating and verifying tokens.
+
+use super::*;
+
+use displaydoc::Display;
+use hmac::{Hmac, Mac, NewMac};
+use std::{
+    str,
+    time::{Duration, SystemTime},
+};
+use subtle::ConstantTimeEq;
+use zeroize::Zeroize;
+
+/// The maximum duration a token is valid for.
+pub const TOKEN_MAX_LIFETIME: Duration = Duration::from_secs(86400);
+
+/// User information derived from token authentication.
+#[derive(Clone, Debug)]
+pub struct TokenUser {
+    pub username: String,
+}
+
+/// Token-based authentication: An object that implements `Authenticator`, allowing to authenticate
+/// users using HMAC-generated tokens.
+#[derive(Zeroize)]
+pub struct TokenUserAuthenticator {
+    shared_secret: [u8; 32],
+}
+
+/// Error values for token authentication.
+#[derive(Display, Debug, Eq, PartialEq)]
+pub enum TokenUserAuthenticationError {
+    /// Invalid HMAC key
+    InvalidHmacKey,
+
+    /// Unauthenticated
+    Unauthenticated,
+
+    /// Invalid user authorization token
+    InvalidAuthorizationToken,
+
+    /// Expired user authorization token
+    ExpiredAuthorizationToken,
+}
+
+impl Authenticator for TokenUserAuthenticator {
+    type User = TokenUser;
+    type Error = TokenUserAuthenticationError;
+
+    fn authenticate(
+        &self,
+        maybe_credentials: Option<BasicCredentials>,
+    ) -> Result<Self::User, Self::Error> {
+        let credentials = maybe_credentials.ok_or(TokenUserAuthenticationError::Unauthenticated)?;
+        let mut parts = credentials.password.split(":");
+        let username = parts
+            .next()
+            .ok_or(TokenUserAuthenticationError::InvalidAuthorizationToken)?;
+        let timestamp = parts
+            .next()
+            .ok_or(TokenUserAuthenticationError::InvalidAuthorizationToken)?;
+        let signature = parts
+            .next()
+            .ok_or(TokenUserAuthenticationError::InvalidAuthorizationToken)?;
+        if parts.next().is_some() {
+            return Err(TokenUserAuthenticationError::InvalidAuthorizationToken);
+        }
+        if username != credentials.username {
+            return Err(TokenUserAuthenticationError::InvalidAuthorizationToken);
+        }
+        if !self.is_valid_time(timestamp, SystemTime::now())? {
+            return Err(TokenUserAuthenticationError::ExpiredAuthorizationToken);
+        }
+        if !self.is_valid_signature(&format!("{}:{}", username, timestamp), signature)? {
+            return Err(TokenUserAuthenticationError::InvalidAuthorizationToken);
+        }
+        Ok(TokenUser {
+            username: credentials.username,
+        })
+    }
+}
+
+impl TokenUserAuthenticator {
+    pub fn new(shared_secret: [u8; 32]) -> Self {
+        Self { shared_secret }
+    }
+
+    fn is_valid_time(
+        &self,
+        timestamp: &str,
+        now: SystemTime,
+    ) -> Result<bool, TokenUserAuthenticationError> {
+        let token_time: Duration = Duration::from_secs(
+            timestamp
+                .parse()
+                .map_err(|_| TokenUserAuthenticationError::InvalidAuthorizationToken)?,
+        );
+        let our_time: Duration = now
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|_| TokenUserAuthenticationError::ExpiredAuthorizationToken)?;
+        let distance: Duration = our_time
+            .checked_sub(token_time)
+            .unwrap_or_else(|| token_time - our_time);
+        Ok(distance < TOKEN_MAX_LIFETIME)
+    }
+
+    fn is_valid_signature(
+        &self,
+        data: &str,
+        signature: &str,
+    ) -> Result<bool, TokenUserAuthenticationError> {
+        let mut mac = Hmac::<sha2::Sha256>::new_varkey(&self.shared_secret)
+            .map_err(|_| TokenUserAuthenticationError::InvalidHmacKey)?;
+        mac.update(data.as_bytes());
+        let our_signature = mac.finalize().into_bytes();
+
+        let their_suffix: Vec<u8> = hex::decode(signature)
+            .map_err(|_| TokenUserAuthenticationError::InvalidAuthorizationToken)?;
+        let our_suffix: &[u8] = &our_signature[..10];
+        Ok(bool::from(our_suffix.ct_eq(&their_suffix)))
+    }
+}
+
+/// Error values for token generator.
+#[derive(Display, Debug)]
+pub enum TokenBasicCredentialsGeneratorError {
+    /// SystemTime error
+    SystemTime,
+
+    /// Invalid HMAC key
+    InvalidHmacKey,
+}
+
+/// Token generator - an object that can generate HMAC authentication tokens.
+#[derive(Zeroize)]
+pub struct TokenBasicCredentialsGenerator {
+    shared_secret: [u8; 32],
+}
+
+impl TokenBasicCredentialsGenerator {
+    pub fn new(shared_secret: [u8; 32]) -> Self {
+        Self { shared_secret }
+    }
+
+    pub fn generate_for(
+        &self,
+        user_id: &str,
+    ) -> Result<BasicCredentials, TokenBasicCredentialsGeneratorError> {
+        let current_time_seconds = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|_| TokenBasicCredentialsGeneratorError::SystemTime)?
+            .as_secs();
+        let prefix = format!("{}:{}", user_id, current_time_seconds);
+
+        let mut mac = Hmac::<sha2::Sha256>::new_varkey(&self.shared_secret)
+            .map_err(|_| TokenBasicCredentialsGeneratorError::InvalidHmacKey)?;
+        mac.update(prefix.as_bytes());
+        let signature = mac.finalize().into_bytes();
+
+        Ok(BasicCredentials::new(
+            user_id,
+            &format!(
+                "{}:{}:{}",
+                user_id,
+                current_time_seconds,
+                hex::encode(&signature[..10])
+            ),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_token_authenticates_successfully() {
+        let shared_secret = [3; 32];
+        const TEST_USERNAME: &str = "test user";
+
+        let generator = TokenBasicCredentialsGenerator::new(shared_secret.clone());
+        let authenticator = TokenUserAuthenticator::new(shared_secret);
+
+        let creds = generator.generate_for(TEST_USERNAME).unwrap();
+        let user = authenticator
+            .authenticate(Some(creds))
+            .expect("authenticate failed");
+        assert_eq!(user.username, TEST_USERNAME);
+    }
+
+    #[test]
+    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Unauthenticated")]
+    fn missing_creds_fails_authentication() {
+        let shared_secret = [3; 32];
+        let authenticator = TokenUserAuthenticator::new(shared_secret);
+
+        // We expect this to panic.
+        let _ = authenticator.authenticate(None).unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: InvalidAuthorizationToken"
+    )]
+    fn invalid_token_fails_authentication() {
+        let shared_secret = [3; 32];
+        const TEST_USERNAME: &str = "test user";
+
+        let generator = TokenBasicCredentialsGenerator::new(shared_secret.clone());
+
+        // Signature will fail if authenticator uses a different shared secret.
+        let authenticator = TokenUserAuthenticator::new([4; 32]);
+
+        let creds = generator.generate_for(TEST_USERNAME).unwrap();
+
+        // We expect this to panic.
+        let _ = authenticator.authenticate(Some(creds)).unwrap();
+    }
+
+    #[test]
+    fn is_valid_time_rejects_expired() {
+        let authenticator = TokenUserAuthenticator::new([4; 32]);
+
+        let now = SystemTime::now();
+        let now_in_seconds = now
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let expired = now_in_seconds - TOKEN_MAX_LIFETIME.as_secs();
+
+        assert!(authenticator
+            .is_valid_time(&now_in_seconds.to_string(), now.clone())
+            .unwrap());
+        assert!(!authenticator
+            .is_valid_time(&expired.to_string(), now)
+            .unwrap());
+    }
+}

--- a/util/grpc/src/lib.rs
+++ b/util/grpc/src/lib.rs
@@ -19,6 +19,8 @@ mod build_info_service;
 mod grpcio_extensions;
 mod health_service;
 
+pub mod auth;
+
 use futures::prelude::*;
 use grpcio::{RpcContext, RpcStatus, RpcStatusCode, UnarySink};
 use mc_common::logger::{log, o, Logger};

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -13,6 +13,7 @@ base64 = "0.11"
 displaydoc = { version = "0.1.7", default-features = false }
 ed25519 = { version = "1.0.1", default-features = false, features = ["serde"] }
 hex = "0.4"
+percent-encoding = "2.1.0"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 url = "2.1"
 

--- a/util/uri/src/lib.rs
+++ b/util/uri/src/lib.rs
@@ -111,6 +111,8 @@ mod consensus_client_uri_tests {
             ResponderId::from_str("127.0.0.1:443").unwrap()
         );
         assert_eq!(uri.use_tls(), true);
+        assert_eq!(uri.username(), "");
+        assert_eq!(uri.password(), "");
 
         let uri = ClientUri::from_str("mc://node1.test.mobilecoin.com/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:443");
@@ -119,6 +121,8 @@ mod consensus_client_uri_tests {
             ResponderId::from_str("node1.test.mobilecoin.com:443").unwrap()
         );
         assert_eq!(uri.use_tls(), true);
+        assert_eq!(uri.username(), "");
+        assert_eq!(uri.password(), "");
 
         let uri = ClientUri::from_str("mc://node1.test.mobilecoin.com:666/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:666");
@@ -127,6 +131,8 @@ mod consensus_client_uri_tests {
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
         assert_eq!(uri.use_tls(), true);
+        assert_eq!(uri.username(), "");
+        assert_eq!(uri.password(), "");
 
         let uri = ClientUri::from_str("insecure-mc://127.0.0.1/").unwrap();
         assert_eq!(uri.addr(), "127.0.0.1:3223");
@@ -135,6 +141,8 @@ mod consensus_client_uri_tests {
             ResponderId::from_str("127.0.0.1:3223").unwrap()
         );
         assert_eq!(uri.use_tls(), false);
+        assert_eq!(uri.username(), "");
+        assert_eq!(uri.password(), "");
 
         let uri = ClientUri::from_str("insecure-mc://localhost:3223/").unwrap();
         assert_eq!(uri.addr(), "localhost:3223");
@@ -143,6 +151,8 @@ mod consensus_client_uri_tests {
             ResponderId::from_str("localhost:3223").unwrap()
         );
         assert_eq!(uri.use_tls(), false);
+        assert_eq!(uri.username(), "");
+        assert_eq!(uri.password(), "");
 
         let uri = ClientUri::from_str("insecure-mc://localhost:3223/?consensus-msg-key=MCowBQYDK2VwAyEAUBfht6884a45r0AjFRXgLlnw3yIDllTepWavLrT8Lfk=").unwrap();
         assert_eq!(uri.addr(), "localhost:3223");
@@ -151,6 +161,8 @@ mod consensus_client_uri_tests {
             ResponderId::from_str("localhost:3223").unwrap()
         );
         assert_eq!(uri.use_tls(), false);
+        assert_eq!(uri.username(), "");
+        assert_eq!(uri.password(), "");
 
         let uri = ClientUri::from_str("insecure-mc://node1.test.mobilecoin.com/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3223");
@@ -159,6 +171,8 @@ mod consensus_client_uri_tests {
             ResponderId::from_str("node1.test.mobilecoin.com:3223").unwrap()
         );
         assert_eq!(uri.use_tls(), false);
+        assert_eq!(uri.username(), "");
+        assert_eq!(uri.password(), "");
 
         let uri = ClientUri::from_str("insecure-mc://node1.test.mobilecoin.com:666/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:666");
@@ -167,6 +181,41 @@ mod consensus_client_uri_tests {
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
         assert_eq!(uri.use_tls(), false);
+        assert_eq!(uri.username(), "");
+        assert_eq!(uri.password(), "");
+
+        let uri =
+            ClientUri::from_str("insecure-mc://coiner@node1.test.mobilecoin.com:666/").unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:666");
+        assert_eq!(
+            uri.responder_id().unwrap(),
+            ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
+        );
+        assert_eq!(uri.use_tls(), false);
+        assert_eq!(uri.username(), "coiner");
+        assert_eq!(uri.password(), "");
+
+        let uri =
+            ClientUri::from_str("insecure-mc://:passw0rd@node1.test.mobilecoin.com:666/").unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:666");
+        assert_eq!(
+            uri.responder_id().unwrap(),
+            ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
+        );
+        assert_eq!(uri.use_tls(), false);
+        assert_eq!(uri.username(), "");
+        assert_eq!(uri.password(), "passw0rd");
+
+        let uri =
+            ClientUri::from_str("insecure-mc://abc:def@node1.test.mobilecoin.com:666/").unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:666");
+        assert_eq!(
+            uri.responder_id().unwrap(),
+            ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
+        );
+        assert_eq!(uri.use_tls(), false);
+        assert_eq!(uri.username(), "abc");
+        assert_eq!(uri.password(), "def");
     }
 
     #[test]

--- a/util/uri/src/lib.rs
+++ b/util/uri/src/lib.rs
@@ -216,6 +216,17 @@ mod consensus_client_uri_tests {
         assert_eq!(uri.use_tls(), false);
         assert_eq!(uri.username(), "abc");
         assert_eq!(uri.password(), "def");
+
+        let uri = ClientUri::from_str("insecure-mc://abc:def:1:2:3@node1.test.mobilecoin.com:666/")
+            .unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:666");
+        assert_eq!(
+            uri.responder_id().unwrap(),
+            ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
+        );
+        assert_eq!(uri.use_tls(), false);
+        assert_eq!(uri.username(), "abc");
+        assert_eq!(uri.password(), "def:1:2:3");
     }
 
     #[test]

--- a/util/uri/src/traits.rs
+++ b/util/uri/src/traits.rs
@@ -79,6 +79,12 @@ pub trait ConnectionUri:
     /// Whether TLS should be used for this connection.
     fn use_tls(&self) -> bool;
 
+    /// Retrieve the username part of the URI, or an empty string if one is not available.
+    fn username(&self) -> String;
+
+    /// Retrieve the password part of the URI, or an empty string if one is not available.
+    fn password(&self) -> String;
+
     /// Retrieve the responder id for this connection.
     fn responder_id(&self) -> StdResult<ResponderId, UriConversionError> {
         // .addr() is always expected to return a host:port, so from_str should not fail.

--- a/util/uri/src/uri.rs
+++ b/util/uri/src/uri.rs
@@ -33,6 +33,12 @@ pub struct Uri<Scheme: UriScheme> {
     /// Whether to use TLS when connecting.
     use_tls: bool,
 
+    /// Optional username.
+    username: String,
+
+    /// Optional password.
+    password: String,
+
     /// The uri scheme
     _scheme: PhantomData<fn() -> Scheme>,
 }
@@ -56,6 +62,14 @@ impl<Scheme: UriScheme> ConnectionUri for Uri<Scheme> {
 
     fn use_tls(&self) -> bool {
         self.use_tls
+    }
+
+    fn username(&self) -> String {
+        self.username.clone()
+    }
+
+    fn password(&self) -> String {
+        self.password.clone()
     }
 }
 
@@ -101,11 +115,19 @@ impl<Scheme: UriScheme> FromStr for Uri<Scheme> {
             (None, false) => Scheme::DEFAULT_INSECURE_PORT,
         };
 
+        let username = url.username().to_owned();
+        let password = url
+            .password()
+            .map(|s| s.to_owned())
+            .unwrap_or_else(|| "".to_owned());
+
         Ok(Self {
             url,
             host,
             port,
             use_tls,
+            username,
+            password,
             _scheme: Default::default(),
         })
     }


### PR DESCRIPTION
Soundtrack of this PR: [On and Off the Beaten Path 1](https://soundcloud.com/shoutingfire/oobp1?ref=whatsapp&p=i&c=0)
### Motivation

We'd like to have the option to require authentication when accessing some of our GRPC services. This could allow for things such as centralized rate limiting, or nodes that only accept client requests from specific entities. 

### In this PR

Add support for client request authentication in `mc-consensus-service`. Currently, the only supported authenticated method is a token-based one. A token-generating entity (currently a command line utility, but eventually some service) shares a secret with the token-validating entity (`mc-consensus-service`). The shared secret allows the validating entity to ensure tokens handed to it were signed by a trusted party. Generated tokens contain a unix timestamp of when they were generated, allowing their lifetime to be limited. Other authentication can easily be added in the future.

With regards to code changes, the main ones are:
* A new module, `mc_util_grpc::auth` that contains the authentication primitives.
* A new crate `mc-util-grpc-token-generator` that provides a command line tool for generating tokens, used for testing.
* Two new optional command line arguments to `mc-consensus-service` for enabling token-based authentication (`--client-auth-token-secret` for enabling the authentication, and setting the shared secret and `--client-auth-token-max-lifetime` which allows adjusting the token's max lifetime from the default 24 hours).
* Add username/password support to our `Uri` trait. Those are used to carry authentication information.
* Change attestation GRPC errors to be `PermissionDenied`, and use `Unauthenticated` for authentication errors. We must use separate error codes here since the behavior differs when we encounter them: Upon attestation-related errors the solution is to re-attest (which `ThickClient` can do automatically), but upon authentication error a new token has to be obtained which is outside the scope of `ThickClient`.

While there are some automated tests in place to ensure the basics work, in order to test an actual network with this I did the following:
1) Edit `tools/local-network/local_network.py` and add the required command line argument to consensus service so that it enables token authentication (e.g. `----client-auth-token-secret e9a1cc8b6846eb64248df3cf33afc9c7878ec550f0d221186d577b8ed681218a'
2) Run the local network, `mobilecoind` will fail due to `Unauthenticated`.
3) Generate an authentication token: `cargo run -p mc-util-grpc-token-generator -- --shared-secret e9a1cc8b6846eb64248df3cf33afc9c7878ec550f0d221186d577b8ed681218a --username lol`
4) Edit `tools/local-network/local_network.py` and add the authentication information to the URLs passed to `mobilecoind`: `peers = [f'--peer "insecure-mc://lol:lol%3A1600890302%3Adffd0a03009418cb66e6@localhost:{node.client_port}/"' for node in network.nodes]`. `mobilecoind` now works.

### Future Work
* A standalone service that is capable of handing out authentication tokens based on whatever criteria we come up with (such as rate limits).
* Converting our internal services to support the work presented here.
