### PR TITLE
add QuorumSet::is_valid, call it when quorum sets are being parsed

### DIFF
--- a/consensus/scp/play/src/main.rs
+++ b/consensus/scp/play/src/main.rs
@@ -37,8 +37,14 @@ pub struct Config {
 }
 
 fn parse_quorum_set_from_json(src: &str) -> Result<QuorumSet, String> {
-    Ok(serde_json::from_str(src)
-        .map_err(|err| format!("Error parsing quorum set {}: {:?}", src, err))?)
+    let quorum_set: QuorumSet = serde_json::from_str(src)
+        .map_err(|err| format!("Error parsing quorum set {}: {:?}", src, err))?;
+
+    if !quorum_set.is_valid() {
+        return Err(format!("Invalid quorum set: {:?}", quorum_set));
+    }
+
+    Ok(quorum_set)
 }
 
 fn parse_node_id_from_uri(src: &str) -> Result<NodeID, String> {

--- a/consensus/scp/src/msg.rs
+++ b/consensus/scp/src/msg.rs
@@ -360,6 +360,10 @@ impl<
 
     /// Basic validation of Msg structure.
     pub fn validate(&self) -> Result<(), String> {
+        if !self.quorum_set.is_valid() {
+            return Err(format!("Invalid quorum set {:?}", self.quorum_set));
+        }
+
         let validate_nominate = |payload: &NominatePayload<V>| -> Result<(), String> {
             if payload.X.intersection(&payload.Y).next().is_some() {
                 Err(format!("X intersects Y, msg: {}", self.to_display()))

--- a/consensus/service/src/config.rs
+++ b/consensus/service/src/config.rs
@@ -129,6 +129,10 @@ pub struct NetworkConfig {
 
 impl NetworkConfig {
     pub fn quorum_set(&self) -> QuorumSet {
+        if !self.quorum_set.is_valid() {
+            panic!("invalid quorum set: {:?}", self.quorum_set);
+        }
+
         let mut peer_map: HashMap<ResponderId, NodeID> =
             HashMap::from_iter(self.broadcast_peers.iter().cloned().map(|uri| {
                 (

--- a/mobilecoind/src/config.rs
+++ b/mobilecoind/src/config.rs
@@ -70,8 +70,14 @@ fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseIntEr
 }
 
 fn parse_quorum_set_from_json(src: &str) -> Result<QuorumSet<ResponderId>, String> {
-    Ok(serde_json::from_str(src)
-        .map_err(|err| format!("Error parsing quorum set {}: {:?}", src, err))?)
+    let quorum_set: QuorumSet<ResponderId> = serde_json::from_str(src)
+        .map_err(|err| format!("Error parsing quorum set {}: {:?}", src, err))?;
+
+    if !quorum_set.is_valid() {
+        return Err(format!("Invalid quorum set: {:?}", quorum_set));
+    }
+
+    Ok(quorum_set)
 }
 
 impl Config {


### PR DESCRIPTION
### Motivation

We'd like to have a sanity check around basic quorum set configuration when it is constructed from user input or external sources.

### In this PR
* Add an `is_valid()` method on `QuorumSet` that ensures the quorum set, and all of its inner sets have `threshold <= number of members`.

### Future Work
* Ideally we should have less panics around this and more `Result<>`, but that is a bigger change and the extra panics were added to places that would already panic on incorrect input.
* It would've been nice if the various `QuorumSet` constructors returned a `Result` and forced validation - but that means changing about 200 calls, mostly in test code. It also does not protect against deserializing a broken `QuorumSet`, which is where the real problem is and unfortunately `serde` does not have a good solution for that at the moment.

