### PR TITLE
New data type: BlockData

### DIFF
--- a/api/src/convert/archive_block.rs
+++ b/api/src/convert/archive_block.rs
@@ -1,0 +1,25 @@
+//! Convert to/from blockchain::ArchiveBlock
+
+use crate::blockchain; // , convert::ConversionError
+
+/// Convert mc_transaction_core::BlockData --> blockchain::ArchiveBlock.
+impl From<&mc_transaction_core::BlockData> for blockchain::ArchiveBlock {
+    fn from(src: &mc_transaction_core::BlockData) -> Self {
+        let bc_block = blockchain::Block::from(src.block());
+        let bc_block_contents = blockchain::BlockContents::from(src.contents());
+
+        let mut archive_block_v1 = blockchain::ArchiveBlockV1::new();
+        archive_block_v1.set_block(bc_block);
+        archive_block_v1.set_block_contents(bc_block_contents);
+
+        if let Some(signature) = src.signature() {
+            let bc_signature = blockchain::BlockSignature::from(signature);
+            archive_block_v1.set_signature(bc_signature);
+        }
+
+        let mut archive_block = blockchain::ArchiveBlock::new();
+        archive_block.set_v1(archive_block_v1);
+
+        archive_block
+    }
+}

--- a/api/src/convert/archive_block.rs
+++ b/api/src/convert/archive_block.rs
@@ -1,6 +1,7 @@
 //! Convert to/from blockchain::ArchiveBlock
 
-use crate::blockchain; // , convert::ConversionError
+use crate::{blockchain, convert::ConversionError};
+use std::convert::TryFrom;
 
 /// Convert mc_transaction_core::BlockData --> blockchain::ArchiveBlock.
 impl From<&mc_transaction_core::BlockData> for blockchain::ArchiveBlock {
@@ -21,5 +22,44 @@ impl From<&mc_transaction_core::BlockData> for blockchain::ArchiveBlock {
         archive_block.set_v1(archive_block_v1);
 
         archive_block
+    }
+}
+
+/// Convert from blockchain::ArchiveBlock --> mc_transaction_core::BlockData
+impl TryFrom<&blockchain::ArchiveBlock> for mc_transaction_core::BlockData {
+    type Error = ConversionError;
+
+    fn try_from(src: &blockchain::ArchiveBlock) -> Result<Self, Self::Error> {
+        if !src.has_v1() {
+            return Err(ConversionError::ObjectMissing);
+        }
+
+        let block = mc_transaction_core::Block::try_from(src.get_v1().get_block())?;
+
+        let block_contents =
+            mc_transaction_core::BlockContents::try_from(src.get_v1().get_block_contents())?;
+
+        let signature = src
+            .get_v1()
+            .signature
+            .as_ref()
+            .map(mc_transaction_core::BlockSignature::try_from)
+            .transpose()?;
+
+        if let Some(signature) = signature.as_ref() {
+            signature
+                .verify(&block)
+                .map_err(|_| ConversionError::InvalidSignature)?;
+        }
+
+        if block.contents_hash != block_contents.hash() {
+            return Err(ConversionError::InvalidContents);
+        }
+
+        Ok(mc_transaction_core::BlockData::new(
+            block,
+            block_contents,
+            signature,
+        ))
     }
 }

--- a/api/src/convert/error.rs
+++ b/api/src/convert/error.rs
@@ -15,6 +15,9 @@ pub enum ConversionError {
     Key(mc_crypto_keys::KeyError),
     FeeMismatch,
     IndexOutOfBounds,
+    ObjectMissing,
+    InvalidSignature,
+    InvalidContents,
     Other,
 }
 

--- a/api/src/convert/mod.rs
+++ b/api/src/convert/mod.rs
@@ -9,6 +9,7 @@
 mod error;
 
 // blockchain
+mod archive_block;
 mod block;
 mod block_contents;
 mod block_contents_hash;
