### PR TITLE
always return full API response from python library (MCC-1904)

### DIFF
--- a/mobilecoind/clients/python/blockchain_explorer/blockchain_explorer.py
+++ b/mobilecoind/clients/python/blockchain_explorer/blockchain_explorer.py
@@ -32,7 +32,10 @@ def command_args():
     return parser.parse_args()
 
 def render_ledger_range(start, count):
-    num_blocks, num_transactions = client.get_ledger_info()
+    ledger_info_response = client.get_ledger_info()
+    num_blocks = ledger_info_response.block_count
+    num_transactions = ledger_info_response.txo_count
+
     start = max(int(start), 0)
     finish = min(int(start + 100), num_blocks - 1)
     if finish - start < 100:
@@ -42,7 +45,9 @@ def render_ledger_range(start, count):
     signers = {}
 
     for i in range(finish, start, -1):
-        key_image_count, txo_count = client.get_block_info(i)
+        block_info_response = client.get_block_info(i)
+        key_image_count = block_info_response.key_image_count
+        txo_count = block_info_response.txo_count
 
         # very large blocks cause errors for client.get_block()
         # specifically ResourceExhausted for messages larger than 4194304
@@ -84,7 +89,9 @@ def format_datetime(value):
 
 @app.route('/')
 def index():
-    num_blocks, num_transactions = client.get_ledger_info()
+    ledger_info_response = client.get_ledger_info()
+    num_blocks = ledger_info_response.block_count
+    num_transactions = ledger_info_response.txo_count
     return render_ledger_range(num_blocks - 101, 100)
 
 @app.route('/from/<block_num>')
@@ -93,7 +100,9 @@ def ledger(block_num):
 
 @app.route('/block/<block_num>')
 def block(block_num):
-    num_blocks, num_transactions = client.get_ledger_info()
+    ledger_info_response = client.get_ledger_info()
+    num_blocks = ledger_info_response.block_count
+    num_transactions = ledger_info_response.txo_count
     block_num = int(block_num)
     if block_num < 0 or block_num >= num_blocks:
         return render_template('block404.html',

--- a/mobilecoind/clients/python/cli/benchmark.py
+++ b/mobilecoind/clients/python/cli/benchmark.py
@@ -42,13 +42,13 @@ if __name__ == '__main__':
     print("\n...testing `mobilecoind.add_monitor`")
     print("{:>18}, {:>18}".format("num_subaddresses", "duration (sec)"))
     for count in subaddress_counts:
-        entropy_bytes = mobilecoind.generate_entropy()
-        account_key = mobilecoind.get_account_key(entropy_bytes)
+        entropy_bytes = mobilecoind.generate_entropy().entropy
+        account_key = mobilecoind.get_account_key(entropy_bytes).account_key
         start = datetime.datetime.now()
         monitor_id = mobilecoind.add_monitor(account_key,
                                              first_subaddress = mobilecoin.DEFAULT_SUBADDRESS_INDEX,
                                              num_subaddresses = count,
-                                             first_block = remote_count)
+                                             first_block = remote_count).monitor_id
         finish = datetime.datetime.now()
         print("{:>18}, {:>18}".format(count, (finish - start).total_seconds()))
         monitors.append(monitor_id)
@@ -62,7 +62,7 @@ if __name__ == '__main__':
 
     def active_monitors():
         count = 0
-        for monitor_id in mobilecoind.get_monitor_list():
+        for monitor_id in mobilecoind.get_monitor_list().monitor_id_list:
             (monitor_is_behind, next_block, remote_count, blocks_per_second) = mobilecoind.wait_for_monitor(monitor_id)
             if monitor_is_behind:
                 count += 1
@@ -73,7 +73,7 @@ if __name__ == '__main__':
     monitors_are_behind = True
     while monitors_are_behind:
         monitors_are_behind = False
-        for monitor_id in mobilecoind.get_monitor_list():
+        for monitor_id in mobilecoind.get_monitor_list().monitor_id_list:
             (monitor_is_behind, prev_next_block, remote_count, blocks_per_second) = mobilecoind.wait_for_monitor(monitor_id)
             if monitor_is_behind:
                 (monitor_is_behind, next_block, remote_count, blocks_per_second) = mobilecoind.wait_for_ledger(max_blocks_to_sync=1000, timeout_seconds=10)
@@ -86,12 +86,12 @@ if __name__ == '__main__':
         print("\n...testing block processing rate with new monitor with {} subaddresses".format(count))
         accum_count = 0
         accum_rate_times_count = 0
-        entropy_bytes = mobilecoind.generate_entropy()
-        account_key = mobilecoind.get_account_key(entropy_bytes)
+        entropy_bytes = mobilecoind.generate_entropy().entropy
+        account_key = mobilecoind.get_account_key(entropy_bytes).account_key
         monitor_id = mobilecoind.add_monitor(account_key,
                                              first_subaddress = mobilecoin.DEFAULT_SUBADDRESS_INDEX,
                                              num_subaddresses = count,
-                                             first_block = remote_count-5000)
+                                             first_block = remote_count-5000).monitor_id
 
         (monitor_is_behind, prev_next_block, remote_count, blocks_per_second) = mobilecoind.wait_for_monitor(monitor_id)
         start = datetime.datetime.now()

