### PR TITLE
[MCC-1977] Fix dependabot parsing issue

### DIFF
--- a/sgx/epid-types/Cargo.toml
+++ b/sgx/epid-types/Cargo.toml
@@ -29,7 +29,7 @@ mc-sgx-core-types-sys = { path = "../core-types-sys" }
 mc-sgx-epid-types-sys = { path = "../epid-types-sys" }
 
 base64 = "0.12"
-bytes = { version = "0.5", optional = true , default-features = false}
+bytes = { version = "0.5", optional = true, default-features = false}
 hex = "0.4"
 hex_fmt = "0.3"
 prost = { version = "0.6.1", optional = true, default-features = false }


### PR DESCRIPTION
### Motivation

Dependabot is failing with the following error:
```
Dependabot couldn't parse the Cargo.toml found at /sgx/epid-types/Cargo.toml.

The error Dependabot encountered was:

Dependabot::DependencyFileNotParseable
```

(see: https://github.com/mobilecoinofficial/mobilecoin/network/updates/65925226)

Running it locally reveals the underlying issue:
```
/home/dependabot/dependabot-script/vendor/ruby/2.6.0/gems/citrus-3.0.2/lib/citrus.rb:669:in `parse': Failed to parse input on line 32 at offset 43 (Citrus::ParseError)
bytes = { version = "0.5", optional = true , default-features = false}

                                           ^
```

### In this PR
* Fixes a parsing issue with `sgx/epid-types/Cargo.toml`

Fixes [MCC-1977]


[MCC-1977]: https://mobilecoin.atlassian.net/browse/MCC-1977