@@ -37,6 +38,7 @@ mod tx_prefix;
 
 pub use account_key::*;
 pub use amount::*;
+pub use archive_block::*;
 pub use block::*;
 pub use block_contents::*;
 pub use block_contents_hash::*;

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -6,7 +6,7 @@ use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipProof},
-    Block, BlockContents, BlockSignature,
+    Block, BlockContents, BlockData, BlockSignature,
 };
 use mockall::*;
 
@@ -31,6 +31,9 @@ pub trait Ledger: Send {
 
     /// Gets a block signature by its index in the blockchain.
     fn get_block_signature(&self, block_number: u64) -> Result<BlockSignature, Error>;
+
+    /// Gets a block and all of its associated data by its index in the blockchain.
+    fn get_block_data(&self, block_number: u64) -> Result<BlockData, Error>;
 
     /// Gets block index by a TxOut global index.
     fn get_block_index_by_tx_out_index(&self, tx_out_index: u64) -> Result<u64, Error>;

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -26,7 +26,7 @@ use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipProof},
-    Block, BlockContents, BlockID, BlockSignature, BLOCK_VERSION,
+    Block, BlockContents, BlockData, BlockID, BlockSignature, BLOCK_VERSION,
 };
 use mc_util_lmdb::MetadataStoreSettings;
 use mc_util_serial::{decode, encode, Message};
