### PR TITLE
bump failure to 0.1.8

### DIFF
--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -42,7 +42,7 @@ cfg-if = "0.1"
 chrono = { version = "0.4.10", default-features = false, features = ["alloc"] }
 digest = { version = "0.9", default-features = false }
 displaydoc = { version = "0.1.7", default-features = false }
-failure = { version = "0.1.5", default-features = false, features = ["derive"] }
+failure = { version = "0.1.8", default-features = false, features = ["derive"] }
 hex_fmt = "0.3"
 rand_core = { version = "0.5", default-features = false }
 rjson = "0.3.1"

--- a/attest/net/Cargo.toml
+++ b/attest/net/Cargo.toml
@@ -23,7 +23,7 @@ mc-util-encodings = { path = "../../util/encodings" }
 mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", tag = "mc-0.3" }
 
 cfg-if = "0.1"
-failure = { version = "0.1.5", features = ["derive"] }
+failure = { version = "0.1.8", features = ["derive"] }
 pem = "0.6"
 reqwest = { version = "0.10" , default-features = false, features = ["rustls-tls", "gzip"] }
 percent-encoding = "2.1.0"

--- a/attest/trusted/Cargo.toml
+++ b/attest/trusted/Cargo.toml
@@ -10,5 +10,5 @@ mc-common = { path = "../../common", default-features = false }
 mc-sgx-compat = { path = "../../sgx/compat" }
 mc-sgx-types = { path = "../../sgx/types" }
 
-failure = { version = "0.1.5", default-features = false, features = ["derive"] }
+failure = { version = "0.1.8", default-features = false, features = ["derive"] }
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -38,7 +38,7 @@ loggers = [
 [dependencies]
 cfg-if = "0.1"
 mc-crypto-digestible = { path = "../crypto/digestible" }
-failure = { version = "0.1.5", default-features = false, features = ["derive"] }
+failure = { version = "0.1.8", default-features = false, features = ["derive"] }
 generic-array = { version = "0.14", features = ["serde"] }
 hashbrown = { version = "0.6", default-features = false, features = ["serde", "nightly"] }
 mc-crypto-keys = { path = "../crypto/keys", default-features = false }

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -20,7 +20,7 @@ mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }
 
 aes-gcm = "0.6"
-failure = "0.1.5"
+failure = "0.1.8"
 grpcio = "0.6.0"
 retry = "0.5"
 secrecy = "0.4"

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -30,5 +30,5 @@ mc-sgx-report-cache-api = { path = "../../../sgx/report-cache/api" }
 mc-transaction-core = { path = "../../../transaction/core" }
 
 cfg-if = "0.1"
