### PR TITLE
Adds moburl to returned proto when creating a request code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,6 +2873,7 @@ dependencies = [
  "mc-util-repr-bytes",
  "mc-util-serial",
  "mc-util-uri",
+ "mc-util-url-encoding",
  "mc-watcher",
  "more-asserts",
  "num_cpus",

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -32,6 +32,7 @@ mc-util-lmdb = { path = "../util/lmdb" }
 mc-util-repr-bytes = { path = "../util/repr-bytes" }
 mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }
+mc-util-url-encoding = { path = "../util/url-encoding" }
 mc-watcher = { path = "../watcher" }
 
 crossbeam-channel = "0.3"

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -341,6 +341,7 @@ message CreateRequestCodeRequest {
 }
 message CreateRequestCodeResponse {
     string b58_code = 1;
+    string mob_url = 2;
 }
 
 // Decode a base-58 encoded "MobileCoin Transfer Code" into entropy/tx_public_key/memo.

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -317,6 +317,7 @@ message GetPublicAddressRequest {
 message GetPublicAddressResponse {
     external.PublicAddress public_address = 1;
     string b58_code = 2;
+    string mob_url = 3;
 }
 
 //

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1586,6 +1586,7 @@ mod test {
     use std::{
         convert::{TryFrom, TryInto},
         iter::FromIterator,
+        str::FromStr,
     };
 
     #[test_with_logger]
@@ -3620,7 +3621,13 @@ mod test {
             let response = client.create_request_code(&request).unwrap();
             let b58_code = response.get_b58_code();
 
-            // Attempt to decode it.
+            // Check that the mob url is correct
+            let mob_url = MobUrl::from_str(response.get_mob_url()).unwrap();
+            assert_eq!(PublicAddress::try_from(&mob_url).unwrap(), receiver);
+            assert_eq!(mob_url.get_amount().unwrap(), "1234567890");
+            assert_eq!(mob_url.get_memo().unwrap(), "hello there");
+
+            // Attempt to decode the b58.
             let mut request = mc_mobilecoind_api::ParseRequestCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3621,12 +3621,6 @@ mod test {
             let response = client.create_request_code(&request).unwrap();
             let b58_code = response.get_b58_code();
 
-            // Check that the mob url is correct
-            let mob_url = MobUrl::from_str(response.get_mob_url()).unwrap();
-            assert_eq!(PublicAddress::try_from(&mob_url).unwrap(), receiver);
-            assert_eq!(mob_url.get_amount().unwrap(), "1234567890");
-            assert_eq!(mob_url.get_memo().unwrap(), "hello there");
-
             // Attempt to decode the b58.
             let mut request = mc_mobilecoind_api::ParseRequestCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
@@ -3675,6 +3669,12 @@ mod test {
 
             let response = client.create_request_code(&request).unwrap();
             let b58_code = response.get_b58_code();
+
+            // Check that the mob url is correct
+            let mob_url = MobUrl::from_str(response.get_mob_url()).unwrap();
+            assert_eq!(PublicAddress::try_from(&mob_url).unwrap(), receiver);
+            assert_eq!(mob_url.get_amount().unwrap(), "1234567890");
+            assert_eq!(mob_url.get_memo().unwrap(), "hello there");
 
             // Attempt to decode it.
             let mut request = mc_mobilecoind_api::ParseRequestCodeRequest::new();

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -352,7 +352,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
 
         // Create the MobUrl for the response
         let mob_url = MobUrl::try_from(&subaddress)
-        .map_err(|err| rpc_internal_error("MobUrl.try_from", err, &self.logger))?;
+            .map_err(|err| rpc_internal_error("MobUrl.try_from", err, &self.logger))?;
 
         // Return response.
         let mut response = mc_mobilecoind_api::GetPublicAddressResponse::new();
@@ -1977,7 +1977,10 @@ mod test {
 
         // Test the the mob_url encoding is correct
         let mob_url = MobUrl::from_str(response.get_mob_url()).unwrap();
-        assert_eq!(PublicAddress::try_from(&mob_url).unwrap(), account_key.subaddress(10).into());
+        assert_eq!(
+            PublicAddress::try_from(&mob_url).unwrap(),
+            account_key.subaddress(10).into()
+        );
 
         // Subaddress that is out of index or an invalid monitor id should error.
         let request = mc_mobilecoind_api::GetPublicAddressRequest::new();


### PR DESCRIPTION
### Motivation

Product spec includes QR codes for request codes in desktop clients, these should be encoded as mob_urls 

### In this PR
* Return mob_url  as part of CreateRequestCode in mobilecoind

### Future Work
* If we like this approach, also add to transfer codes?