--- a/mobilecoind/clients/python/cli/check_balance.py
+++ b/mobilecoind/clients/python/cli/check_balance.py
@@ -26,8 +26,8 @@ if __name__ == '__main__':
 
     # create a monitor
     entropy_bytes = bytes.fromhex(args.key)
-    account_key = mobilecoind.get_account_key(entropy_bytes)
-    monitor_id = mobilecoind.add_monitor(account_key, first_subaddress=args.subaddress, first_block=args.first_block)
+    account_key = mobilecoind.get_account_key(entropy_bytes).account_key
+    monitor_id = mobilecoind.add_monitor(account_key, first_subaddress=args.subaddress, first_block=args.first_block).monitor_id
 
     # Wait for the monitor to process the complete ledger (this also downloads the complete ledger)
     (monitor_is_behind, next_block, remote_count, blocks_per_second) = mobilecoind.wait_for_monitor(monitor_id)
@@ -44,8 +44,8 @@ if __name__ == '__main__':
         print("# monitor has processed all {} blocks\n".format(remote_count))
 
 
-    balance_picoMOB = mobilecoind.get_balance(monitor_id, subaddress_index=args.subaddress)
-    public_address = mobilecoind.get_public_address(monitor_id, subaddress_index=args.subaddress)
+    balance_picoMOB = mobilecoind.get_balance(monitor_id, subaddress_index=args.subaddress).balance
+    public_address = mobilecoind.get_public_address(monitor_id, subaddress_index=args.subaddress).public_address
 
     # print account information
     print("\n")

--- a/mobilecoind/clients/python/cli/cleanup_monitors.py
+++ b/mobilecoind/clients/python/cli/cleanup_monitors.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     # Connect to mobilecoind
     mobilecoind = mobilecoin.Client("localhost:4444", ssl=False)
 
-    monitor_list = mobilecoind.get_monitor_list()
+    monitor_list = mobilecoind.get_monitor_list().monitor_id_list
     # show a summary of all monitors
     if len(monitor_list) == 0:
         print("\n    There no active monitors.\n")
@@ -38,7 +38,7 @@ if __name__ == '__main__':
         print("    {:<18}{:<18}{:<18}".format("Monitor ID", "Subaddress Range", "Next Block"))
         for monitor_id in monitor_list:
             # check monitor status
-            status = mobilecoind.get_monitor_status(monitor_id)
+            status = mobilecoind.get_monitor_status(monitor_id).status
             first_subaddress: int = status.first_subaddress if hasattr(status, 'first_subaddress') else 0
             num_subaddresses: int = status.num_subaddresses if hasattr(status, 'num_subaddresses')  else 0
             last_subaddress:int = first_subaddress + num_subaddresses - 1
@@ -49,10 +49,13 @@ if __name__ == '__main__':
     # iterate over all active monitors
     for monitor_id in monitor_list:
         # check ledger status
-        remote_count, local_count, is_behind = mobilecoind.get_network_status()
+        network_status_response = self.get_network_status()
+        remote_count = network_status_response.network_highest_block_index
+        local_count = network_status_response.local_block_index
+        ledger_is_behind = network_status_response.is_behind
 
         # check monitor status
-        status = mobilecoind.get_monitor_status(monitor_id)
+        status = mobilecoind.get_monitor_status(monitor_id).status
 
         # get fields (protobuf omits fields with empty or zero values)
         account_key = status.account_key if hasattr(status, 'account_key') else None
@@ -74,7 +77,7 @@ if __name__ == '__main__':
         print("    {:<18}{:<20}".format("Address Code", "Balance (pMOB)", "Balance"))
         for subaddress_index in range(first_subaddress, first_subaddress + min(10, num_subaddresses)):
             address_code = mobilecoind.get_public_address(monitor_id, subaddress_index=subaddress_index).b58_code
-            balance_picoMOB = mobilecoind.get_balance(monitor_id, subaddress_index=subaddress_index)
+            balance_picoMOB = mobilecoind.get_balance(monitor_id, subaddress_index=subaddress_index).balance
             print("    {:<18}{:<20}{:<20}".format(address_code[0:10]+"...", balance_picoMOB, mobilecoin.display_as_MOB(balance_picoMOB)))
         print("\n")
 

--- a/mobilecoind/clients/python/cli/get_public_address.py
+++ b/mobilecoind/clients/python/cli/get_public_address.py
@@ -23,10 +23,10 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # create a monitor and use it to calculate the public address
-    entropy_bytes = bytes.fromhex(args.key) if args.key else mobilecoind.generate_entropy()
-    account_key = mobilecoind.get_account_key(entropy_bytes)
-    monitor_id = mobilecoind.add_monitor(account_key, first_subaddress=args.subaddress)
-    public_address = mobilecoind.get_public_address(monitor_id, subaddress_index=args.subaddress)
+    entropy_bytes = bytes.fromhex(args.key) if args.key else mobilecoind.generate_entropy().entropy
+    account_key = mobilecoind.get_account_key(entropy_bytes).account_key
+    monitor_id = mobilecoind.add_monitor(account_key, first_subaddress=args.subaddress).monitor_id
+    public_address = mobilecoind.get_public_address(monitor_id, subaddress_index=args.subaddress).public_address
 
     # print the public address information
     print("\n")

