### PR TITLE
Cleanup generic array references, add more_lengths

### DIFF
--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 cfg-if = "0.1"
 merlin = { version = "2.0", default-features = false }
-generic-array = { version = "0.14", default-features = false }
+generic-array = "0.14"
 
 # For derive support
 mc-crypto-digestible-derive = { path = "./derive", optional = true }

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -9,7 +9,7 @@ mc-util-serial = { path = "../../util/serial", default-features = false }
 
 aes-gcm = { version = "0.6.0" }
 failure = { version = "0.1.8", default-features = false, features = ["derive"] }
-generic-array = { version = "0.14", default-features = false }
+generic-array = "0.14"
 rand_core = { version = "0.5", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 subtle = { version = "2.2", default-features = false, features = ["i128"] }

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -13,7 +13,7 @@ aes-gcm = "0.6"
 aead = "0.3"
 digest = { version = "0.9", default-features = false }
 failure = { version = "0.1.8", default-features = false, features = ["derive"] }
-generic-array = { version = "0.14", default-features = false, features = ["serde"] }
+generic-array = { version = "0.14", features = ["serde"] }
 hkdf = "0.9.0"
 rand_core = "0.5"
 secrecy = "0.4"

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # External dependencies
 digest = { version = "0.9", default-features = false }
 displaydoc = { version = "0.1", default-features = false }
-generic-array = { version = "0.14", features = ["serde"] }
+generic-array = { version = "0.14", features = ["serde", "more_lengths"] }
 hex_fmt = "0.3"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 merlin = { version = "2.0", default-features = false }


### PR DESCRIPTION
### Motivation

The `generic-array` crate does not include `ArrayLength<T>` implementations for all the types in `typenum`, and in fact only does `U0` through `U32` by default. This adds the `more_lengths` feature to the use of `generic-array` in the `mc-util-repr-bytes` crate, and removes `default-features = false` where it appears, as it is not necessary.

### In this PR
* Cleanup cargo inclusion of `generic-array`
* Enable the `more_lengths` feature in `mc-util-repr-bytes` use of `generic-array`.