@@ -201,45 +201,35 @@ impl Ledger for LedgerDB {
     /// Gets a Block by its index in the blockchain.
     fn get_block(&self, block_number: u64) -> Result<Block, Error> {
         let db_transaction = self.env.begin_ro_txn()?;
-        let key = u64_to_key_bytes(block_number);
-        let block_bytes = db_transaction.get(self.blocks, &key)?;
-        let block = decode(&block_bytes)?;
-        Ok(block)
+        self.get_block_impl(&db_transaction, block_number)
     }
 
     /// Get the contents of a block.
     fn get_block_contents(&self, block_number: u64) -> Result<BlockContents, Error> {
         let db_transaction = self.env.begin_ro_txn()?;
-
-        // Get all TxOuts in block.
-        let bytes = db_transaction.get(self.tx_outs_by_block, &u64_to_key_bytes(block_number))?;
-        let value: TxOutsByBlockValue = decode(&bytes)?;
-
-        let outputs = (value.first_tx_out_index..(value.first_tx_out_index + value.num_tx_outs))
-            .map(|tx_out_index| {
-                self.tx_out_store
-                    .get_tx_out_by_index(tx_out_index, &db_transaction)
-            })
-            .collect::<Result<Vec<TxOut>, Error>>()?;
-
-        // Get all KeyImages in block.
-        let key_image_list: KeyImageList =
-            decode(db_transaction.get(self.key_images_by_block, &u64_to_key_bytes(block_number))?)?;
-
-        // Returns block contents.
-        Ok(BlockContents {
-            key_images: key_image_list.key_images,
-            outputs,
-        })
+        self.get_block_contents_impl(&db_transaction, block_number)
     }
 
     /// Gets a block signature by its index in the blockchain.
     fn get_block_signature(&self, block_number: u64) -> Result<BlockSignature, Error> {
         let db_transaction = self.env.begin_ro_txn()?;
-        let key = u64_to_key_bytes(block_number);
-        let signature_bytes = db_transaction.get(self.block_signatures, &key)?;
-        let signature = decode(&signature_bytes)?;
-        Ok(signature)
+        self.get_block_signature_impl(&db_transaction, block_number)
+    }
+
+    /// Gets a block and all of its associated data by its index in the blockchain.
+    fn get_block_data(&self, block_number: u64) -> Result<BlockData, Error> {
+        let db_transaction = self.env.begin_ro_txn()?;
+
+        let block = self.get_block_impl(&db_transaction, block_number)?;
+        let contents = self.get_block_contents_impl(&db_transaction, block_number)?;
+
+        let signature = match self.get_block_signature_impl(&db_transaction, block_number) {
+            Ok(sig) => Ok(Some(sig)),
+            Err(Error::NotFound) => Ok(None),
+            Err(err) => Err(err),
+        }?;
+
+        Ok(BlockData::new(block, contents, signature))
     }
 
     /// Gets block index by a TxOut global index.
@@ -608,6 +598,58 @@ impl LedgerDB {
 
         let metadata = fs::metadata(filename)?;
         Ok(metadata.len())
+    }
+
+    /// Implementatation of the `get_block` method that operates inside a given transaction.
+    fn get_block_impl(
+        &self,
+        db_transaction: &impl Transaction,
+        block_number: u64,
+    ) -> Result<Block, Error> {
+        let key = u64_to_key_bytes(block_number);
+        let block_bytes = db_transaction.get(self.blocks, &key)?;
+        let block = decode(&block_bytes)?;
+        Ok(block)
+    }
+
+    /// Implementation of the `get_block_contents` method that operates inside a given transaction.
+    fn get_block_contents_impl(
+        &self,
+        db_transaction: &impl Transaction,
+        block_number: u64,
+    ) -> Result<BlockContents, Error> {
+        // Get all TxOuts in block.
+        let bytes = db_transaction.get(self.tx_outs_by_block, &u64_to_key_bytes(block_number))?;
+        let value: TxOutsByBlockValue = decode(&bytes)?;
+
+        let outputs = (value.first_tx_out_index..(value.first_tx_out_index + value.num_tx_outs))
+            .map(|tx_out_index| {
+                self.tx_out_store
+                    .get_tx_out_by_index(tx_out_index, db_transaction)
+            })
+            .collect::<Result<Vec<TxOut>, Error>>()?;
+
+        // Get all KeyImages in block.
+        let key_image_list: KeyImageList =
+            decode(db_transaction.get(self.key_images_by_block, &u64_to_key_bytes(block_number))?)?;
+
+        // Returns block contents.
+        Ok(BlockContents {
+            key_images: key_image_list.key_images,
+            outputs,
+        })
+    }
+
+    /// Implementation of the `get_block_signature` method that operates inside a given transaction.
+    fn get_block_signature_impl(
+        &self,
+        db_transaction: &impl Transaction,
+        block_number: u64,
+    ) -> Result<BlockSignature, Error> {
+        let key = u64_to_key_bytes(block_number);
+        let signature_bytes = db_transaction.get(self.block_signatures, &key)?;
+        let signature = decode(&signature_bytes)?;
+        Ok(signature)
     }
 }
 

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -222,7 +222,6 @@ impl Ledger for LedgerDB {
 
         let block = self.get_block_impl(&db_transaction, block_number)?;
         let contents = self.get_block_contents_impl(&db_transaction, block_number)?;
-
         let signature = match self.get_block_signature_impl(&db_transaction, block_number) {
             Ok(sig) => Ok(Some(sig)),
             Err(Error::NotFound) => Ok(None),

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -7,7 +7,7 @@ use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate};
 use mc_transaction_core::{
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
-    Block, BlockContents, BlockID, BlockSignature, BLOCK_VERSION,
+    Block, BlockContents, BlockData, BlockID, BlockSignature, BLOCK_VERSION,
 };
 use mc_util_from_random::FromRandom;
 use rand::{rngs::StdRng, SeedableRng};
@@ -121,6 +121,13 @@ impl Ledger for MockLedger {
 
     fn get_block_signature(&self, _block_number: u64) -> Result<BlockSignature, Error> {
         Err(Error::NotFound)
+    }
+
+    fn get_block_data(&self, block_number: u64) -> Result<BlockData, Error> {
+        let block = self.get_block(block_number)?;
+        let contents = self.get_block_contents(block_number)?;
+        let signature = self.get_block_signature(block_number).ok();
+        Ok(BlockData::new(block, contents, signature))
     }
 
     /// Gets block index by a TxOut global index.

--- a/ledger/distribution/src/main.rs
+++ b/ledger/distribution/src/main.rs
@@ -8,8 +8,8 @@ pub mod uri;
 use crate::uri::{Destination, Uri};
 use mc_api::{block_num_to_s3block_path, blockchain};
 use mc_common::logger::{create_app_logger, log, o, Logger};
-use mc_ledger_db::{Error as LedgerDbError, Ledger, LedgerDB};
-use mc_transaction_core::{Block, BlockContents, BlockIndex, BlockSignature};
+use mc_ledger_db::{Ledger, LedgerDB};
+use mc_transaction_core::{BlockData, BlockIndex};
 use protobuf::Message;
 use rusoto_core::{Region, RusotoError};
 use rusoto_s3::{PutObjectError, PutObjectRequest, S3Client, S3};
@@ -18,12 +18,7 @@ use std::{fs, path::PathBuf, str::FromStr};
 use structopt::StructOpt;
 
 pub trait BlockHandler {
-    fn handle_block(
-        &mut self,
-        block: &Block,
-        block_contents: &BlockContents,
-        signature: &Option<BlockSignature>,
-    );
+    fn handle_block(&mut self, block_data: &BlockData);
 }
 
 /// Block to start syncing from.
@@ -142,22 +137,21 @@ impl S3BlockWriter {
 }
 
 impl BlockHandler for S3BlockWriter {
-    fn handle_block(
-        &mut self,
-        block: &Block,
-        block_contents: &BlockContents,
-        signature: &Option<BlockSignature>,
-    ) {
-        log::info!(self.logger, "S3: Handling block {}", block.index);
+    fn handle_block(&mut self, block_data: &BlockData) {
+        log::info!(
+            self.logger,
+            "S3: Handling block {}",
+            block_data.block().index
+        );
 
-        let bc_block = blockchain::Block::from(block);
-        let bc_block_contents = blockchain::BlockContents::from(block_contents);
+        let bc_block = blockchain::Block::from(block_data.block());
+        let bc_block_contents = blockchain::BlockContents::from(block_data.contents());
 
         let mut archive_block_v1 = blockchain::ArchiveBlockV1::new();
         archive_block_v1.set_block(bc_block);
         archive_block_v1.set_block_contents(bc_block_contents);
 
-        if let Some(signature) = signature {
+        if let Some(signature) = block_data.signature() {
             let bc_signature = blockchain::BlockSignature::from(signature);
             archive_block_v1.set_signature(bc_signature);
         }
@@ -168,7 +162,7 @@ impl BlockHandler for S3BlockWriter {
         let dest = self
             .path
             .as_path()
-            .join(block_num_to_s3block_path(block.index));
+            .join(block_num_to_s3block_path(block_data.block().index));
 
         let dir = dest.as_path().parent().expect("failed getting parent");
         let filename = dest.file_name().unwrap();
@@ -198,22 +192,21 @@ impl LocalBlockWriter {
 }
 
 impl BlockHandler for LocalBlockWriter {
-    fn handle_block(
-        &mut self,
-        block: &Block,
-        block_contents: &BlockContents,
-        signature: &Option<BlockSignature>,
-    ) {
-        log::info!(self.logger, "S3: Handling block {}", block.index);
+    fn handle_block(&mut self, block_data: &BlockData) {
+        log::info!(
+            self.logger,
+            "Local: Handling block {}",
+            block_data.block().index
+        );
 
-        let bc_block = blockchain::Block::from(block);
-        let bc_block_contents = blockchain::BlockContents::from(block_contents);
+        let bc_block = blockchain::Block::from(block_data.block());
+        let bc_block_contents = blockchain::BlockContents::from(block_data.contents());
 
         let mut archive_block_v1 = blockchain::ArchiveBlockV1::new();
         archive_block_v1.set_block(bc_block);
         archive_block_v1.set_block_contents(bc_block_contents);
 
-        if let Some(signature) = signature {
+        if let Some(signature) = block_data.signature() {
             let bc_signature = blockchain::BlockSignature::from(signature);
             archive_block_v1.set_signature(bc_signature);
         }
@@ -228,13 +221,18 @@ impl BlockHandler for LocalBlockWriter {
         let dest = self
             .path
             .as_path()
-            .join(block_num_to_s3block_path(block.index));
+            .join(block_num_to_s3block_path(block_data.block().index));
         let dir = dest.as_path().parent().expect("failed getting parent");
 
         fs::create_dir_all(dir)
             .unwrap_or_else(|e| panic!("failed creating directory {:?}: {:?}", dir, e));
-        fs::write(&dest, bytes)
-            .unwrap_or_else(|_| panic!("failed writing block #{} to {:?}", block.index, dest));
+        fs::write(&dest, bytes).unwrap_or_else(|_| {
+            panic!(
+                "failed writing block #{} to {:?}",
+                block_data.block().index,
+                dest
+            )
+        });
     }
 }
 
@@ -303,27 +301,10 @@ fn main() {
     );
     let mut next_block_num = first_desired_block;
     loop {
-        while let (Ok(block_contents), Ok(block)) = (
-            ledger_db.get_block_contents(next_block_num),
-            ledger_db.get_block(next_block_num),
-        ) {
+        while let Ok(block_data) = ledger_db.get_block_data(next_block_num) {
             log::trace!(logger, "Handling block #{}", next_block_num);
 
-            let signature = match ledger_db.get_block_signature(next_block_num) {
-                Ok(signature) => Some(signature),
-                Err(LedgerDbError::NotFound) => None,
-                Err(err) => {
-                    log::error!(
-                        logger,
-                        "Failed getting signature for block #{}: {:?}",
-                        next_block_num,
-                        err
-                    );
-                    None
-                }
-            };
-
-            block_handler.handle_block(&block, &block_contents, &signature);
+            block_handler.handle_block(&block_data);
             next_block_num += 1;
 
             let state = StateData {

--- a/ledger/distribution/src/main.rs
+++ b/ledger/distribution/src/main.rs
@@ -144,20 +144,7 @@ impl BlockHandler for S3BlockWriter {
             block_data.block().index
         );
 
-        let bc_block = blockchain::Block::from(block_data.block());
-        let bc_block_contents = blockchain::BlockContents::from(block_data.contents());
-
-        let mut archive_block_v1 = blockchain::ArchiveBlockV1::new();
-        archive_block_v1.set_block(bc_block);
-        archive_block_v1.set_block_contents(bc_block_contents);
-
-        if let Some(signature) = block_data.signature() {
-            let bc_signature = blockchain::BlockSignature::from(signature);
-            archive_block_v1.set_signature(bc_signature);
-        }
-
-        let mut archive_block = blockchain::ArchiveBlock::new();
-        archive_block.set_v1(archive_block_v1);
+        let archive_block = blockchain::ArchiveBlock::from(block_data);
 
         let dest = self
             .path
@@ -199,20 +186,7 @@ impl BlockHandler for LocalBlockWriter {
             block_data.block().index
         );
 
-        let bc_block = blockchain::Block::from(block_data.block());
-        let bc_block_contents = blockchain::BlockContents::from(block_data.contents());
-
-        let mut archive_block_v1 = blockchain::ArchiveBlockV1::new();
-        archive_block_v1.set_block(bc_block);
-        archive_block_v1.set_block_contents(bc_block_contents);
-
-        if let Some(signature) = block_data.signature() {
-            let bc_signature = blockchain::BlockSignature::from(signature);
-            archive_block_v1.set_signature(bc_signature);
-        }
-
-        let mut archive_block = blockchain::ArchiveBlock::new();
-        archive_block.set_v1(archive_block_v1);
+        let archive_block = blockchain::ArchiveBlock::from(block_data);
 
         let bytes = archive_block
             .write_to_bytes()

--- a/ledger/from-archive/src/main.rs
+++ b/ledger/from-archive/src/main.rs
@@ -30,11 +30,15 @@ fn main() {
 
     // Sync Origin Block
     log::debug!(logger, "Getting origin block");
-    let (origin_block, origin_txs) = transactions_fetcher
+    let block_data = transactions_fetcher
         .get_origin_block_and_transactions()
         .expect("Could not retrieve origin block");
     local_ledger
-        .append_block(&origin_block, &origin_txs, None)
+        .append_block(
+            block_data.block(),
+            block_data.contents(),
+            block_data.signature().clone(),
+        )
         .expect("Could not append origin block to ledger");
 
     // Sync all blocks
@@ -65,13 +69,13 @@ fn main() {
             url
         );
         match transactions_fetcher.block_from_url(&url) {
-            Ok(s3_block_data) => {
+            Ok(block_data) => {
                 // Append new data to the ledger
                 local_ledger
                     .append_block(
-                        &s3_block_data.block,
-                        &s3_block_data.block_contents,
-                        s3_block_data.signature,
+                        block_data.block(),
+                        block_data.contents(),
+                        block_data.signature().clone(),
                     )
                     .unwrap_or_else(|_| panic!("Could not append block {:?}", block_index))
             }

--- a/ledger/sync/src/test_utils.rs
+++ b/ledger/sync/src/test_utils.rs
@@ -3,7 +3,7 @@
 use crate::{TransactionFetcherError, TransactionsFetcher};
 use mc_common::ResponderId;
 use mc_ledger_db::Ledger;
-use mc_transaction_core::{Block, BlockContents};
+use mc_transaction_core::{Block, BlockData};
 
 impl TransactionFetcherError for String {}
 
@@ -21,13 +21,13 @@ impl<L: Ledger + Sync> MockTransactionsFetcher<L> {
 impl<L: Ledger + Sync> TransactionsFetcher for MockTransactionsFetcher<L> {
     type Error = String;
 
-    fn get_block_contents(
+    fn get_block_data(
         &self,
         _safe_responder_ids: &[ResponderId],
         block: &Block,
-    ) -> Result<BlockContents, Self::Error> {
+    ) -> Result<BlockData, Self::Error> {
         self.ledger
-            .get_block_contents(block.index)
-            .map_err(|e| format!("Error getting contents of block #{}: {:?}", block.index, e))
+            .get_block_data(block.index)
+            .map_err(|e| format!("Error getting data for block #{}: {:?}", block.index, e))
     }
 }

--- a/ledger/sync/src/transactions_fetcher_trait.rs
+++ b/ledger/sync/src/transactions_fetcher_trait.rs
@@ -4,7 +4,7 @@
 //! fetching transaction data.
 
 use mc_common::ResponderId;
-use mc_transaction_core::{Block, BlockContents};
+use mc_transaction_core::{Block, BlockData};
 use std::fmt::Debug;
 
 pub trait TransactionFetcherError: Debug + Send + Sync {}
@@ -19,9 +19,9 @@ pub trait TransactionsFetcher: Sized + Sync + Send {
     /// * `safe_responder_ids` - List of responder IDs that have been identified as being able to provide a
     /// consistent copy of the blockchain.
     /// * `block` - The block we want to fetch contents for.
-    fn get_block_contents(
+    fn get_block_data(
         &self,
         safe_responder_ids: &[ResponderId],
         block: &Block,
-    ) -> Result<BlockContents, Self::Error>;
+    ) -> Result<BlockData, Self::Error>;
 }

--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -201,13 +201,17 @@ fn create_or_open_ledger_db(
                 );
             std::fs::create_dir_all(config.ledger_db.clone()).expect("Could not create ledger dir");
             LedgerDB::create(config.ledger_db.clone()).expect("Could not create ledger_db");
-            let (block, transactions) = transactions_fetcher
+            let block_data = transactions_fetcher
                 .get_origin_block_and_transactions()
                 .expect("Failed to download initial transactions");
             let mut db =
                 LedgerDB::open(config.ledger_db.clone()).expect("Could not open ledger_db");
-            db.append_block(&block, &transactions, None)
-                .expect("Failed to appened initial transactions");
+            db.append_block(
+                block_data.block(),
+                block_data.contents(),
+                block_data.signature().clone(),
+            )
+            .expect("Failed to appened initial transactions");
             log::info!(logger, "Bootstrapping completed!");
         }
     }

--- a/transaction/core/src/blockchain/block_data.rs
+++ b/transaction/core/src/blockchain/block_data.rs
@@ -1,0 +1,40 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+use crate::{Block, BlockContents, BlockSignature};
+use prost::Message;
+use serde::{Deserialize, Serialize};
+
+/// An object that holds all data included in and associated with a block.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Message)]
+pub struct BlockData {
+    #[prost(message, required, tag = "1")]
+    block: Block,
+
+    #[prost(message, required, tag = "2")]
+    contents: BlockContents,
+
+    #[prost(message, tag = "3")]
+    signature: Option<BlockSignature>,
+}
+
+impl BlockData {
+    pub fn new(block: Block, contents: BlockContents, signature: Option<BlockSignature>) -> Self {
+        Self {
+            block,
+            contents,
+            signature,
+        }
+    }
+
+    pub fn block(&self) -> &Block {
+        &self.block
+    }
+
+    pub fn contents(&self) -> &BlockContents {
+        &self.contents
+    }
+
+    pub fn signature(&self) -> &Option<BlockSignature> {
+        &self.signature
+    }
+}

--- a/transaction/core/src/blockchain/mod.rs
+++ b/transaction/core/src/blockchain/mod.rs
@@ -6,11 +6,13 @@ use failure::Fail;
 
 mod block;
 mod block_contents;
+mod block_data;
 mod block_id;
 mod block_signature;
 
 pub use block::*;
 pub use block_contents::*;
+pub use block_data::*;
 pub use block_id::*;
 pub use block_signature::*;
 

--- a/watcher/src/watcher.rs
+++ b/watcher/src/watcher.rs
@@ -83,18 +83,18 @@ impl Watcher {
             url
         );
         match self.transactions_fetcher.block_from_url(&url) {
-            Ok(archive_block) => {
+            Ok(block_data) => {
                 log::debug!(
                     self.logger,
                     "Archive block retrieved for {:?} {:?}",
                     src_url,
                     block_index
                 );
-                if let Some(signature) = archive_block.signature {
+                if let Some(signature) = block_data.signature() {
                     self.watcher_db.add_block_signature(
                         src_url,
                         block_index,
-                        signature,
+                        signature.clone(),
                         filename,
                     )?;
                 } else {


### PR DESCRIPTION
Soundtrack of this PR: [Le pas du chat noir](https://open.spotify.com/album/1Vi1fmvatCuzuASdvUGTuf?si=nUDN47zaQ0qsN7pr-syBtg)

### Motivation

As part of work I am doing on merging blocks together for more efficient distribution, I ran into the lack of ergonomics around `Block`+`BlockContents`+`BlockSignature`. There are a few occasions where we want to get all three, and pass them around. Previously this was done in 3 separate calls to `LedgerDB`, and a bunch of tuples or custom but specific object (`ArchiveBlockData`). This PR cleans up this pattern, and provides a new and reusable`BlockData` object.


### In this PR
* Introduce `BlockData`, which is a `Block` + `BlockContents`+ optional `BlockSignature` and use it in places where appropriate. 

### Future Work
* The internal repo could benefit from this, so I will follow up with a PR there once this is merged.

