### PR TITLE
"MobileCoinAPI" is in use by external.proto

### DIFF
--- a/api/proto/printable.proto
+++ b/api/proto/printable.proto
@@ -8,7 +8,6 @@ import "external.proto";
 package printable;
 
 option java_package = "com.mobilecoin.api";
-option java_outer_classname = "MobileCoinAPI";
 
 /// Message for a payment request, which combines a public address
 /// with an a requested payment amount and memo field


### PR DESCRIPTION
### Motivation

"MobileCoinAPI" outer_classname is in use by external.proto, which creates conflict in java implementations.

### In this PR

Remove java_outer_classname option. 
With no outer class name specified, it will be generated by converting the file name to upper camel case
