### PR TITLE
Update blockchain explorer for PyPi module

### DIFF
--- a/mobilecoind/clients/python/README.md
+++ b/mobilecoind/clients/python/README.md
@@ -31,15 +31,7 @@ See the included README.md file for details.
 
 The `blockchain_explorer` directory contains a simple webserver that displays the raw blockchain content that `mobilecoind` downloads.
 
-Usage:
-```
-
-python3 ./blockchain_explorer.py
-
-```
-
-You can then view the leaderboard website at http://localhost:5000
-
+See the [blockchain_explorer README](./blockchain_explorer/README.md) for more info.
 
 #### Jupyter Wallet
 

--- a/mobilecoind/clients/python/blockchain_explorer/README.md
+++ b/mobilecoind/clients/python/blockchain_explorer/README.md
@@ -1,0 +1,19 @@
+blockchain_explorer
+=====
+
+Quick start:
+
+```
+pip3 install -r requirements.txt
+python3 blockchain_explorer.py --mobilecoind_host localhost --mobilecoind_port 4444 --port 5000
+```
+
+Go to localhost:5000 in a browser to interact.
+
+This can also be run as a flask app:
+
+```
+pip3 install -r requirements.txt
+export FLASK_APP=blockchain_explorer.py
+flask run
+```

--- a/mobilecoind/clients/python/blockchain_explorer/blockchain_explorer.py
+++ b/mobilecoind/clients/python/blockchain_explorer/blockchain_explorer.py
@@ -7,7 +7,6 @@ import argparse, datetime
 from flask import Flask, render_template
 
 import os,sys
-sys.path.insert(1, os.path.realpath(os.path.join(os.path.pardir, "lib")))
 import mobilecoin
 
 client = None  # client is initialized at the bottom of this file

--- a/mobilecoind/clients/python/blockchain_explorer/install.sh
+++ b/mobilecoind/clients/python/blockchain_explorer/install.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-# install python dependencies here
-python3 -m pip install --upgrade pip
-pip install --upgrade mobilecoin
-pip install --upgrade flask

--- a/mobilecoind/clients/python/blockchain_explorer/requirements.txt
+++ b/mobilecoind/clients/python/blockchain_explorer/requirements.txt
@@ -1,0 +1,4 @@
+Flask==1.1.2
+grpcio==1.32.0
+grpcio-tools==1.32.0
+mobilecoin==0.2.1


### PR DESCRIPTION
### Motivation

We now have mobilecoin as a PyPi package, so we can update our blockchain explorer appropriately.

### In this PR
* Updates blockchain_explorer to use the mobilecoin module
* Adds README
* Removes install.sh script in favor of requirements.txt

[MCC-1889](https://mobilecoin.atlassian.net/browse/MCC-1889)