### PR TITLE
[MCC-528] PeerApiService unit tests

### DIFF
--- a/consensus/api/proto/consensus_peer.proto
+++ b/consensus/api/proto/consensus_peer.proto
@@ -27,7 +27,7 @@ service ConsensusPeerAPI {
 }
 
 message ConsensusMsg {
-    // ReponderId this message is coming from.
+    // ResponderId this message is coming from.
     string from_responder_id = 1;
 
     // Serialized peers::ConsensusMsg.

--- a/consensus/api/proto/consensus_peer.proto
+++ b/consensus/api/proto/consensus_peer.proto
@@ -27,7 +27,7 @@ service ConsensusPeerAPI {
 }
 
 message ConsensusMsg {
-    // ReponsderId this message is coming from.
+    // ReponderId this message is coming from.
     string from_responder_id = 1;
 
     // Serialized peers::ConsensusMsg.

--- a/consensus/service/src/client_api_service.rs
+++ b/consensus/service/src/client_api_service.rs
@@ -165,18 +165,7 @@ mod client_api_tests {
     };
     use mc_util_grpc::auth::{AnonymousAuthenticator, TokenAuthenticator};
     use serial_test_derive::serial;
-    use std::{
-        sync::{
-            atomic::{AtomicUsize, Ordering::SeqCst},
-            Arc,
-        },
-        time::Duration,
-    };
-
-    fn get_free_port() -> u16 {
-        static PORT_NR: AtomicUsize = AtomicUsize::new(0);
-        PORT_NR.fetch_add(1, SeqCst) as u16 + 30100
-    }
+    use std::{sync::Arc, time::Duration};
 
     /// Starts the service on localhost and connects a client to it.
     fn get_client_server(instance: ClientApiService) -> (ConsensusClientApiClient, Server) {
@@ -184,7 +173,7 @@ mod client_api_tests {
         let env = Arc::new(Environment::new(1));
         let mut server = ServerBuilder::new(env.clone())
             .register_service(service)
-            .bind("127.0.0.1", get_free_port())
+            .bind("127.0.0.1", 0)
             .build()
             .unwrap();
         server.start();

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -432,10 +432,10 @@ impl<
         let peer_service =
             consensus_peer_grpc::create_consensus_peer_api(peer_api_service::PeerApiService::new(
                 Arc::new(self.enclave.clone()),
-                self.consensus_msgs_from_network.get_sender_fn(),
-                self.create_scp_client_value_sender_fn(),
                 Arc::new(self.ledger_db.clone()),
                 self.tx_manager.clone(),
+                self.consensus_msgs_from_network.get_sender_fn(),
+                self.create_scp_client_value_sender_fn(),
                 get_highest_scp_message_fn,
                 self.peer_manager.responder_ids(),
                 self.logger.clone(),

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -431,7 +431,7 @@ impl<
 
         let peer_service =
             consensus_peer_grpc::create_consensus_peer_api(peer_api_service::PeerApiService::new(
-                self.enclave.clone(), // TODO use Arc'ed enclave from above
+                Arc::new(self.enclave.clone()),
                 self.consensus_msgs_from_network.get_sender_fn(),
                 self.create_scp_client_value_sender_fn(),
                 self.ledger_db.clone(),

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -434,7 +434,7 @@ impl<
                 Arc::new(self.enclave.clone()),
                 self.consensus_msgs_from_network.get_sender_fn(),
                 self.create_scp_client_value_sender_fn(),
-                self.ledger_db.clone(),
+                Arc::new(self.ledger_db.clone()),
                 self.tx_manager.clone(),
                 get_highest_scp_message_fn,
                 self.peer_manager.responder_ids(),

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -43,9 +43,9 @@ use std::{
 type FetchLatestMsgFn = Arc<dyn Fn() -> Option<mc_peers::ConsensusMsg> + Sync + Send>;
 
 #[derive(Clone)]
-pub struct PeerApiService<E: ConsensusEnclave, L: Ledger, TXM: TxManager> {
+pub struct PeerApiService<L: Ledger, TXM: TxManager> {
     /// Enclave instance.
-    enclave: E,
+    enclave: Arc<dyn ConsensusEnclave + Send + Sync>,
 
     /// Callback function for feeding consensus messages into ByzantineLedger.
     incoming_consensus_msgs_sender: BackgroundWorkQueueSenderFn<IncomingConsensusMsg>,
@@ -72,9 +72,9 @@ pub struct PeerApiService<E: ConsensusEnclave, L: Ledger, TXM: TxManager> {
     logger: Logger,
 }
 
-impl<E: ConsensusEnclave, L: Ledger, TXM: TxManager + Clone> PeerApiService<E, L, TXM> {
+impl<L: Ledger, TXM: TxManager + Clone> PeerApiService<L, TXM> {
     pub fn new(
-        enclave: E,
+        enclave: Arc<dyn ConsensusEnclave + Send + Sync>,
         incoming_consensus_msgs_sender: BackgroundWorkQueueSenderFn<IncomingConsensusMsg>,
         scp_client_value_sender: ProposeTxCallback,
         ledger: L,
@@ -197,9 +197,7 @@ impl<E: ConsensusEnclave, L: Ledger, TXM: TxManager + Clone> PeerApiService<E, L
     }
 }
 
-impl<E: ConsensusEnclave, L: Ledger, TXM: TxManager + Clone> ConsensusPeerApi
-    for PeerApiService<E, L, TXM>
-{
+impl<L: Ledger, TXM: TxManager + Clone> ConsensusPeerApi for PeerApiService<L, TXM> {
     fn peer_tx_propose(
         &mut self,
         ctx: RpcContext,

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -106,6 +106,7 @@ impl PeerApiService {
         }
     }
 
+    /// Handle transactions proposed by clients to a different node.
     fn real_peer_tx_propose(
         &mut self,
         request: Message,
@@ -160,7 +161,7 @@ impl PeerApiService {
         Ok(ProposeTxResponse::new())
     }
 
-    /// Get tx contents.
+    /// Returns the full, encrypted transactions corresponding to a list of transaction hashes.
     fn real_fetch_txs(
         &mut self,
         request: FetchTxsRequest,
@@ -209,7 +210,7 @@ impl PeerApiService {
 }
 
 impl ConsensusPeerApi for PeerApiService {
-    /// Handle a transaction proposed by a client to a different node.
+    /// Handle transactions proposed by clients to a different node.
     fn peer_tx_propose(
         &mut self,
         ctx: RpcContext,

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -82,8 +82,8 @@ impl PeerApiService {
     /// * `incoming_consensus_msgs_sender` - Callback for a new consensus message from a peer.
     /// * `scp_client_value_sender` - Callback for proposed transactions.
     /// * `fetch_latest_msg_fn` - Returns highest message emitted by this node.
-    /// * `known_responder_ids` - Whitelist. Messages from peers not on this list are ignored.
-    /// * `logger` -
+    /// * `known_responder_ids` - Messages from peers not on this "whitelist" are ignored.
+    /// * `logger` - Logger.
     pub fn new(
         consensus_enclave: Arc<dyn ConsensusEnclave + Send + Sync>,
         ledger: Arc<dyn Ledger + Send + Sync>,
@@ -172,7 +172,7 @@ impl PeerApiService {
             .iter()
             .map(|bytes| {
                 TxHash::try_from(&bytes[..])
-                    .map_err(|_| ConsensusGrpcError::InvalidArgument("invalid tx hash".to_string()))
+                    .map_err(|_| ConsensusGrpcError::InvalidArgument("Invalid TxHash".to_string()))
             })
             .collect::<Result<Vec<TxHash>, ConsensusGrpcError>>()?;
 
@@ -693,4 +693,10 @@ mod tests {
             Err(e) => panic!("Unexpected error: {:?}", e),
         }
     }
+
+    // TODO: fetch_latest_msg
+
+    // TODO: fetch_txs
+
+    // TODO: peer_tx_propose
 }

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -73,6 +73,17 @@ pub struct PeerApiService {
 }
 
 impl PeerApiService {
+    /// Creates a PeerApiService.
+    ///
+    /// # Arguments:
+    /// * `enclave` - The local node's consensus enclave.
+    /// * `incoming_consensus_msgs_sender` - Callback for... adding to a queue of received consensus messages?
+    /// * `scp_client_value_sender` -
+    /// * `ledger` - The local node's ledger.
+    /// * `tx_manager` - The local node's TxManager.
+    /// * `fetch_latest_msg_fn` - Returns highest message emitted by this node.
+    /// * `known_responder_ids` - Whitelist. Messages from peers not on this list are ignored.
+    /// * `logger` -
     pub fn new(
         enclave: Arc<dyn ConsensusEnclave + Send + Sync>,
         incoming_consensus_msgs_sender: BackgroundWorkQueueSenderFn<IncomingConsensusMsg>,
@@ -198,6 +209,7 @@ impl PeerApiService {
 }
 
 impl ConsensusPeerApi for PeerApiService {
+    /// Handle a transaction proposed by a client to a different node.
     fn peer_tx_propose(
         &mut self,
         ctx: RpcContext,
@@ -222,6 +234,7 @@ impl ConsensusPeerApi for PeerApiService {
         });
     }
 
+    /// Handle a consensus message from another peer.
     fn send_consensus_msg(
         &mut self,
         ctx: RpcContext,
@@ -325,6 +338,7 @@ impl ConsensusPeerApi for PeerApiService {
         });
     }
 
+    /// Returns the highest consensus message issued by this node.
     fn fetch_latest_msg(
         &mut self,
         ctx: RpcContext,
@@ -336,13 +350,14 @@ impl ConsensusPeerApi for PeerApiService {
             let mut response = FetchLatestMsgResponse::new();
             if let Some(latest_msg) = (self.fetch_latest_msg_fn)() {
                 let serialized_msg = mc_util_serial::serialize(&latest_msg)
-                    .expect("failed serializizng consensus msg");
+                    .expect("Failed serializing consensus msg");
                 response.set_payload(serialized_msg);
             }
             send_result(ctx, sink, Ok(response), &logger);
         });
     }
 
+    /// Returns the full, encrypted transactions corresponding to a list of transaction hashes.
     fn fetch_txs(
         &mut self,
         ctx: RpcContext,

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -361,3 +361,59 @@ impl ConsensusPeerApi for PeerApiService {
         });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        consensus_service::IncomingConsensusMsg, peer_api_service::PeerApiService,
+        tx_manager::MockTxManager,
+    };
+    use mc_common::{
+        logger::{test_with_logger, Logger},
+        NodeID, ResponderId,
+    };
+    use mc_consensus_enclave_mock::MockConsensusEnclave;
+    use mc_ledger_db::MockLedger;
+    use mc_transaction_core::tx::TxHash;
+    use std::sync::Arc;
+
+    #[test_with_logger]
+    // Example setup for a unit test.
+    fn test_example(logger: Logger) {
+        let consensus_enclave = MockConsensusEnclave::new();
+        let ledger = MockLedger::new();
+        let tx_manager = MockTxManager::new();
+
+        // BackgroundWorkQueueSenderFn<IncomingConsensusMsg>
+        // Arc<dyn Fn(T) -> Result<(), BackgroundWorkQueueError> + Sync + Send>;
+        let incoming_consensus_msgs_sender = Arc::new(|_msg: IncomingConsensusMsg| {
+            // TODO: store inputs for inspection.
+            Ok(())
+        });
+
+        // Arc<dyn Fn(TxHash, Option<&NodeID>, Option<&ResponderId>) + Sync + Send>
+        let scp_client_value_sender = Arc::new(
+            |_tx_hash: TxHash, _node_id: Option<&NodeID>, _responder_id: Option<&ResponderId>| {
+                // TODO: store inputs for inspection.
+            },
+        );
+
+        // type FetchLatestMsgFn = Arc<dyn Fn() -> Option<mc_peers::ConsensusMsg> + Sync + Send>;
+        let fetch_latest_msg_fn = Arc::new(|| None);
+
+        let known_responder_ids = Vec::new();
+
+        let _instance = PeerApiService::new(
+            Arc::new(consensus_enclave),
+            incoming_consensus_msgs_sender,
+            scp_client_value_sender,
+            Arc::new(ledger),
+            Arc::new(tx_manager),
+            fetch_latest_msg_fn,
+            known_responder_ids,
+            logger,
+        );
+
+        // TODO: create gRPC client and server.
+    }
+}

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -405,10 +405,7 @@ mod tests {
     use mc_transaction_core::{tx::TxHash, Block};
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
-    use std::sync::{
-        atomic::{AtomicUsize, Ordering::SeqCst},
-        Arc,
-    };
+    use std::sync::Arc;
 
     // Get sensibly-initialized mocks.
     fn get_mocks() -> (MockConsensusEnclave, MockLedger, MockTxManager) {
@@ -444,17 +441,12 @@ mod tests {
         Arc::new(|| None)
     }
 
-    fn get_free_port() -> u16 {
-        static PORT_NR: AtomicUsize = AtomicUsize::new(0);
-        PORT_NR.fetch_add(1, SeqCst) as u16 + 30100
-    }
-
     fn get_client_server(instance: PeerApiService) -> (ConsensusPeerApiClient, Server) {
         let service = consensus_peer_grpc::create_consensus_peer_api(instance);
         let env = Arc::new(Environment::new(1));
         let mut server = ServerBuilder::new(env.clone())
             .register_service(service)
-            .bind("127.0.0.1", get_free_port())
+            .bind("127.0.0.1", 0)
             .build()
             .unwrap();
         server.start();

--- a/consensus/service/src/peer_api_service.rs
+++ b/consensus/service/src/peer_api_service.rs
@@ -43,7 +43,7 @@ use std::{
 type FetchLatestMsgFn = Arc<dyn Fn() -> Option<mc_peers::ConsensusMsg> + Sync + Send>;
 
 #[derive(Clone)]
-pub struct PeerApiService<L: Ledger> {
+pub struct PeerApiService {
     /// Enclave instance.
     enclave: Arc<dyn ConsensusEnclave + Send + Sync>,
 
@@ -57,7 +57,7 @@ pub struct PeerApiService<L: Ledger> {
     scp_client_value_sender: ProposeTxCallback,
 
     /// Ledger database.
-    ledger: L,
+    ledger: Arc<dyn Ledger + Send + Sync>,
 
     /// Callback function for getting the latest SCP statement the local node has issued.
     fetch_latest_msg_fn: FetchLatestMsgFn,
@@ -72,12 +72,12 @@ pub struct PeerApiService<L: Ledger> {
     logger: Logger,
 }
 
-impl<L: Ledger> PeerApiService<L> {
+impl PeerApiService {
     pub fn new(
         enclave: Arc<dyn ConsensusEnclave + Send + Sync>,
         incoming_consensus_msgs_sender: BackgroundWorkQueueSenderFn<IncomingConsensusMsg>,
         scp_client_value_sender: ProposeTxCallback,
-        ledger: L,
+        ledger: Arc<dyn Ledger + Send + Sync>,
         tx_manager: Arc<dyn TxManager + Send + Sync>,
         fetch_latest_msg_fn: FetchLatestMsgFn,
         known_responder_ids: Vec<ResponderId>,
@@ -197,7 +197,7 @@ impl<L: Ledger> PeerApiService<L> {
     }
 }
 
-impl<L: Ledger> ConsensusPeerApi for PeerApiService<L> {
+impl ConsensusPeerApi for PeerApiService {
     fn peer_tx_propose(
         &mut self,
         ctx: RpcContext,


### PR DESCRIPTION
Soundtrack of this PR: [Final Song](https://www.youtube.com/watch?v=WUcXQ--yGWQ)

### Motivation

PeerApiService provides the gRPC API that consensus nodes use to communicate with each other. It currently lacks unit tests. 

### In this PR
* Sets up PeerApiService to use mocked dependencies.
* Adds initial unit tests for send_consensus_msg, which handles incoming consensus messages.

### Future Work
* This PR mostly sets the pattern for unit testing and gets things ready for upcoming changes to PeerApiService, like MCC-1867, Modify send_consensus_msg to fetch transactions referenced by a consensus message.
* Additional unit tests.

