### PR TITLE
Peer API error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,7 +2505,6 @@ dependencies = [
  "chrono",
  "curve25519-dalek",
  "displaydoc",
- "failure",
  "fs_extra",
  "futures 0.3.5",
  "grpcio",

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -40,7 +40,6 @@ base64 = "0.11"
 cfg-if = "0.1"
 chrono = "0.4"
 displaydoc = { version = "0.1.7", default-features = false }
-failure = "0.1.5"
 fs_extra = "1.1"
 futures = "0.3"
 grpcio = "0.6.0"

--- a/consensus/service/src/api/grpc_error.rs
+++ b/consensus/service/src/api/grpc_error.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use crate::tx_manager::TxManagerError;
-use failure::Fail;
+use displaydoc::Display;
 use grpcio::{RpcStatus, RpcStatusCode};
 use mc_common::logger::global_log;
 use mc_consensus_api::consensus_common::{ProposeTxResponse, ProposeTxResult};
@@ -9,38 +9,30 @@ use mc_consensus_enclave::Error as EnclaveError;
 use mc_ledger_db::Error as LedgerError;
 use mc_transaction_core::validation::TransactionValidationError;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Display)]
 pub enum ConsensusGrpcError {
-    /// Built-in grpc error
-    #[fail(display = "GRPC Error: {:?}", _0)]
+    /// GRPC Error: `{0:?}`
     RpcStatus(RpcStatus),
 
-    /// Ledger-related error
-    #[fail(display = "Ledger error: {}", _0)]
+    /// Ledger error: `{0}`
     Ledger(LedgerError),
 
-    /// Service is over capacity.
-    #[fail(display = "Over capacity")]
+    /// Service is over capacity
     OverCapacity,
 
-    /// Service is currently not serving requests.
-    #[fail(display = "Temporarily not serving requests")]
+    /// Service is currently not serving requests
     NotServing,
 
-    /// Enclave-related error.
-    #[fail(display = "Enclave error: {}", _0)]
+    /// Enclave error: `{0}`
     Enclave(EnclaveError),
 
-    /// Transaction validation error.
-    #[fail(display = "Transaction validation error: {}", _0)]
+    /// Transaction validation error `{0}`
     TransactionValidation(TransactionValidationError),
 
-    /// Invalid argument.
-    #[fail(display = "Invalid argument: {}", _0)]
+    /// Invalid argument `{0}`
     InvalidArgument(String),
 
-    /// Other errors.
-    #[fail(display = "Other error: {}", _0)]
+    /// Other error `{0}`
     Other(String),
 }
 

--- a/consensus/service/src/api/mod.rs
+++ b/consensus/service/src/api/mod.rs
@@ -7,6 +7,7 @@ mod blockchain_api_service;
 mod client_api_service;
 mod grpc_error;
 mod peer_api_service;
+mod peer_service_error;
 
 pub use attested_api_service::AttestedApiService;
 pub use blockchain_api_service::BlockchainApiService;

