### PR TITLE
[MCC-1911 Add Xcode 12 testing to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ version: 2.1
 
 defaults:
   builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_12
-  default-xcode-version: &default-xcode-version "11.7.0"
+  default-xcode-version: &default-xcode-version "12.0.0"
 
   default-environment: &default-environment
     # sccache config
@@ -565,4 +565,4 @@ workflows:
           name: build-macos-xcode-<< matrix.xcode-version >>
           matrix:
             parameters:
-              xcode-version: [*default-xcode-version]
+              xcode-version: ["11.7.0", *default-xcode-version]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ version: 2.1
 
 defaults:
   builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_12
+  default-xcode-version: &default-xcode-version "11.7.0"
 
   default-environment: &default-environment
     # sccache config
@@ -37,8 +38,12 @@ executors:
     resource_class: large
 
   macos:
+    parameters:
+      xcode-version:
+        type: string
+        default: *default-xcode-version
     macos:
-      xcode: 11.7.0
+      xcode: << parameters.xcode-version >>
     environment:
       HOMEBREW_NO_AUTO_UPDATE: "1"
       HOMEBREW_NO_INSTALL_CLEANUP: "1"
@@ -492,7 +497,13 @@ jobs:
 
   # Build using macOS
   build-macos:
-    executor: macos
+    parameters:
+      xcode-version:
+        type: string
+        default: *default-xcode-version
+    executor:
+      name: macos
+      xcode-version: << parameters.xcode-version >>
     environment:
       <<: *default-build-environment
       SCCACHE_CACHE_SIZE: 450M
@@ -550,4 +561,8 @@ workflows:
       - build-and-lint-debug
 
       # Build using macOS
-      - build-macos
+      - build-macos:
+          name: build-macos-xcode-<< matrix.xcode-version >>
+          matrix:
+            parameters:
+              xcode-version: [*default-xcode-version]


### PR DESCRIPTION
### Motivation

Apple release Xcode 12 recently which caused the repo to no longer compile on the latest macOS (see #488).

This PR sets up a build matrix for macOS testing using multiple Xcode versions, and adds testing using Xcode 12.0.0 in addition to the existing 11.7.0 testing.

### In this PR
* Parameterize macos executor in circleci config
* Add Xcode 12 testing to CI

Fixes [MCC-1911]

[MCC-1911]: https://mobilecoin.atlassian.net/browse/MCC-1911