### PR TITLE
Update path for mobilecoind-json to match mirror

### DIFF
--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -581,7 +581,7 @@ fn block_details(
     Ok(Json(JsonBlockDetailsResponse::from(&resp)))
 }
 /// Retreives processed block information.
-#[get("/monitors/<monitor_hex>/processed-blocks/<block_num>")]
+#[get("/monitors/<monitor_hex>/processed-block/<block_num>")]
 fn processed_block(
     state: rocket::State<State>,
     monitor_hex: String,

--- a/tools/release-tests/mirror-json-test.py
+++ b/tools/release-tests/mirror-json-test.py
@@ -239,19 +239,18 @@ if response.status_code == 200:
     processed_block_pub = response.json()
     print(f"Got processed_block = {processed_block_pub}")
 else:
-    print("tx-out/tx_public_key/block-index returned status code %d" % response.status_code)
+    print("processed-block/block-index returned status code %d" % response.status_code)
     shutdown(1)
 
 # Get the processed block for that block index via mobilecoind-json
-# FIXME: Singular processed-block after release for MCC-1910
-url = f"http://localhost:9090/monitors/{monitor_id}/processed-blocks/{block_index}"
+url = f"http://localhost:9090/monitors/{monitor_id}/processed-block/{block_index}"
 response = requests.get(url)
 if response.status_code == 200:
     processed_block = response.json()
     print(f"Got processed_block = {processed_block}")
     assert processed_block == processed_block_pub, "Processed blocks do not match"
 else:
-    print("tx-out/tx_public_key/block-index returned status code %d" % response.status_code)
+    print("monitors/monitor-id/processed-block/block-index returned status code %d" % response.status_code)
     shutdown(1)
 
 print("All tests succeeded!")


### PR DESCRIPTION
### Motivation

Currently, the processed-block endpoint is `processed-blocks` in mobilecoind-json, and `processed-block` on the mirror. This PR makes them consistent (processed-block).

### In this PR
* Updates mobilecoind-json `processed-blocks` -> `processed-block`
* Adds the mobilecoind-json processed-block endpoint to the integration test

[MCC-1910](https://mobilecoin.atlassian.net/browse/MCC-1910)
