### PR TITLE
MCC-1881: TransferPayload.tx_out_public_key should use actual key data type

### DIFF
--- a/api/proto/printable.proto
+++ b/api/proto/printable.proto
@@ -31,7 +31,7 @@ message TransferPayload {
 
     /// The public key of the UTXO to spend. This is an optimization, meaning
     /// the recipient does not need to scan the entire ledger.
-    bytes tx_out_public_key = 2;
+    external.CompressedRistretto tx_out_public_key = 2;
 
     /// Any additional text explaining the gift
     string memo = 3;

--- a/api/src/display.rs
+++ b/api/src/display.rs
@@ -197,7 +197,9 @@ mod display_tests {
     fn test_transfer_payload_roundtrip() {
         let mut transfer_payload = TransferPayload::new();
         transfer_payload.set_entropy(vec![1u8; 32]);
-        transfer_payload.set_tx_out_public_key(vec![2u8; 32]);
+        transfer_payload
+            .mut_tx_out_public_key()
+            .set_data(vec![2u8; 32]);
 
         let mut wrapper = PrintableWrapper::new();
         wrapper.set_transfer_payload(transfer_payload);

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -527,7 +527,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
 
         let mut transfer_payload = mc_mobilecoind_api::printable::TransferPayload::new();
         transfer_payload.set_entropy(request.get_entropy().to_vec());
-        transfer_payload.set_tx_out_public_key(request.get_tx_public_key().get_data().to_vec());
+        transfer_payload.set_tx_out_public_key(request.get_tx_public_key().clone());
         transfer_payload.set_memo(request.get_memo().to_string());
 
         let mut transfer_wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
@@ -840,7 +840,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static> ServiceApi<T> {
 
         let mut transfer_payload = mc_mobilecoind_api::printable::TransferPayload::new();
         transfer_payload.set_entropy(entropy_bytes.to_vec());
-        transfer_payload.set_tx_out_public_key(tx_public_key.to_bytes().to_vec());
+        transfer_payload.set_tx_out_public_key((&tx_public_key).into());
         transfer_payload.set_memo(request.get_memo().to_string());
 
         let mut transfer_wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();


### PR DESCRIPTION
### Motivation

We should use concrete data when available, instead of byte arrays.

### In this PR
* Switching a bytes field into `CompressedRistretto`.

### Future Work
* Since this changes the proto APIs, the Python package will need to be updated (cc @rjwalters)