--- a/mobilecoind/clients/python/lib/setup.py
+++ b/mobilecoind/clients/python/lib/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mobilecoin",
-    version="0.2.1",
+    version="0.3.0",
     author="MobileCoin",
     author_email="support@mobilecoin.com",
     description="Python bindings for the MobileCoin daemon API.",

--- a/mobilecoind/clients/python/mailchimp/download_members.py
+++ b/mobilecoind/clients/python/mailchimp/download_members.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     # clean up all old monitors
     if args.clean:
-        for monitor_id in mobilecoind.get_monitor_list():
+        for monitor_id in mobilecoind.get_monitor_list().monitor_id_list:
             print("# removing existing monitor_id {}".format(monitor_id.hex()))
             mobilecoind.remove_monitor(monitor_id)
 
@@ -55,8 +55,8 @@ if __name__ == '__main__':
             email = member_record["email_address"]
 
             entropy_bytes = bytes.fromhex(entropy)
-            account_key = mobilecoind.get_account_key(entropy_bytes)
-            monitor_id = mobilecoind.add_monitor(account_key)
+            account_key = mobilecoind.get_account_key(entropy_bytes).account_key
+            monitor_id = mobilecoind.add_monitor(account_key).monitor_id
 
             (monitor_is_behind, next_block, remote_count, blocks_per_second) = mobilecoind.wait_for_monitor(monitor_id)
             if monitor_is_behind:
@@ -71,5 +71,5 @@ if __name__ == '__main__':
                     (monitor_is_behind, next_block, remote_count, blocks_per_second) = mobilecoind.wait_for_monitor(monitor_id, max_blocks_to_sync=10000, timeout_seconds=60)
                 print("# monitor has processed all {} blocks\n#".format(remote_count))
 
-            balance_picoMOB = mobilecoind.get_balance(monitor_id)
+            balance_picoMOB = mobilecoind.get_balance(monitor_id).balance
             print("{}, {}, {}, {}".format(entropy, email, balance_picoMOB, mobilecoin.display_as_MOB(balance_picoMOB)))

--- a/mobilecoind/clients/python/pizzamob_leaderboard/pizzamob_leaderboard.py
+++ b/mobilecoind/clients/python/pizzamob_leaderboard/pizzamob_leaderboard.py
@@ -73,8 +73,8 @@ def add_user():
         subaddress = res[0]['subaddress']
 
     monitor = get_or_add_monitor(subaddress)
-    request_code = create_request_code(monitor, subaddress)
-    balance = mobilecoind.get_balance(monitor, subaddress)
+    request_code = create_request_code(monitor, subaddress).b58_code
+    balance = mobilecoind.get_balance(monitor, subaddress).balance
 
     if new_player:
         players.insert({
@@ -112,12 +112,11 @@ def get_or_add_monitor(subaddress):
         monitor_id = mobilecoind.get_monitor_id(credentials, index=subaddress)
     except Exception as _e:
         # Always only add for the master credentials.
-        monitor_id = mobilecoind.add_monitor(credentials)
+        monitor_id = mobilecoind.add_monitor(credentials).monitor_id
     return monitor_id
 
 def create_request_code(monitor, subaddress):
-    public_address = mobilecoind.get_public_address(monitor, subaddress)
-    return mobilecoind.create_request_code(public_address)
+    return mobilecoind.get_public_address(monitor, subaddress).b58_code
 
 def get_leaderboard():
     player_table = db.table('Players')
@@ -125,7 +124,7 @@ def get_leaderboard():
     res = []
     for p in players:
         monitor = get_or_add_monitor(p['subaddress'])
-        balance = mobilecoind.get_balance(monitor, p['subaddress'])
+        balance = mobilecoind.get_balance(monitor, p['subaddress']).balance
         res.append({'balance': balance / MOB, 'code': p['code']})
     res.sort(key=lambda player: player['balance'])
     res.reverse()
@@ -145,7 +144,7 @@ if __name__ == "__main__":
     mobilecoind = mobilecoin.Client(args.mobilecoind_host + ':' + str(args.mobilecoind_port), False)
 
     # Load the credentials for the master account
-    credentials = mobilecoind.get_account_key(bytes.fromhex(args.entropy))
+    credentials = mobilecoind.get_account_key(bytes.fromhex(args.entropy)).account_key
     get_or_add_monitor(0)
 
     app.run(host='0.0.0.0', port=int(args.port))


### PR DESCRIPTION
Soundtrack of this PR: [bg](https://soundcloud.com/pheel518/pheel-featherbed-sessions-vol1-mix)

### Motivation

If we add fields to messages in the protobuf API, it would be great for these to be available immediately in the python library.

### In this PR
* avoid unwrapping API responses in the python library [MCC-1904]
* since this is a breaking change, update the library to v0.3



[MCC-1904]: https://mobilecoin.atlassian.net/browse/MCC-1904