### PR TITLE
fix mc-common std feature usage

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
-#![cfg_attr(not(any(test, feature = "log")), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![feature(optin_builtin_traits)]
 #![warn(unused_extern_crates)]
 


### PR DESCRIPTION
### Motivation

`cargo check -p mc-common --features std` should work

### In this PR
* Change `no_std` gating to use the correct feature
