### PR TITLE
Mobilecoind performance improvements

### DIFF
--- a/ledger/sync/src/ledger_sync/ledger_sync_service.rs
+++ b/ledger/sync/src/ledger_sync/ledger_sync_service.rs
@@ -33,6 +33,9 @@ use std::{
 const DEFAULT_GET_BLOCKS_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_GET_TRANSACTIONS_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Maximal amount of concurrent get_block_contents calls to allow.
+const MAX_CONCURRENT_GET_BLOCK_CONTENTS_CALLS: usize = 500;
+
 pub struct LedgerSyncService<L: Ledger, BC: BlockchainConnection, TF: TransactionsFetcher> {
     ledger: L,
     manager: ConnectionManager<BC>,
@@ -514,8 +517,7 @@ fn get_block_contents<TF: TransactionsFetcher + 'static>(
     // Spawn worker threads.
     let mut thread_handles = Vec::new();
 
-    // TODO: hardcoded limit
-    let num_workers = std::cmp::min(5, blocks.len());
+    let num_workers = std::cmp::min(MAX_CONCURRENT_GET_BLOCK_CONTENTS_CALLS, blocks.len());
     for worker_num in 0..num_workers {
         let thread_results_and_condvar = results_and_condvar.clone();
         let thread_sender = sender.clone();

--- a/ledger/sync/src/ledger_sync/ledger_sync_service_thread.rs
+++ b/ledger/sync/src/ledger_sync/ledger_sync_service_thread.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 /// Maximal number of blocks to attempt to sync at each loop iteration.
-const MAX_BLOCKS_PER_SYNC_ITERATION: u32 = 100;
+const MAX_BLOCKS_PER_SYNC_ITERATION: u32 = 10000;
 
 pub struct LedgerSyncServiceThread {
     join_handle: Option<thread::JoinHandle<()>>,

--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -12,7 +12,7 @@ use mc_mobilecoind::{
 use mc_watcher::{watcher::WatcherSyncThread, watcher_db::create_or_open_rw_watcher_db};
 use std::{
     path::Path,
-    sync::{Arc, Mutex},
+    sync::{Arc, RwLock},
 };
 use structopt::StructOpt;
 
@@ -36,7 +36,7 @@ fn main() {
     let peer_manager = config.peers_config.create_peer_manager(verifier, &logger);
 
     // Create network state, transactions fetcher and ledger sync.
-    let network_state = Arc::new(Mutex::new(PollingNetworkState::new(
+    let network_state = Arc::new(RwLock::new(PollingNetworkState::new(
         config.quorum_set(),
         peer_manager.clone(),
         logger.clone(),

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -42,7 +42,7 @@ use mc_watcher::watcher_db::WatcherDB;
 use protobuf::{ProtobufEnum, RepeatedField};
 use std::{
     convert::TryFrom,
-    sync::{Arc, Mutex},
+    sync::{Arc, RwLock},
 };
 
 pub struct Service {
@@ -59,7 +59,7 @@ impl Service {
         mobilecoind_db: Database,
         watcher_db: Option<WatcherDB>,
         transactions_manager: TransactionsManager<T>,
-        network_state: Arc<Mutex<PollingNetworkState<T>>>,
+        network_state: Arc<RwLock<PollingNetworkState<T>>>,
         listen_uri: &MobilecoindUri,
         num_workers: Option<usize>,
         logger: Logger,
@@ -119,7 +119,7 @@ pub struct ServiceApi<T: BlockchainConnection + UserTxConnection + 'static> {
     ledger_db: LedgerDB,
     mobilecoind_db: Database,
     watcher_db: Option<WatcherDB>,
-    network_state: Arc<Mutex<PollingNetworkState<T>>>,
+    network_state: Arc<RwLock<PollingNetworkState<T>>>,
     logger: Logger,
 }
 
@@ -142,7 +142,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         ledger_db: LedgerDB,
         mobilecoind_db: Database,
         watcher_db: Option<WatcherDB>,
-        network_state: Arc<Mutex<PollingNetworkState<T>>>,
+        network_state: Arc<RwLock<PollingNetworkState<T>>>,
         logger: Logger,
     ) -> Self {
         Self {
@@ -1473,7 +1473,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
         &mut self,
         _request: mc_mobilecoind_api::Empty,
     ) -> Result<mc_mobilecoind_api::GetNetworkStatusResponse, RpcStatus> {
-        let network_state = self.network_state.lock().expect("mutex poisoned");
+        let network_state = self.network_state.read().expect("lock poisoned");
         let num_blocks = self
             .ledger_db
             .num_blocks()

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -34,7 +34,7 @@ use std::{
     str::FromStr,
     sync::{
         atomic::{AtomicUsize, Ordering::SeqCst},
-        Arc, Mutex,
+        Arc, RwLock,
     },
 };
 use tempdir::TempDir;
@@ -247,14 +247,14 @@ fn setup_server(
 
     let conn_manager = ConnectionManager::new(vec![peer1, peer2], logger.clone());
 
-    let network_state = Arc::new(Mutex::new(PollingNetworkState::new(
+    let network_state = Arc::new(RwLock::new(PollingNetworkState::new(
         quorum_set,
         conn_manager.clone(),
         logger.clone(),
     )));
 
     {
-        let mut network_state = network_state.lock().unwrap();
+        let mut network_state = network_state.write().unwrap();
         network_state.poll();
     }
 


### PR DESCRIPTION
Soundtrack of this PR: [Chino Moreno - Brief Exchange](https://www.youtube.com/watch?v=sBMGiHosRYk)

### Motivation

Slow ledger syncing is a suboptimal user-experience, and we'd like it to be faster.

### In this PR
* Increasing number of worker threads when fetching S3 blocks, as well as increasing the amount of block headers fetched from consensus. This results in bringing ledger sync time from several minutes to 40-60 seconds on my machines.
* Switch a mutex around `NetworkState` to an `RwLock` - this allows mobilecoind's `GetNetworkStatus` RPC call to not block when a ledger sync is taking place.

### Future Work
* Dig further into why attempts at changing the S3 fetching to use async code result in worse performance than creating 500 real threads.
* Consider post-processing blocks into larger chunks in order to reduce number of S3 requests needed.