--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -185,17 +185,15 @@ impl PeerApiService {
         consensus_msg: mc_peers::ConsensusMsg,
         from_responder_id: ResponderId,
     ) -> Result<(), PeerServiceError> {
-        // Ignore consensus messages from unknown peers.
+        // Ignore a consensus message from an unknown peer.
         if !self.known_responder_ids.contains(&from_responder_id) {
             return Err(PeerServiceError::UnknownPeer(from_responder_id.to_string()));
         }
 
         // A consensus message with a valid signature.
-        let verified_consensus_msg: mc_peers::VerifiedConsensusMsg = {
-            consensus_msg
-                .try_into()
-                .map_err(|_| PeerServiceError::ConsensusMsgInvalidSignature)?
-        };
+        let verified_consensus_msg: mc_peers::VerifiedConsensusMsg = consensus_msg
+            .try_into()
+            .map_err(|_| PeerServiceError::ConsensusMsgInvalidSignature)?;
 
         (self.incoming_consensus_msgs_sender)(IncomingConsensusMsg {
             from_responder_id,

--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -161,11 +161,7 @@ impl PeerApiService {
     }
 
     /// Handle a consensus message from another node.
-    fn handle_consensus_msg(
-        &mut self,
-        request: &GrpcConsensusMsg,
-        logger: &Logger,
-    ) -> Result<(), PeerServiceError> {
+    fn handle_consensus_msg(&mut self, request: &GrpcConsensusMsg) -> Result<(), PeerServiceError> {
         // The peer who delivered this message to us.
         let from_responder_id = ResponderId::from_str(request.get_from_responder_id())
             .map_err(|_| PeerServiceError::InvalidArgument("from_responder_id".to_owned()))?;
@@ -275,7 +271,7 @@ impl ConsensusPeerApi for PeerApiService {
         let _timer = SVC_COUNTERS.req(&ctx);
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             let result: Result<ConsensusMsgResponse, RpcStatus> = match self
-                .handle_consensus_msg(&request, logger)
+                .handle_consensus_msg(&request)
             {
                 Ok(()) => {
                     let mut response = ConsensusMsgResponse::new();

--- a/consensus/service/src/api/peer_service_error.rs
+++ b/consensus/service/src/api/peer_service_error.rs
@@ -1,26 +1,21 @@
-use failure::Fail;
+use displaydoc::Display;
 use mc_transaction_core::tx::TxHash;
 
 /// Errors experienced when handling PeerAPI requests.
-#[derive(Debug, Fail)]
+#[derive(Debug, Display)]
 pub enum PeerServiceError {
-    /// Unknown peer.
-    #[fail(display = "Unknown peer: {}", _0)]
+    /// Unknown peer `{0}`.
     UnknownPeer(String),
 
     /// The ConsensusMsg's signature is invalid.
-    #[fail(display = "ConsensusMsgInvalidSignature")]
     ConsensusMsgInvalidSignature,
 
-    /// Unknown transactions
-    #[fail(display = "Unknown transactions")]
+    /// Unknown transactions `{0:?}`.
     UnknownTransactions(Vec<TxHash>),
 
-    /// Enclave-related error.
-    #[fail(display = "Enclave error: {}", _0)]
+    /// Enclave-related error `{0}`.
     Enclave(mc_consensus_enclave::Error),
 
     /// Something went wrong...
-    #[fail(display = "Internal error")]
     InternalError,
 }

--- a/consensus/service/src/api/peer_service_error.rs
+++ b/consensus/service/src/api/peer_service_error.rs
@@ -1,12 +1,9 @@
 use failure::Fail;
+use mc_transaction_core::tx::TxHash;
 
 /// Errors experienced when handling PeerAPI requests.
 #[derive(Debug, Fail)]
 pub enum PeerServiceError {
-    /// Invalid argument.
-    #[fail(display = "Invalid argument: {}", _0)]
-    InvalidArgument(String),
-
     /// Unknown peer.
     #[fail(display = "Unknown peer: {}", _0)]
     UnknownPeer(String),
@@ -14,6 +11,14 @@ pub enum PeerServiceError {
     /// The ConsensusMsg's signature is invalid.
     #[fail(display = "ConsensusMsgInvalidSignature")]
     ConsensusMsgInvalidSignature,
+
+    /// Unknown transactions
+    #[fail(display = "Unknown transactions")]
+    UnknownTransactions(Vec<TxHash>),
+
+    /// Enclave-related error.
+    #[fail(display = "Enclave error: {}", _0)]
+    Enclave(mc_consensus_enclave::Error),
 
     /// Something went wrong...
     #[fail(display = "Internal error")]

--- a/consensus/service/src/api/peer_service_error.rs
+++ b/consensus/service/src/api/peer_service_error.rs
@@ -1,0 +1,21 @@
+use failure::Fail;
+
+/// Errors experienced when handling PeerAPI requests.
+#[derive(Debug, Fail)]
+pub enum PeerServiceError {
+    /// Invalid argument.
+    #[fail(display = "Invalid argument: {}", _0)]
+    InvalidArgument(String),
+
+    /// Unknown peer.
+    #[fail(display = "Unknown peer: {}", _0)]
+    UnknownPeer(String),
+
+    /// The ConsensusMsg's signature is invalid.
+    #[fail(display = "ConsensusMsgInvalidSignature")]
+    ConsensusMsgInvalidSignature,
+
+    /// Something went wrong...
+    #[fail(display = "Internal error")]
+    InternalError,
+}

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -804,7 +804,6 @@ mod tests {
         },
         tx_manager::{MockTxManager, TxManagerError},
     };
-    use failure::_core::time::Duration;
     use mc_common::{
         logger::{test_with_logger, Logger},
         NodeID, ResponderId,
@@ -832,7 +831,7 @@ mod tests {
             atomic::{AtomicBool, AtomicU64},
             Arc, Mutex,
         },
-        time::Instant,
+        time::{Duration, Instant},
     };
 
     /// Create test mocks with sensible defaults.

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -12,7 +12,7 @@ use crate::{
     tx_manager::TxManager,
 };
 use base64::{encode_config, URL_SAFE};
-use failure::Fail;
+use displaydoc::Display;
 use futures::executor::block_on;
 use grpcio::{EnvBuilder, Environment, Server, ServerBuilder};
 use mc_attest_api::attest_grpc::create_attested_api;
@@ -48,17 +48,17 @@ use std::{
 /// Crate version, used for admin info endpoint
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Display)]
 pub enum ConsensusServiceError {
-    #[fail(display = "Failed to join thread: {}", _0)]
+    /// Failed to join thread: `{0}`
     ThreadJoin(String),
-    #[fail(display = "RPC shutdown failure: {}", _0)]
+    /// RPC shutdown failure: `{0}`
     RpcShutdown(String),
-    #[fail(display = "Failed to start background work queue: {}", _0)]
+    /// Failed to start background work queue: `{0}`
     BackgroundWorkQueueStart(String),
-    #[fail(display = "Failed to stop background work queue: {}", _0)]
+    /// Failed to stop background work queue: `{0}`
     BackgroundWorkQueueStop(String),
-    #[fail(display = "Report cache error: {}", _0)]
+    /// Report cache error: `{0}`
     ReportCache(ReportCacheError),
 }
 impl From<ReportCacheError> for ConsensusServiceError {


### PR DESCRIPTION
Soundtrack of this PR: [Kiss from a Rose](https://www.youtube.com/watch?v=G76nKGWRLPU)

### Motivation

I was getting bogged down by the error handling in PeerApiService. 

### In this PR
* Separates "logic" error handling from gRPC serialization/deserialization error handling.
* Extracts some logic into `handle_consensus_msg`.
* Creates an error type for PeerAPIService.

In total, I think this makes it easier to see what's going on.