-failure = { version = "0.1.5", default-features = false, features = ["derive"] }
+failure = { version = "0.1.8", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -371,15 +371,15 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure_derive"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -618,7 +618,7 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",
@@ -653,7 +653,7 @@ dependencies = [
 name = "mc-attest-trusted"
 version = "1.0.0"
 dependencies = [
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-attest-core 1.0.0",
  "mc-common 1.0.0",
  "mc-sgx-compat 1.0.0",
@@ -667,7 +667,7 @@ version = "1.0.0"
 dependencies = [
  "binascii 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -687,7 +687,7 @@ name = "mc-consensus-enclave-api"
 version = "1.0.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-attest-ake 1.0.0",
  "mc-attest-core 1.0.0",
  "mc-attest-enclave-api 1.0.0",
@@ -779,7 +779,7 @@ dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-attest-ake 1.0.0",
  "mc-attest-core 1.0.0",
  "mc-attest-enclave-api 1.0.0",
@@ -805,7 +805,7 @@ dependencies = [
  "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-keys 1.0.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -852,7 +852,7 @@ dependencies = [
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-digestible 1.0.0",
  "mc-util-from-random 1.0.0",
@@ -872,7 +872,7 @@ name = "mc-crypto-message-cipher"
 version = "1.0.0"
 dependencies = [
  "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-util-serial 1.0.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -887,7 +887,7 @@ dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-keys 1.0.0",
@@ -1049,7 +1049,7 @@ dependencies = [
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1077,7 +1077,7 @@ name = "mc-util-build-script"
 version = "1.0.0"
 dependencies = [
  "cargo-emit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1715,8 +1715,8 @@ dependencies = [
 "checksum ed25519-dalek 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53d2e93f837d749c16d118e7ddf7a4dfd0ac8f452cf51e46e9348824e5ef6851"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
-"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
-"checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
+"checksum failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+"checksum failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 "checksum generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 "checksum genio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4e26859a808ffa83a83f20c7e3c9366afea91edae637a6ac203051885882dc8"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -20,7 +20,7 @@ mc-sgx-compat = { path = "../../../sgx/compat", default-features = false }
 aead = "0.3"
 aes-gcm = "0.6"
 digest = { version = "0.9", default-features = false }
-failure = { version = "0.1.5", default-features = false, features = ["derive"] }
+failure = { version = "0.1.8", default-features = false, features = ["derive"] }
 rand_core = { version = "0.5", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
 sha2 = { version = "0.9", default-features = false }

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -9,7 +9,7 @@ aead = "0.3"
 aes-gcm = { version = "0.6.0" }
 blake2 = { version = "0.9", default-features = false }
 digest = { version = "0.9" }
-failure = { version = "0.1.5", default-features = false }
+failure = { version = "0.1.8", default-features = false }
 hkdf = { version = "0.9.0", default-features = false }
 mc-crypto-keys = { path = "../keys", default-features = false }
 rand_core = { version = "0.5", default-features = false }

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -10,7 +10,7 @@ cfg-if = "0.1"
 digest = { version = "0.9", default-features = false }
 ed25519 = { version = "1.0.1", default-features = false, features = ["serde"] }
 mc-crypto-digestible = { path = "../../crypto/digestible", features = ["dalek", "derive"] }
-failure = { version = "0.1.5", default-features = false, features = ["derive"] }
+failure = { version = "0.1.8", default-features = false, features = ["derive"] }
 hex_fmt = "0.3"
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-repr-bytes = { path = "../../util/repr-bytes" }

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 mc-util-serial = { path = "../../util/serial", default-features = false }
 
 aes-gcm = { version = "0.6.0" }
-failure = { version = "0.1.5", default-features = false, features = ["derive"] }
+failure = { version = "0.1.8", default-features = false, features = ["derive"] }
 generic-array = { version = "0.14", default-features = false }
 rand_core = { version = "0.5", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -12,7 +12,7 @@ mc-util-repr-bytes = { path = "../../util/repr-bytes" }
 aes-gcm = "0.6"
 aead = "0.3"
 digest = { version = "0.9", default-features = false }
-failure = { version = "0.1", default-features = false, features = ["derive"] }
+failure = { version = "0.1.8", default-features = false, features = ["derive"] }
 generic-array = { version = "0.14", default-features = false, features = ["serde"] }
 hkdf = "0.9.0"
 rand_core = "0.5"

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -20,7 +20,7 @@ mc-util-lmdb = { path = "../../util/lmdb" }
 mc-util-metrics = { path = "../../util/metrics" }
 mc-util-serial = { path = "../../util/serial", features = ["std"] }
 
-failure = "0.1.5"
+failure = "0.1.8"
 lazy_static = "1.4"
 lmdb-rkv = "0.14.0"
 mockall = "0.7.2"

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -16,7 +16,7 @@ mc-transaction-core = { path = "../../transaction/core" }
 
 dirs = "2.0"
 dotenv = "0.14"
-failure = "0.1.5"
+failure = "0.1.8"
 protobuf = "2.12"
 retry = "0.5"
 rusoto_core = { version = "0.42.0", features = ["rustls"], default_features = false }

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -25,7 +25,7 @@ mc-util-metrics = { path = "../..//util/metrics" }
 mc-util-uri = { path = "../../util/uri" }
 
 crossbeam-channel = "0.3"
-failure = "0.1.5"
+failure = "0.1.8"
 grpcio = "0.6.0"
 lazy_static = "1.4"
 mockall = "0.7.2"

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -34,7 +34,7 @@ mc-util-uri = { path = "../util/uri" }
 mc-watcher = { path = "../watcher" }
 
 crossbeam-channel = "0.3"
-failure = "0.1.5"
+failure = "0.1.8"
 futures = "0.3"
 grpcio = "0.6.0"
 hex_fmt = "0.3"

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -25,7 +25,7 @@ mc-util-uri = { path = "../util/uri" }
 
 crossbeam-channel = "0.3"
 ed25519 = { version = "1.0.1", default-features = false, features = ["serde"] }
-failure = "0.1.5"
+failure = "0.1.8"
 grpcio = "0.6.0"
 mockall = "0.7.2"
 protobuf = "2.12"

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # External dependencies
 digest = { version = "0.9", default-features = false }
 displaydoc = { version = "0.1", default-features = false }
-failure = { version = "0.1.5", default-features = false, features = ["derive"] }
+failure = { version = "0.1.8", default-features = false, features = ["derive"] }
 generic-array = { version = "0.14", features = ["serde"] }
 hex_fmt = "0.3"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 # External dependencies
-failure = "0.1.5"
+failure = "0.1.8"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand = { version = "0.7", default-features = false }
 rand_core = { version = "0.5", default-features = false }

--- a/util/build/script/Cargo.toml
+++ b/util/build/script/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [dependencies]
 cargo-emit = "0.1.1"
-failure = { version = "0.1.6", default-features = false, features = ["derive"] }
+failure = { version = "0.1.8", default-features = false, features = ["derive"] }
 lazy_static = "1.4"
 url = "2.1"
 walkdir = "2.3"

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -21,7 +21,7 @@ mc-util-lmdb = { path = "../util/lmdb" }
 mc-util-serial = { path = "../util/serial" }
 mc-watcher-api = { path = "api" }
 
-failure = "0.1.5"
+failure = "0.1.8"
 lmdb-rkv = "0.14.0"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 structopt = "0.3"


### PR DESCRIPTION
### Motivation

* This fixes the build in certain cases.

### In this PR
* Updating `failure` to its most recent version, and ensuring all crates refer to the same version.

